### PR TITLE
Fixed pointer events in table while searching

### DIFF
--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -99,6 +99,11 @@ class ExplorerDatasetSearch extends Component {
 
         const numResults = (this.props.searchResults || {searchFormattedResults: []}).searchFormattedResults.length;
 
+        const tableStyle = {
+          opacity: (this.props.fetchingSearch ? 0.5 : 1),
+          pointerEvents: (this.props.fetchingSearch ? "none" : "auto")
+        };
+
         // Calculate page numbers and range
         const showingResults = numResults > 0
             ? (this.state.currentPage * this.state.pageSize) - this.state.pageSize + 1
@@ -142,7 +147,7 @@ class ExplorerDatasetSearch extends Component {
                 <SearchTracksModal searchResults={this.props.searchResults}
                                    visible={this.state.tracksModalVisible}
                                    onCancel={() => this.setState({tracksModalVisible: false})} />
-                    <div style={{opacity: (this.props.fetchingSearch ? 0.5 : 1), pointerEvents: (this.props.fetchingSearch ? "none" : "auto") }}>
+                    <div style={tableStyle}>
                         <Table bordered
                                disabled={this.props.fetchingSearch}
                                size="middle"

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -100,8 +100,8 @@ class ExplorerDatasetSearch extends Component {
         const numResults = (this.props.searchResults || {searchFormattedResults: []}).searchFormattedResults.length;
 
         const tableStyle = {
-           opacity: (this.props.fetchingSearch ? 0.5 : 1),
-           pointerEvents: (this.props.fetchingSearch ? "none" : "auto")
+            opacity: (this.props.fetchingSearch ? 0.5 : 1),
+            pointerEvents: (this.props.fetchingSearch ? "none" : "auto")
         };
 
         // Calculate page numbers and range

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -142,7 +142,7 @@ class ExplorerDatasetSearch extends Component {
                 <SearchTracksModal searchResults={this.props.searchResults}
                                    visible={this.state.tracksModalVisible}
                                    onCancel={() => this.setState({tracksModalVisible: false})} />
-                    <div style={{opacity: (this.props.fetchingSearch ? 0.5 : 1)}}>
+                    <div style={{opacity: (this.props.fetchingSearch ? 0.5 : 1), pointerEvents: (this.props.fetchingSearch ? "none" : "auto") }}>
                         <Table bordered
                                disabled={this.props.fetchingSearch}
                                size="middle"

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -100,8 +100,8 @@ class ExplorerDatasetSearch extends Component {
         const numResults = (this.props.searchResults || {searchFormattedResults: []}).searchFormattedResults.length;
 
         const tableStyle = {
-          opacity: (this.props.fetchingSearch ? 0.5 : 1),
-          pointerEvents: (this.props.fetchingSearch ? "none" : "auto")
+           opacity: (this.props.fetchingSearch ? 0.5 : 1),
+           pointerEvents: (this.props.fetchingSearch ? "none" : "auto")
         };
 
         // Calculate page numbers and range


### PR DESCRIPTION
Fixed David's comments regarding the Explorer search table: "When I submit a new search, the table is greyed out, but the links to patient records and the bottom right pagination are still clickable. They shouldn't be usable once a new search has been launched."