### PR TITLE
Lint improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,50 +47,23 @@ module.exports = {
                 "ignoreComments": true,
             }
         ],
-        "react/jsx-indent-props": [
-            "error",
-            "first"
-        ],
+        "react/jsx-indent-props": ["error", "first"],
 
         "no-prototype-builtins": "off",
         "react/display-name": "off",
 
-        "no-unused-vars": [
-            "error",
-            {"argsIgnorePattern": "^_"}
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "react/prop-types": [
-            "error",
-            {"ignore": ["form", "match", "history"]}
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ],
-        "no-var": [
-            "error"
-        ],
-        "prefer-const": [
-            "error"
-        ],
-        "eqeqeq": [
-            "error"
-        ],
-        "max-len": [
-            "error",
-            {"code": 120}
-        ],
-        "no-trailing-spaces": [
-            "error"
-        ]
+        "no-unused-vars": ["error", {"argsIgnorePattern": "^_"}],
+        "linebreak-style": ["error", "unix"],
+        "react/prop-types": ["error", {"ignore": ["form", "match", "history"]}],
+        "quotes": ["error", "double"],
+        "semi": ["error", "always"],
+        "semi-spacing": ["error"],
+        "no-var": ["error"],
+        "prefer-const": ["error"],
+        "eqeqeq": ["error"],
+        "max-len": ["error", {"code": 120}],
+        "no-trailing-spaces": ["error"],
+        "space-before-blocks": ["error", "always"]
     },
     "settings": {
         "react": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,9 @@ module.exports = {
         ],
         "react/jsx-indent-props": ["error", "first"],
 
+        // Prevent some legacy HTML tags
+        "react/forbid-elements": ["error", {"forbid": ["b", "font"]}],
+
         "no-prototype-builtins": "off",
         "react/display-name": "off",
 
@@ -63,7 +66,8 @@ module.exports = {
         "eqeqeq": ["error"],
         "max-len": ["error", {"code": 120}],
         "no-trailing-spaces": ["error"],
-        "space-before-blocks": ["error", "always"]
+        "space-before-blocks": ["error", "always"],
+        "eol-last": ["error", "always"],
     },
     "settings": {
         "react": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,7 +74,20 @@ module.exports = {
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        "no-var": [
+            "error"
+        ],
+        "prefer-const": [
+            "error"
+        ],
+        "eqeqeq": [
+            "error"
+        ],
+        "max-len": [
+            "error",
+            {"code": 120}
+        ],
     },
     "settings": {
         "react": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,9 @@ module.exports = {
             "error",
             {"code": 120}
         ],
+        "no-trailing-spaces": [
+            "error"
+        ]
     },
     "settings": {
         "react": {

--- a/src/components/OverviewContent.js
+++ b/src/components/OverviewContent.js
@@ -79,7 +79,7 @@ class OverviewContent extends Component {
                 map[item] = 1;
             }
         });
-        
+
         return Object.items(map).map(([key, value]) => ({x: key, y: value}));
     }
 

--- a/src/components/OverviewContent.js
+++ b/src/components/OverviewContent.js
@@ -48,17 +48,17 @@ const RADIAN = Math.PI / 180;
 
 // Random 'fixed' colors
 const COLORS = [
-    "#4d47a5", "#dbecc4", "#c72540", "#0da650", "#9d176a", 
-    "#968722", "#36f8bb", "#6671c2", "#2ada39", "#611a28", 
+    "#4d47a5", "#dbecc4", "#c72540", "#0da650", "#9d176a",
+    "#968722", "#36f8bb", "#6671c2", "#2ada39", "#611a28",
     "#cf39f2", "#58433c", "#91faee", "#89c791", "#f47ae3",
     "#180b3c", "#a7e046"
 ];
 
-  
+
 class OverviewContent extends Component {
-    
-    constructor() {
-        super();
+
+    constructor(props) {
+        super(props);
         this.state = {
             chartPadding:  "1rem",
             activeIndex: 0,
@@ -114,7 +114,7 @@ class OverviewContent extends Component {
             sumOfAllValues++;
         });
 
-        // Group the items in the array of objects denoted by 
+        // Group the items in the array of objects denoted by
         // a "name" and "value" parameter
         const jsonObjsXY = [];
         for (const key in map) {
@@ -149,7 +149,7 @@ class OverviewContent extends Component {
         const birth_year =  birthday.getFullYear();
         const birth_month =  birthday.getMonth();
         const birth_date =  birthday.getDate();
-        
+
         let age = today_year - birth_year;
 
         if ( today_month < (birth_month - 1))
@@ -176,7 +176,7 @@ class OverviewContent extends Component {
         const participantDOB = phenopackets.flatMap(p => this.stringToDateYearAsXJSON(p.subject.date_of_birth));
 
         const numBiosamples = biosamples.length;
-        
+
         const sexLabels = this.getFrequencyNameValue(phenopackets.flatMap(p => p.subject.sex));
         const diseaseLabels = this.getFrequencyNameValue(
             phenopackets.flatMap(p => p.diseases.flatMap(d => d.term.label)));
@@ -185,7 +185,7 @@ class OverviewContent extends Component {
 
         const variantTableSummaries = ((this.props.tableSummaries || {})
             .summariesByServiceArtifactAndTableID || {}).variant || undefined;
-        
+
         let numVariants = 0;
         let numSamples = 0;
         let numVCFs = 0;
@@ -236,10 +236,10 @@ class OverviewContent extends Component {
                                     </Spin>
                                 </Col>
                             </Row>
-                            <Row style={{paddingTop: this.state.chartLabelPaddingTop+"rem", 
-                                paddingLeft: this.state.chartPadding, 
-                                paddingRight: this.state.chartPadding, 
-                                paddingBottom: 0}}>      
+                            <Row style={{paddingTop: this.state.chartLabelPaddingTop+"rem",
+                                paddingLeft: this.state.chartPadding,
+                                paddingRight: this.state.chartPadding,
+                                paddingBottom: 0}}>
                                 <Col style={{textAlign: "center"}}>
                                     <h2>{fetchingPhenopackets ? "" : "Age"}</h2>
                                     <Spin spinning={fetchingPhenopackets}>
@@ -255,13 +255,13 @@ class OverviewContent extends Component {
                                                          style={{
                                                              axisLabel: { padding: 30},
                                                          }} />
-                                            <VictoryHistogram 
-                                                data={participantDOB} 
+                                            <VictoryHistogram
+                                                data={participantDOB}
                                                 bins={AGE_HISTOGRAM_BINS}
                                                 style={{ data: { fill: COLORS[0] } }} />
                                         </VictoryChart>
                                     </Spin>
-                                </Col>                          
+                                </Col>
                             </Row>
                         </Col>
                         <Col lg={12} md={24}>
@@ -277,8 +277,8 @@ class OverviewContent extends Component {
                                         />
                                     </Spin>
                                 </Col>
-                            </Row>                           
-                            <Row style={{paddingTop: this.state.chartLabelPaddingTop+"rem", 
+                            </Row>
+                            <Row style={{paddingTop: this.state.chartLabelPaddingTop+"rem",
                                 display: "flex", justifyContent: "center"}}>
                                 <Col style={{textAlign: "center"}}>
                                     <h2>{this.props.phenopackets.isFetching ? "" : "Biosamples"}</h2>
@@ -288,7 +288,7 @@ class OverviewContent extends Component {
                                       chartWidthHeight={this.state.chartWidthHeight}
                                       fieldLabel={"[dataset item].biosamples.[item].sampled_tissue.label"}
                                       setAutoQueryPageTransition={this.props.setAutoQueryPageTransition}
-                                      />                                    
+                                      />
                                   </Spin>
                                 </Col>
                             </Row>
@@ -327,39 +327,39 @@ class OverviewContent extends Component {
      */
     updateDimensions() {
         if(window.innerWidth < 576) { //xs
-            this.setState({ 
-                chartPadding: "0rem", 
+            this.setState({
+                chartPadding: "0rem",
                 chartWidthHeight: window.innerWidth,
                 chartLabelPaddingTop: 3,
                 chartLabelPaddingLeft: 3
             });
         } else if(window.innerWidth < 768) { // sm
-            this.setState({ 
-                chartPadding: "1rem", 
+            this.setState({
+                chartPadding: "1rem",
                 chartWidthHeight: window.innerWidth,
                 chartLabelPaddingTop: 3,
                 chartLabelPaddingLeft: 6 });
         } else if(window.innerWidth < 992) { // md
-            this.setState({ 
-                chartPadding: "2rem", 
+            this.setState({
+                chartPadding: "2rem",
                 chartWidthHeight: window.innerWidth,
                 chartLabelPaddingTop: 3,
                 chartLabelPaddingLeft: 5 });
         } else if(window.innerWidth < 1200) { // lg
-            this.setState({ 
-                chartPadding: "4rem", 
+            this.setState({
+                chartPadding: "4rem",
                 chartWidthHeight: window.innerWidth / 2,
                 chartLabelPaddingTop: 3,
                 chartLabelPaddingLeft: 6 });
         } else if(window.innerWidth < 1600) { // xl
-            this.setState({ 
-                chartPadding: "6rem", 
+            this.setState({
+                chartPadding: "6rem",
                 chartWidthHeight: window.innerWidth / 2,
                 chartLabelPaddingTop: 3,
                 chartLabelPaddingLeft: 7 });
         } else {
-            this.setState({ 
-                chartPadding: "10rem", 
+            this.setState({
+                chartPadding: "10rem",
                 chartWidthHeight: window.innerWidth / 2,
                 chartLabelPaddingTop: 5,
                 chartLabelPaddingLeft: 7 }); // > xl
@@ -395,11 +395,11 @@ class CustomPieChart extends React.Component {
         graphTerm: undefined,
         fieldLabel: undefined
     }
-  
+
     onEnter = (_data, index) => {
         this.setState({ activeIndex: index });
     }
-  
+
     onLeave = (_data, _index) => {
         this.setState({ activeIndex: undefined });
     }
@@ -417,7 +417,7 @@ class CustomPieChart extends React.Component {
         // Navigate to Explorer
         history.push(withBasePath("/data/explorer/search"));
     }
-  
+
     componentDidMount() {
       /*
        * This ugly hack prevents the Pie labels from not appearing
@@ -425,17 +425,17 @@ class CustomPieChart extends React.Component {
        */
         setTimeout(() => this.setState({ canUpdate: true }), 3000);
     }
-  
+
     shouldComponentUpdate(props, state) {
         if (this.state !== state && state.canUpdate)
             return true;
-  
+
         return this.props.data !== props.data;
     }
-  
+
     render() {
         const { data, chartWidthHeight } = this.props;
-  
+
         return (
         <PieChart width={chartWidthHeight} height={chartWidthHeight/2}>
           <Pie data={data}
@@ -476,16 +476,16 @@ class CustomPieChart extends React.Component {
             // value
             index,
         } = params;
-    
+
 
         // skip rendering this static label if the sector is selected.
         // this will let the 'renderActiveState' draw without overlapping
         if (index === state.activeIndex) {
             return;
         }
-  
+
         const name = payload.name === "null" ? "(Empty)" : payload.name;
-    
+
         const sin = Math.sin(-RADIAN * midAngle);
         const cos = Math.cos(-RADIAN * midAngle);
         const sx = cx + (outerRadius + 10) * cos;
@@ -495,13 +495,13 @@ class CustomPieChart extends React.Component {
         const ex = mx + (cos >= 0 ? 1 : -1) * 22;
         const ey = my;
         const textAnchor = cos >= 0 ? "start" : "end";
-    
+
         const currentTextStyle = {
             ...textStyle,
             fontWeight: payload.selected ? "bold" : "normal",
             fontStyle: payload.name === "null" ? "italic" : "normal",
         };
-    
+
         const offsetRadius = 20;
         const startPoint = polarToCartesian(params.cx, params.cy, params.outerRadius, midAngle);
         const endPoint   = polarToCartesian(params.cx, params.cy, params.outerRadius + offsetRadius, midAngle);
@@ -511,16 +511,16 @@ class CustomPieChart extends React.Component {
             stroke: fill,
             points: [startPoint, endPoint],
         };
-    
+
         if (lastAngle > midAngle)
             lastAngle = 0;
-    
-        
+
+
         lastAngle = midAngle;
-    
+
         return (
         <g>
-    
+
           { payload.selected &&
             <Sector
               cx={cx}
@@ -532,13 +532,13 @@ class CustomPieChart extends React.Component {
               fill={fill}
             />
           }
-    
+
           <Curve
             { ...lineProps }
             type='linear'
             className='recharts-pie-label-line'
           />
-    
+
           <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={fill} fill='none'/>
           <circle cx={ex} cy={ey} r={2} fill={fill} stroke='none'/>
           <text x={ex + (cos >= 0 ? 1 : -1) * 12} y={ey + 3}
@@ -556,7 +556,7 @@ class CustomPieChart extends React.Component {
           >
             {`(${ payload.value } donor${ payload.value > 1 ? "s" : "" })`}
           </text>
-    
+
         </g>
         );
     }
@@ -574,11 +574,11 @@ class CustomPieChart extends React.Component {
             fill,
             payload
         } = params;
-    
+
         const name = payload.name === "null" ? "(Empty)" : payload.name;
-    
+
         const offsetRadius = 40;
-  
+
         const sin = Math.sin(-RADIAN * midAngle);
         const cos = Math.cos(-RADIAN * midAngle);
         const sx = cx + (outerRadius + 10) * cos;
@@ -588,13 +588,13 @@ class CustomPieChart extends React.Component {
         const ex = mx + (cos >= 0 ? 1 : -1) * 22;
         const ey = my;
         const textAnchor = cos >= 0 ? "start" : "end";
-    
+
         const currentTextStyle = {
             ...textStyle,
             fontWeight: "bold",
             fontStyle: payload.name === "null" ? "italic" : "normal",
         };
-    
+
         const startPoint = polarToCartesian(params.cx, params.cy, params.outerRadius, midAngle);
         const endPoint   = polarToCartesian(params.cx, params.cy, params.outerRadius + offsetRadius, midAngle);
         const lineProps = {
@@ -603,12 +603,12 @@ class CustomPieChart extends React.Component {
             stroke: fill,
             points: [startPoint, endPoint],
         };
-    
+
         lastAngle = midAngle;
-    
+
         return (
         <g>
-    
+
           <Sector
             cx={cx}
             cy={cy}
@@ -618,7 +618,7 @@ class CustomPieChart extends React.Component {
             outerRadius={outerRadius}
             fill={fill}
           />
-    
+
           { payload.selected &&
             <Sector
               cx={cx}
@@ -630,13 +630,13 @@ class CustomPieChart extends React.Component {
               fill={fill}
             />
           }
-    
+
           <Curve
             { ...lineProps }
             type='linear'
             className='recharts-pie-label-line'
           />
-    
+
           <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={fill} fill='none'/>
           <circle cx={ex} cy={ey} r={2} fill={fill} stroke='none'/>
           <text x={ex + (cos >= 0 ? 1 : -1) * 12} y={ey + 3}
@@ -654,7 +654,7 @@ class CustomPieChart extends React.Component {
           >
             {`(${ payload.value } donor${ payload.value > 1 ? "s" : "" })`}
           </text>
-    
+
         </g>
         );
     }
@@ -670,7 +670,7 @@ const CustomPieChartWithRouter = withRouter(CustomPieChart);
    * indicate at which angle is the last shown label.
    */
 let lastAngle = 0;
-  
+
 const textStyle = {
     fontSize: "11px",
     fill: "#333",
@@ -679,7 +679,7 @@ const countTextStyle = {
     fontSize: "10px",
     fill: "#999",
 };
-  
+
 
 CustomPieChart.propTypes = {
     data: PropTypes.array,
@@ -687,8 +687,8 @@ CustomPieChart.propTypes = {
     chartWidthHeight: PropTypes.number,
     setAutoQueryPageTransition: PropTypes.func
 };
-  
-  
+
+
 //
 
 
@@ -736,7 +736,7 @@ const mapStateToProps = state => ({
     phenopackets: state.phenopackets,
     experiments: state.experiments,
     tableSummaries: state.tableSummaries
-    
+
 });
 
 

--- a/src/components/OverviewContent.js
+++ b/src/components/OverviewContent.js
@@ -13,7 +13,12 @@ import "antd/es/typography/style/css";
 import SitePageHeader from "./SitePageHeader";
 
 import {SITE_NAME} from "../constants";
-import {nodeInfoDataPropTypesShape, projectPropTypesShape, phenopacketPropTypesShape, experimentPropTypesShape} from "../propTypes";
+import {
+    nodeInfoDataPropTypesShape,
+    projectPropTypesShape,
+    phenopacketPropTypesShape,
+    experimentPropTypesShape
+} from "../propTypes";
 
 import {VictoryAxis, VictoryChart, VictoryHistogram} from "victory";
 // import {
@@ -74,28 +79,23 @@ class OverviewContent extends Component {
                 map[item] = 1;
             }
         });
-
-        const jsonObjsXY = [];
-        for (var key in map) {
-            jsonObjsXY.push({x: key, y:map[key]});
-        }
-
-        return jsonObjsXY;
+        
+        return Object.items(map).map(([key, value]) => ({x: key, y: value}));
     }
 
     onPieEnter = (chartNum, data, index) => {
         // console.log(data)
-        if (chartNum == 0){    
+        if (chartNum === 0){
             this.setState({
                 sexChartActiveIndex: index,
             });
         }
-        else if (chartNum == 1){    
+        else if (chartNum === 1){
             this.setState({
                 diseaseChartActiveIndex: index,
             });
         }
-        else if (chartNum == 2){    
+        else if (chartNum === 2){
             this.setState({
                 biosamplesChartActiveIndex: index,
             });
@@ -103,7 +103,7 @@ class OverviewContent extends Component {
     };
 
     getFrequencyNameValue(array) {
-        var sumOfAllValues = 0; // Accumulate all values to compute on them later
+        let sumOfAllValues = 0; // Accumulate all values to compute on them later
         const map = {}; // Gather elements by their name and group them
         array.forEach(item => {
             if(map[item]){
@@ -117,11 +117,11 @@ class OverviewContent extends Component {
         // Group the items in the array of objects denoted by 
         // a "name" and "value" parameter
         const jsonObjsXY = [];
-        for (var key in map) {
-            var val = map[key];
+        for (const key in map) {
+            const val = map[key];
             // Group all elements with a small enough value together under an "Other"
             if ((val / sumOfAllValues) < 0.04){
-                var otherIndex = jsonObjsXY.findIndex(obj => obj.name=="Other");
+                const otherIndex = jsonObjsXY.findIndex(obj => obj.name === "Other");
                 if (otherIndex > -1) {
                     jsonObjsXY[otherIndex].value += val; // Accumulate
                 } else {
@@ -140,23 +140,23 @@ class OverviewContent extends Component {
 
     stringToDateYearAsXJSON(birthdayStr) {
         // curtosity of : https://stackoverflow.com/questions/10008050/get-age-from-birthdate
-        var today_date = new Date();
-        var today_year = today_date.getFullYear();
-        var today_month = today_date.getMonth();
-        var today_day = today_date.getDate();
+        const today_date = new Date();
+        const today_year = today_date.getFullYear();
+        const today_month = today_date.getMonth();
+        const today_day = today_date.getDate();
 
-        var birthday = new Date(birthdayStr);
-        var birth_year =  birthday.getFullYear();
-        var birth_month =  birthday.getMonth();
-        var birth_date =  birthday.getDate();
+        const birthday = new Date(birthdayStr);
+        const birth_year =  birthday.getFullYear();
+        const birth_month =  birthday.getMonth();
+        const birth_date =  birthday.getDate();
         
-        var age = today_year - birth_year;
+        let age = today_year - birth_year;
 
         if ( today_month < (birth_month - 1))
         {
             age--;
         }
-        if (((birth_month - 1) == today_month) && (today_day < birth_date))
+        if (((birth_month - 1) === today_month) && (today_day < birth_date))
         {
             age--;
         }
@@ -165,44 +165,39 @@ class OverviewContent extends Component {
     }
 
     render() {
-        const numParticipants = this.props.phenopackets != undefined ? this.props.phenopackets.items.length : 0;
-        const biosamples = this.props.phenopackets != undefined ? this.props.phenopackets.items.flatMap(p => p.biosamples) : [];
+        const phenopackets = (this.props.phenopackets || {items: []}).items;
+
+        // TODO: Note: technically this is not the number of participants,
+        //  since phenopackets may not all have unique individuals
+        const numParticipants = phenopackets.length;
+        const biosamples = phenopackets.flatMap(p => p.biosamples);
         const biosampleLabels = this.getFrequencyNameValue(biosamples.flatMap(bs => bs.sampled_tissue.label));
         //const biosampleAgeAtCollection = biosamples.flatMap(bs => bs.sampled_tissue.label)
-        const participantDOB = this.props.phenopackets != undefined ? this.props.phenopackets.items.flatMap(p => this.stringToDateYearAsXJSON(p.subject.date_of_birth)) : [];
+        const participantDOB = phenopackets.flatMap(p => this.stringToDateYearAsXJSON(p.subject.date_of_birth));
 
         const numBiosamples = biosamples.length;
         
-        const sexLabels = this.getFrequencyNameValue(this.props.phenopackets != undefined ? this.props.phenopackets.items.flatMap(p => p.subject.sex) : []);
+        const sexLabels = this.getFrequencyNameValue(phenopackets.flatMap(p => p.subject.sex));
         const diseaseLabels = this.getFrequencyNameValue(
-            this.props.phenopackets != undefined 
-                ? this.props.phenopackets.items.flatMap(p => 
-                    p.diseases.flatMap(d => 
-                        d.term.label)) 
-                : []);
+            phenopackets.flatMap(p => p.diseases.flatMap(d => d.term.label)));
 
-        const experiments = this.props.experiments != undefined ? this.props.experiments.items : [];
+        const experiments = (this.props.experiments || {items: []}).items;
 
-        const variantTableSummaries = this.props.tableSummaries != undefined 
-            ? this.props.tableSummaries.summariesByServiceArtifactAndTableID != undefined 
-                ? this.props.tableSummaries.summariesByServiceArtifactAndTableID.variant != undefined 
-                    ? this.props.tableSummaries.summariesByServiceArtifactAndTableID.variant
-                    : undefined
-                : undefined
-            : undefined;
+        const variantTableSummaries = ((this.props.tableSummaries || {})
+            .summariesByServiceArtifactAndTableID || {}).variant || undefined;
         
-        var numVariants = 0;
-        var numSamples = 0;
-        var numVCFs = 0;
-        if (variantTableSummaries != undefined){
-            for (const key in variantTableSummaries) {
-                numVariants += variantTableSummaries[key].count;
-                numSamples += variantTableSummaries[key].data_type_specific.samples;
-                numVCFs += variantTableSummaries[key].data_type_specific.vcf_files;
-            }
-        }
+        let numVariants = 0;
+        let numSamples = 0;
+        let numVCFs = 0;
+        (variantTableSummaries || []).forEach(key => {
+            numVariants += variantTableSummaries[key].count;
+            numSamples += variantTableSummaries[key].data_type_specific.samples;
+            numVCFs += variantTableSummaries[key].data_type_specific.vcf_files;
+        });
 
-        
+        const fetchingPhenopackets = (this.props.phenopackets || {isFetching: true}).isFetching;
+        const fetchingExperiments = (this.props.experiments || {isFetching: true}).isFetching;
+        const fetchingTableSummaries = (this.props.tableSummaries || {isFetching: true}).isFetching;
 
         return <>
             <SitePageHeader title="Overview" subTitle="" />
@@ -212,17 +207,17 @@ class OverviewContent extends Component {
                         <Typography.Title level={4}>Clinical/Phenotypical Data</Typography.Title>
                         <Row style={{marginBottom: "24px"}} gutter={[0, 16]}>
                             <Col xl={2} lg={3} md={5} sm={6} xs={10}>
-                                <Spin spinning={this.props.phenopackets == undefined ? true : this.props.phenopackets.isFetching}>
+                                <Spin spinning={fetchingPhenopackets}>
                                     <Statistic title="Participants" value={numParticipants} />
                                 </Spin>
                             </Col>
                             <Col xl={2} lg={3} md={5} sm={6} xs={10}>
-                                <Spin spinning={this.props.phenopackets == undefined ? true : this.props.phenopackets.isFetching}>
+                                <Spin spinning={fetchingPhenopackets}>
                                     <Statistic title="Biosamples" value={numBiosamples} />
                                 </Spin>
                             </Col>
                             <Col xl={2} lg={3} md={5} sm={6} xs={10}>
-                                <Spin spinning={this.props.experiments == undefined ? true : this.props.experiments.isFetching}>
+                                <Spin spinning={fetchingExperiments}>
                                     <Statistic title="Experiments" value={experiments.length} />
                                 </Spin>
                             </Col>
@@ -230,8 +225,8 @@ class OverviewContent extends Component {
                         <Col lg={12} md={24}>
                             <Row style={{display: "flex", justifyContent: "center"}}>
                                 <Col style={{textAlign: "center"}}>
-                                    <h2>{this.props.phenopackets.isFetching ? "" : "Sexes"}</h2>
-                                    <Spin spinning={this.props.phenopackets == undefined ? true : this.props.phenopackets.isFetching}>
+                                    <h2>{fetchingPhenopackets ? "" : "Sexes"}</h2>
+                                    <Spin spinning={fetchingPhenopackets}>
                                         <CustomPieChartWithRouter
                                           data={sexLabels}
                                           chartWidthHeight={this.state.chartWidthHeight}
@@ -246,8 +241,8 @@ class OverviewContent extends Component {
                                 paddingRight: this.state.chartPadding, 
                                 paddingBottom: 0}}>      
                                 <Col style={{textAlign: "center"}}>
-                                    <h2>{this.props.phenopackets.isFetching ? "" : "Age"}</h2>
-                                    <Spin spinning={this.props.phenopackets == undefined ? true : this.props.phenopackets.isFetching}>
+                                    <h2>{fetchingPhenopackets ? "" : "Age"}</h2>
+                                    <Spin spinning={fetchingPhenopackets}>
                                         <VictoryChart>
                                             <VictoryAxis tickValues={AGE_HISTOGRAM_BINS}
                                                          label="Age (Years)"
@@ -272,8 +267,8 @@ class OverviewContent extends Component {
                         <Col lg={12} md={24}>
                             <Row style={{display: "flex", justifyContent: "center"}}>
                                 <Col style={{textAlign: "center"}}>
-                                    <h2>{this.props.phenopackets.isFetching ? "" : "Diseases"}</h2>
-                                    <Spin spinning={this.props.phenopackets == undefined ? true : this.props.phenopackets.isFetching}>
+                                    <h2>{fetchingPhenopackets ? "" : "Diseases"}</h2>
+                                    <Spin spinning={fetchingPhenopackets}>
                                         <CustomPieChartWithRouter
                                           data={diseaseLabels}
                                           chartWidthHeight={this.state.chartWidthHeight}
@@ -287,8 +282,7 @@ class OverviewContent extends Component {
                                 display: "flex", justifyContent: "center"}}>
                                 <Col style={{textAlign: "center"}}>
                                     <h2>{this.props.phenopackets.isFetching ? "" : "Biosamples"}</h2>
-                                    <Spin spinning={this.props.phenopackets == undefined 
-                                        ? true : this.props.phenopackets.isFetching}>
+                                    <Spin spinning={(this.props.phenopackets || {isFetching: true}).isFetching}>
                                     <CustomPieChartWithRouter
                                       data={biosampleLabels}
                                       chartWidthHeight={this.state.chartWidthHeight}
@@ -304,19 +298,19 @@ class OverviewContent extends Component {
                     <Typography.Title level={4}>Variants</Typography.Title>
                     <Row style={{marginBottom: "24px"}} gutter={[0, 16]}>
                         <Col xl={3} lg={4} md={5} sm={7}>
-                            <Spin spinning={this.props.tableSummaries == undefined ? true : this.props.tableSummaries.isFetching}>
+                            <Spin spinning={fetchingTableSummaries}>
                                 <Statistic title="Variants"
                                            value={numVariants} />
                             </Spin>
                         </Col>
                         <Col xl={2} lg={3} md={4} sm={5} xs={6}>
-                            <Spin spinning={this.props.tableSummaries == undefined ? true : this.props.tableSummaries.isFetching}>
+                            <Spin spinning={fetchingTableSummaries}>
                                 <Statistic title="Samples"
                                            value={numSamples} />
                             </Spin>
                         </Col>
                         <Col xl={2} lg={3} md={4} sm={5} xs={6}>
-                            <Spin spinning={this.props.tableSummaries == undefined ? true : this.props.tableSummaries.isFetching}>
+                            <Spin spinning={fetchingTableSummaries}>
                                 <Statistic title="VCF Files"
                                            prefix={<Icon type="file" />}
                                            value={numVCFs} />
@@ -436,10 +430,7 @@ class CustomPieChart extends React.Component {
         if (this.state !== state && state.canUpdate)
             return true;
   
-        if (this.props.data === props.data)
-            return false;
-  
-        return true;
+        return this.props.data !== props.data;
     }
   
     render() {
@@ -489,7 +480,7 @@ class CustomPieChart extends React.Component {
 
         // skip rendering this static label if the sector is selected.
         // this will let the 'renderActiveState' draw without overlapping
-        if (index == state.activeIndex){
+        if (index === state.activeIndex) {
             return;
         }
   
@@ -671,7 +662,8 @@ class CustomPieChart extends React.Component {
 
 // Create a new component that is "connected" (to borrow redux
 // terminology) to the router.
-const CustomPieChartWithRouter = withRouter(CustomPieChart);//connect(setAutoQueryPageTransition)(withRouter(CustomPieChart));
+const CustomPieChartWithRouter = withRouter(CustomPieChart);
+//connect(setAutoQueryPageTransition)(withRouter(CustomPieChart));
 
   /*
    * lastAngle is mutated by renderLabel() and renderActiveShape() to
@@ -748,4 +740,9 @@ const mapStateToProps = state => ({
 });
 
 
-export default connect(mapStateToProps, {fetchPhenopackets, fetchExperiments, fetchVariantTableSummaries, setAutoQueryPageTransition})(OverviewContent);
+export default connect(mapStateToProps, {
+    fetchPhenopackets,
+    fetchExperiments,
+    fetchVariantTableSummaries,
+    setAutoQueryPageTransition
+})(OverviewContent);

--- a/src/components/OverviewContent.js
+++ b/src/components/OverviewContent.js
@@ -802,4 +802,10 @@ const mapStateToProps = state => ({
 });
 
 
-export default connect(mapStateToProps, {fetchPhenopackets, fetchExperiments, fetchVariantTableSummaries, fetchOverviewSummary, setAutoQueryPageTransition})(OverviewContent);
+export default connect(mapStateToProps, {
+    fetchPhenopackets,
+    fetchExperiments,
+    fetchVariantTableSummaries,
+    fetchOverviewSummary,
+    setAutoQueryPageTransition
+})(OverviewContent);

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -19,17 +19,11 @@ import {nodeInfoDataPropTypesShape, notificationPropTypesShape, userPropTypesSha
 
 
 class SiteHeader extends Component {
-    constructor(){
+    constructor() {
         super();
         this.state = {
             current: "mail",
         };
-    }
-    handleSubMenuClick(e) {
-        console.log("click ", e);
-        this.setState({
-            current: e.key,
-        });
     }
 
     render() {

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -29,7 +29,7 @@ class SiteHeader extends Component {
         console.log("click ", e);
         this.setState({
             current: e.key,
-        });    
+        });
     }
 
     render() {
@@ -38,7 +38,7 @@ class SiteHeader extends Component {
                 url: withBasePath("overview"),
                 icon: <Icon type="user" />,
                 text: <span className="nav-text">Overview</span>,
-            },         
+            },
             {
                 url: withBasePath("data/sets"),
                 icon: <Icon type="file-search" />,
@@ -121,14 +121,14 @@ class SiteHeader extends Component {
                   mode="horizontal"
                   selectedKeys={matchingMenuKeys(menuItems)}
                   style={{lineHeight: "64px"}}>
-                      
+
                 {menuItems.map(i => renderMenuItem(i))}
-                
+
             </Menu>
         </Layout.Header>;
     }
 }
-    
+
 
 SiteHeader.propTypes = {
     nodeInfo: nodeInfoDataPropTypesShape,

--- a/src/components/VictoryPieWrapSVG.js
+++ b/src/components/VictoryPieWrapSVG.js
@@ -1,7 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const VictoryPieWrapSVG = ({viewBoxStr, children}) => <svg viewBox={viewBoxStr == undefined || viewBoxStr == "" ? "0 0 400 250" : viewBoxStr}>{children}</svg>;
+const VictoryPieWrapSVG = ({viewBoxStr, children}) =>
+    <svg viewBox={viewBoxStr === undefined || viewBoxStr === "" ? "0 0 400 250" : viewBoxStr}>{children}</svg>;
 VictoryPieWrapSVG.propTypes = {viewBoxStr: PropTypes.string, children: PropTypes.any};
 
 export default VictoryPieWrapSVG;

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -45,7 +45,7 @@ class DiscoveryQueryBuilder extends Component {
     componentDidMount() {
         (this.props.requiredDataTypes || []).forEach(dt => this.props.addDataTypeQueryForm(dt));
 
-        if (this.props.autoQuery != undefined && this.props.autoQuery.isAutoQuery){
+        if ((this.props.autoQuery || {}).isAutoQuery) {
 
             // Trigger a cascade of async functions
             // that involve waiting for redux actions to reduce (complete)
@@ -53,16 +53,15 @@ class DiscoveryQueryBuilder extends Component {
             (async () => {
 
                 // Clean old queries (if any)
-                Object.values(this.props.dataTypesByID).forEach(async value=> {
-                    await this.handleTabsEdit(value.id, "remove");
-                });
+                Object.values(this.props.dataTypesByID).forEach(value =>
+                    this.handleTabsEdit(value.id, "remove"));
 
                 // Set type of query
                 await this.handleAddDataTypeQueryForm({key: `:${this.props.autoQuery.autoQueryType}`});     
 
                 // Set term
-                var dataType =this.props.dataTypesByID[this.props.autoQuery.autoQueryType];
-                var fields = {
+                const dataType =this.props.dataTypesByID[this.props.autoQuery.autoQueryType];
+                const fields = {
                     keys: {
                         value:[0]
                     },
@@ -71,7 +70,8 @@ class DiscoveryQueryBuilder extends Component {
                         value: {
                             dataType: dataType,
                             field: this.props.autoQuery.autoQueryField,
-                            fieldSchema: getFieldSchema(dataType.schema, this.props.autoQuery.autoQueryField), // from utils/schema
+                            // from utils/schema:
+                            fieldSchema: getFieldSchema(dataType.schema, this.props.autoQuery.autoQueryField),
                             negated: false,
                             operation: OP_EQUALS,
                             searchValue: this.props.autoQuery.autoQueryValue
@@ -79,13 +79,11 @@ class DiscoveryQueryBuilder extends Component {
                     }]
                 };
 
-                // "Simulate" form datastructure and trigger update
+                // "Simulate" form data structure and trigger update
                 await this.handleFormChange(dataType, fields);
 
-
                 // Simulate form submission click
-                this.handleSubmit();
-
+                await this.handleSubmit();
 
                 // Clean up auto-query "paper trail" (that is, the state segment that 
                 // was introduced in order to transfer intent from the OverviewContent page)

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -57,7 +57,7 @@ class DiscoveryQueryBuilder extends Component {
                     this.handleTabsEdit(value.id, "remove"));
 
                 // Set type of query
-                await this.handleAddDataTypeQueryForm({key: `:${this.props.autoQuery.autoQueryType}`});     
+                await this.handleAddDataTypeQueryForm({key: `:${this.props.autoQuery.autoQueryType}`});
 
                 // Set term
                 const dataType =this.props.dataTypesByID[this.props.autoQuery.autoQueryType];
@@ -85,7 +85,7 @@ class DiscoveryQueryBuilder extends Component {
                 // Simulate form submission click
                 const submit = this.handleSubmit();
 
-                // Clean up auto-query "paper trail" (that is, the state segment that 
+                // Clean up auto-query "paper trail" (that is, the state segment that
                 // was introduced in order to transfer intent from the OverviewContent page)
                 this.props.neutralizeAutoQueryPageTransition();
 

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -83,12 +83,13 @@ class DiscoveryQueryBuilder extends Component {
                 await this.handleFormChange(dataType, fields);
 
                 // Simulate form submission click
-                await this.handleSubmit();
+                const submit = this.handleSubmit();
 
                 // Clean up auto-query "paper trail" (that is, the state segment that 
                 // was introduced in order to transfer intent from the OverviewContent page)
                 this.props.neutralizeAutoQueryPageTransition();
-                
+
+                await submit;
             })();
         }
     }

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -83,13 +83,11 @@ class DiscoveryQueryBuilder extends Component {
                 await this.handleFormChange(dataType, fields);
 
                 // Simulate form submission click
-                const submit = this.handleSubmit();
+                this.handleSubmit();
 
                 // Clean up auto-query "paper trail" (that is, the state segment that
                 // was introduced in order to transfer intent from the OverviewContent page)
                 this.props.neutralizeAutoQueryPageTransition();
-
-                await submit;
             })();
         }
     }

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -97,10 +97,12 @@ class ExplorerDatasetSearch extends Component {
 
         if (!selectedDataset) return null;  // TODO
 
+        const numResults = (this.props.searchResults || {searchFormattedResults: []}).searchFormattedResults.length;
+
         // Calculate page numbers and range
-        var showingResults = 0;
-        if (this.props.searchResults != undefined && this.props.searchResults.searchFormattedResults.length > 0)
-            showingResults = (this.state.currentPage * this.state.pageSize) - this.state.pageSize + 1;
+        const showingResults = numResults > 0
+            ? (this.state.currentPage * this.state.pageSize) - this.state.pageSize + 1
+            : 0;
 
         return <>
             <Typography.Title level={4}>Explore Dataset {selectedDataset.title}</Typography.Title>
@@ -113,10 +115,8 @@ class ExplorerDatasetSearch extends Component {
                                    removeDataTypeQueryForm={this.props.removeDataTypeQueryForm} />
             {this.props.searchResults ? <>
                 <Typography.Title level={4}>
-                    Showing results {showingResults}-{
-                    (this.state.currentPage * this.state.pageSize) < this.props.searchResults.searchFormattedResults.length 
-                        ? (this.state.currentPage * this.state.pageSize) 
-                        : this.props.searchResults.searchFormattedResults.length} of {this.props.searchResults.searchFormattedResults.length}
+                    Showing results {showingResults}-{Math.min(this.state.currentPage * this.state.pageSize,
+                    numResults)} of {this.props.searchResults.searchFormattedResults.length}
                     <div style={{float: "right", verticalAlign: "top"}}>
                         <Button icon="profile"
                                 style={{marginRight: "8px"}}
@@ -128,7 +128,9 @@ class ExplorerDatasetSearch extends Component {
                         <Spin spinning={this.props.isFetchingDownload} style={{display: "inline-block !important"}}>
                             <Button icon="export" style={{marginRight: "8px"}}
                                     disabled={this.props.isFetchingDownload}
-                                    onClick={() => this.props.performIndividualsDownloadCSVIfPossible(this.props.selectedRows, this.props.searchResults.searchFormattedResults)}>Export as CSV</Button>
+                                    onClick={() => this.props.performIndividualsDownloadCSVIfPossible(
+                                        this.props.selectedRows, this.props.searchResults.searchFormattedResults)}>
+                                Export as CSV</Button>
                         </Spin>
                     </div>
                 </Typography.Title>
@@ -145,7 +147,11 @@ class ExplorerDatasetSearch extends Component {
                                size="middle"
                                columns={SEARCH_RESULT_COLUMNS}
                                dataSource={this.props.searchResults.searchFormattedResults || []}
-                               pagination={{pageSize: this.state.pageSize, defaultCurrent: this.state.currentPage, showQuickJumper: true}}
+                               pagination={{
+                                   pageSize: this.state.pageSize,
+                                   defaultCurrent: this.state.currentPage,
+                                   showQuickJumper: true
+                               }}
                                onChange={this.onPageChange}
                                rowSelection={{
                                    selectedRowKeys: this.props.selectedRows,

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -116,7 +116,7 @@ class ExplorerDatasetSearch extends Component {
             {this.props.searchResults ? <>
                 <Typography.Title level={4}>
                     Showing results {showingResults}-{Math.min(this.state.currentPage * this.state.pageSize,
-                    numResults)} of {this.props.searchResults.searchFormattedResults.length}
+                    numResults)} of {numResults}
                     <div style={{float: "right", verticalAlign: "top"}}>
                         <Button icon="profile"
                                 style={{marginRight: "8px"}}

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -194,7 +194,7 @@ ExplorerDatasetSearch.propTypes = {
 
     performIndividualsDownloadCSVIfPossible: PropTypes.func.isRequired,
     isFetchingDownload: PropTypes.bool,
-    
+
     federationServiceInfo: serviceInfoPropTypesShape,
     datasetsByID: PropTypes.objectOf(datasetPropTypesShape),
 };

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -46,7 +46,7 @@ const BIOSAMPLE_COLUMNS = [
     {
         title: "Extra Properties",
         key: "extra_properties",
-        render: (_, individual) => 
+        render: (_, individual) =>
             (individual.hasOwnProperty("extra_properties") && Object.keys(individual.extra_properties).length)
                 ?  <div><pre>{JSON.stringify(individual.extra_properties, null, 2)}</pre></div>
                 : EM_DASH,

--- a/src/components/explorer/IndividualDiseases.js
+++ b/src/components/explorer/IndividualDiseases.js
@@ -31,7 +31,7 @@ const DISEASE_COLUMNS = [
     {
         title: "Onset Age(s)",
         key: "t_onset_ages",
-        render: (_, individual) => 
+        render: (_, individual) =>
         // Print onset age
             (individual.hasOwnProperty("onset") && Object.keys(individual.onset).length)
             // Single onset age
@@ -49,7 +49,7 @@ const DISEASE_COLUMNS = [
     {
         title: "Extra Properties",
         key: "extra_properties",
-        render: (_, individual) => 
+        render: (_, individual) =>
             (individual.hasOwnProperty("extra_properties") && Object.keys(individual.extra_properties).length)
                 ?  <div><pre>{JSON.stringify(individual.extra_properties, null, 2)}</pre></div>
                 : EM_DASH,
@@ -61,7 +61,7 @@ const IndividualDiseases = ({individual}) =>
            size="middle"
            pagination={{pageSize: 25}}
            columns={DISEASE_COLUMNS}
-           rowKey="id"                    
+           rowKey="id"
            dataSource={(individual || {}).phenopackets.flatMap(p => p.diseases)} />;
 
 

--- a/src/components/explorer/IndividualGenes.js
+++ b/src/components/explorer/IndividualGenes.js
@@ -13,7 +13,7 @@ const IndividualGenes = ({individual}) =>
     const genes = (individual || {}).phenopackets.flatMap(p => p.genes);
     const genesFlat = genes.flatMap(g => g.symbol);
     const ids = [{
-        //(biosamples || []).map(_b => 
+        //(biosamples || []).map(_b =>
         title: "Symbol",
             // key: "id",
         render: (_, gene) => <div><pre>{gene}</pre></div>,
@@ -27,7 +27,7 @@ const IndividualGenes = ({individual}) =>
                   pagination={{pageSize: 25}}
                   columns={ids}
                   rowKey="id"
-                  dataSource={genesFlat} 
+                  dataSource={genesFlat}
         />;
 };
 IndividualGenes.propTypes = {

--- a/src/components/explorer/IndividualPhenotypicFeatures.js
+++ b/src/components/explorer/IndividualPhenotypicFeatures.js
@@ -10,7 +10,10 @@ const P_FEATURES_COLUMNS = [
     {
         title: "Type",
         key: "type",
-        render: (_, individual) => <span><b>{((individual || {}).type || {}).label || EM_DASH}</b> {((individual || {}).type || {}).id || EM_DASH}</span>,
+        render: (_, individual) => <span>
+            <strong>{((individual || {}).type || {}).label || EM_DASH} </strong>
+            {((individual || {}).type || {}).id || EM_DASH}
+        </span>,
     },
     {
         title: "Negated",
@@ -20,7 +23,7 @@ const P_FEATURES_COLUMNS = [
     {
         title: "Extra Properties",
         key: "extra_properties",
-        render: (_, individual) => 
+        render: (_, individual) =>
             (individual.hasOwnProperty("extra_properties") && Object.keys(individual.extra_properties).length)
                 ?  <div><pre>{JSON.stringify(individual.extra_properties, null, 2)}</pre></div>
                 : EM_DASH,

--- a/src/components/explorer/IndividualVariants.js
+++ b/src/components/explorer/IndividualVariants.js
@@ -12,13 +12,13 @@ import "./explorer.css";
 const IndividualVariants = ({individual}) =>
 {
     const biosamples = (individual || {}).phenopackets.flatMap(p => p.biosamples);
-    
+
     const variantsMapped = {};
     biosamples.forEach(bs => {
         variantsMapped[bs.id] = ((bs || {}).variants || []).map(v => (v || {}).hgvsAllele);
     });
 
-    const ids = (biosamples || []).map(b => 
+    const ids = (biosamples || []).map(b =>
         ({
             title: `Biosample ${b.id}`,
             key: b.id,
@@ -34,10 +34,10 @@ const IndividualVariants = ({individual}) =>
                   pagination={{pageSize: 25}}
                   columns={ids}
                   rowKey="id"
-                  dataSource={[variantsMapped]} 
+                  dataSource={[variantsMapped]}
         />;
 };
-        
+
 
 IndividualVariants.propTypes = {
     individual: individualPropTypesShape

--- a/src/components/explorer/IndividualVariants.js
+++ b/src/components/explorer/IndividualVariants.js
@@ -22,7 +22,8 @@ const IndividualVariants = ({individual}) =>
         ({
             title: `Biosample ${b.id}`,
             key: b.id,
-            render: (_, map) => <div style={{verticalAlign: "top"}}><pre>{JSON.stringify(map[b.id], null, 2)}</pre></div>,
+            render: (_, map) => <div style={{verticalAlign: "top"}}>
+                <pre>{JSON.stringify(map[b.id], null, 2)}</pre></div>,
             //sorter: (a, b) => a.id.localeCompare(b.id),
             //defaultSortOrder: "ascend"
         })

--- a/src/components/manager/ManagerFilesContent.js
+++ b/src/components/manager/ManagerFilesContent.js
@@ -155,7 +155,7 @@ class ManagerFilesContent extends Component {
         let filesLeft = [...this.state.selectedFiles];
         const inputs = {};
 
-        for (let i of w.inputs.filter(i => i.type.startsWith("file"))) {
+        for (const i of w.inputs.filter(i => i.type.startsWith("file"))) {
             // Find tables that support the data type
             // TODO
 

--- a/src/components/manager/runs/ManagerRunsContent.js
+++ b/src/components/manager/runs/ManagerRunsContent.js
@@ -1,5 +1,4 @@
-import React, {Component} from "react";import "antd/es/tag/style/css";
-import "antd/es/typography/style/css";
+import React, {Component} from "react";
 
 import {Redirect, Route, Switch} from "react-router-dom";
 

--- a/src/modules/auth/actions.js
+++ b/src/modules/auth/actions.js
@@ -8,7 +8,12 @@ import {
 
 import {fetchServiceLogsIfPossible, fetchSystemLogsIfPossible} from "../logs/actions";
 import {fetchDropBoxTreeOrFail} from "../manager/actions";
-import {fetchExperiments, fetchProjectsWithDatasetsAndTables, fetchVariantTableSummaries, fetchPhenopackets} from "../metadata/actions";
+import {
+    fetchExperiments,
+    fetchProjectsWithDatasetsAndTables,
+    fetchVariantTableSummaries,
+    fetchPhenopackets
+} from "../metadata/actions";
 import {fetchNodeInfo} from "../node/actions";
 import {fetchNotifications} from "../notifications/actions";
 import {fetchServicesWithMetadataAndDataTypesAndTablesIfNeeded} from "../services/actions";

--- a/src/modules/discovery/actions.js
+++ b/src/modules/discovery/actions.js
@@ -1,4 +1,8 @@
-import {conditionsToQuery, extractQueriesFromDataTypeForms, extractQueryConditionsFromFormValues} from "../../utils/search";
+import {
+    conditionsToQuery,
+    extractQueriesFromDataTypeForms,
+    extractQueryConditionsFromFormValues
+} from "../../utils/search";
 import {createNetworkActionTypes, networkAction} from "../../utils/actions";
 import {jsonRequest} from "../../utils/requests";
 

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -50,19 +50,16 @@ export const performIndividualsDownloadCSVIfPossible = (datasetId, individualIds
     (dispatch, getState) => {
         console.log("Initiating PerformIndividualsDownloadCSVIfPossible");
 
-        let dataUrl = getState().services.itemsByArtifact.metadata.url + "/api/individuals?format=csv";
+        let dataUrl = `${getState().services.itemsByArtifact.metadata.url}/api/individuals?format=csv`;
 
         // build query string
+        // TODO: This should use the actual JS API for URL construction
         if (individualIds.length > 0) { // Get only selected results
             dataUrl += ("&page_size=" + individualIds.length);
-            for(let i = 0; i < individualIds.length; i++){
-                dataUrl += ("&id="+individualIds[i]);
-            }
+            individualIds.forEach(id => dataUrl += `&id=${id}`);
         } else { // Get all search results
             dataUrl += ("&page_size=" + allSearchResults.length);
-            for(let j = 0; j < allSearchResults.length; j++){
-                dataUrl += ("&id="+allSearchResults[j].key);
-            }
+            allSearchResults.forEach(sr => dataUrl += `&id=${sr.key}`);
         }
 
         return dispatch(performIndividualCSVDownload(dataUrl));

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -46,26 +46,27 @@ export const performSearchIfPossible = (datasetID) => (dispatch, getState) => {
     return dispatch(performSearch(datasetID, dataTypeQueries));
 };
 
-export const performIndividualsDownloadCSVIfPossible = (datasetId, individualIds, allSearchResults) => (dispatch, getState) => {
-    console.log("Initiating PerformIndividualsDownloadCSVIfPossible");
+export const performIndividualsDownloadCSVIfPossible = (datasetId, individualIds, allSearchResults) =>
+    (dispatch, getState) => {
+        console.log("Initiating PerformIndividualsDownloadCSVIfPossible");
 
-    var dataUrl = getState().services.itemsByArtifact.metadata.url + "/api/individuals?format=csv";
-    
-    // build query string 
-    if (individualIds.length > 0) { // Get only selected results
-        dataUrl += ("&page_size=" + individualIds.length);
-        for(var i = 0; i < individualIds.length; i++){
-            dataUrl += ("&id="+individualIds[i]);
+        let dataUrl = getState().services.itemsByArtifact.metadata.url + "/api/individuals?format=csv";
+
+        // build query string
+        if (individualIds.length > 0) { // Get only selected results
+            dataUrl += ("&page_size=" + individualIds.length);
+            for(let i = 0; i < individualIds.length; i++){
+                dataUrl += ("&id="+individualIds[i]);
+            }
+        } else { // Get all search results
+            dataUrl += ("&page_size=" + allSearchResults.length);
+            for(let j = 0; j < allSearchResults.length; j++){
+                dataUrl += ("&id="+allSearchResults[j].key);
+            }
         }
-    } else { // Get all search results
-        dataUrl += ("&page_size=" + allSearchResults.length);
-        for(var j = 0; j < allSearchResults.length; j++){
-            dataUrl += ("&id="+allSearchResults[j].key);
-        }        
-    }
-    
-    return dispatch(performIndividualCSVDownload(dataUrl));
-};
+
+        return dispatch(performIndividualCSVDownload(dataUrl));
+    };
 
 
 

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -107,7 +107,7 @@ export const explorer = (
             };
         case PERFORM_INDIVIDUAL_CSV_DOWNLOAD.RECEIVE:
             FileSaver.saveAs(action.data, "data.csv"); //new Blob([data], {type: "application/octet-stream"})
-            
+
             return {
                 ...state,
                 isFetchingDownload: false,

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -99,7 +99,8 @@ export const fetchVariantTableSummaries = () => async (dispatch, getState) => {
     if (chordService) {
         for (const table of getState().projectTables.items) {
             if (table.service_artifact === "variant") {
-                await dispatch(fetchTableSummaryIfPossible(chordService, {url: "/api/variant"}, table.table_id));
+                await dispatch(fetchTableSummaryIfPossible(chordService,
+                    {url: "/api/variant"}, table.table_id));
             }
         }
     }

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -94,11 +94,12 @@ export const fetchVariantTableSummaries = () => async (dispatch, getState) => {
     dispatch(beginFlow(FETCHING_TABLE_SUMMARIES));
 
     const chordService =  getState().chordServices.itemsByArtifact.variant || null;
-    if (!chordService) return;
 
-    for (const table of getState().projectTables.items) {
-        if (table.service_artifact === "variant") {
-            await dispatch(fetchTableSummaryIfPossible(chordService, {url:"/api/variant"}, table.table_id));
+    if (chordService) {
+        for (const table of getState().projectTables.items) {
+            if (table.service_artifact === "variant") {
+                await dispatch(fetchTableSummaryIfPossible(chordService, {url: "/api/variant"}, table.table_id));
+            }
         }
     }
 

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -21,7 +21,7 @@ import {
 import {nop, objectWithoutProps} from "../../utils/misc";
 import {jsonRequest} from "../../utils/requests";
 import {withBasePath} from "../../utils/url";
-import {fetchTableSummaryIfPossible} from "../../modules/tables/actions";
+import {fetchTableSummaryIfPossible} from "../tables/actions";
 
 
 export const FETCH_PROJECTS = createNetworkActionTypes("FETCH_PROJECTS");
@@ -93,18 +93,14 @@ export const fetchVariantTableSummaries = () => async (dispatch, getState) => {
 
     dispatch(beginFlow(FETCHING_TABLE_SUMMARIES));
 
-    var chordservice =  getState().chordServices.itemsByArtifact.variant || null ;
-    
-    if (chordservice != null)
-    {
-        var tables = getState().projectTables.items;
-        for (var t=0;t<tables.length; t++){
-            var table = tables[t];
-            if (table.service_artifact == "variant") {
-                await dispatch(fetchTableSummaryIfPossible(chordservice, {url:"/api/variant"}, table.table_id));
-            }
+    const chordService =  getState().chordServices.itemsByArtifact.variant || null;
+    if (!chordService) return;
+
+    for (const table of getState().projectTables.items) {
+        if (table.service_artifact === "variant") {
+            await dispatch(fetchTableSummaryIfPossible(chordService, {url:"/api/variant"}, table.table_id));
         }
-    } 
+    }
 
     dispatch(endFlow(FETCHING_TABLE_SUMMARIES));
 };

--- a/src/modules/metadata/reducers.js
+++ b/src/modules/metadata/reducers.js
@@ -376,8 +376,8 @@ export const phenopackets = (
     switch (action.type) {
         case FETCH_PHENOPACKETS.REQUEST:
             return {
-                ...state, items: [], 
-                isFetching: true 
+                ...state, items: [],
+                isFetching: true
             };
         case FETCH_PHENOPACKETS.RECEIVE:
             return {

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -271,7 +271,7 @@ export const experimentPropTypesShape = PropTypes.shape({
 export const overviewSummaryPropTypesShape = PropTypes.shape({
     data: PropTypes.shape({
         // TODO: more precision
-        phenopackets: PropTypes.number, 
+        phenopackets: PropTypes.number,
         data_type_specific: PropTypes.shape({
             biosamples: PropTypes.object,
             diseases: PropTypes.object,

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -58,7 +58,7 @@ const _networkAction = (fn, ...args) => async (dispatch, getState) => {
 
     const {types, params, url, req, err, onSuccess, paginated, asCsv} = fnResult;
     let {parse} = fnResult;
-    if (asCsv){
+    if (asCsv) {
         if (!parse) parse = async r => await r.blob();
     } else {
         if (!parse) parse = async r => await r.json();

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -58,11 +58,7 @@ const _networkAction = (fn, ...args) => async (dispatch, getState) => {
 
     const {types, params, url, req, err, onSuccess, paginated, asCsv} = fnResult;
     let {parse} = fnResult;
-    if (asCsv) {
-        if (!parse) parse = async r => await r.blob();
-    } else {
-        if (!parse) parse = async r => await r.json();
-    }
+    if (!parse) parse = async r => await (asCsv ? r.blob : r.json)();
 
     dispatch({type: types.REQUEST, ...params});
     try {


### PR DESCRIPTION
Mentioned in the Bento meeting, this adds some additional rules to the linter to keep code consistent across the different components, and updates some parts of the codebase to match.

Changes:

* Prevents `var` from being used; see https://hackernoon.com/why-you-shouldnt-use-var-anymore-f109a58b9b70
* Enforces immutability where relevant using `const`
* Prevents use of `==` / `!=` in favour of the more type-safe `===` / `!==`; see https://codeburst.io/javascript-double-equals-vs-triple-equals-61d4ce5a121a for some weird gotchas that can occur with `==`
* Enforces a maximum line length of 120 characters (this one can be removed if seen fit; it's what was being followed by me previously but is up to personal taste)
* Prevents trailing whitespace - IDEs typically handle this automatically; it can create pointless diffs