### PR TITLE
fixed metadata pagination

### DIFF
--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -438,7 +438,7 @@ export const fetchPhenopackets = networkAction(() => (dispatch, getState) => ({
 export const fetchExperiments = networkAction(() => (dispatch, getState) => ({
     types: FETCH_EXPERIMENTS,
     url: `${getState().services.metadataService.url}/api/experiments`,
-    base_url: `${getState().services.metadataService.url}/`,
+    baseUrl: `${getState().services.metadataService.url}/`,
     err: "Error fetching experiments metadata",
     paginated: true
 }));

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -438,6 +438,7 @@ export const fetchPhenopackets = networkAction(() => (dispatch, getState) => ({
 export const fetchExperiments = networkAction(() => (dispatch, getState) => ({
     types: FETCH_EXPERIMENTS,
     url: `${getState().services.metadataService.url}/api/experiments`,
+    base_url: `${getState().services.metadataService.url}/`,
     err: "Error fetching experiments metadata",
     paginated: true
 }));

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -18,7 +18,7 @@ export const createFlowActionTypes = name => ({
 });
 
 
-const _unpaginatedNetworkFetch = async (url, base_url, req, parse) => {
+const _unpaginatedNetworkFetch = async (url, baseUrl, req, parse) => {
     const response = await fetch(url, req);
     if (!response.ok) {
         throw `${response.status} ${response.statusText}`;
@@ -26,7 +26,7 @@ const _unpaginatedNetworkFetch = async (url, base_url, req, parse) => {
     return response.status === 204 ? null : await parse(response);
 };
 
-const _paginatedNetworkFetch = async (url, base_url, req, parse) => {
+const _paginatedNetworkFetch = async (url, baseUrl, req, parse) => {
     const results = [];
     const _fetchNext = async (pageUrl) => {
         const response = await fetch(pageUrl, req);
@@ -37,7 +37,7 @@ const _paginatedNetworkFetch = async (url, base_url, req, parse) => {
         const data = await parse(response);
         if (!data.hasOwnProperty("results")) throw "Missing results set";
         const pageResults = data.results;
-        const nextUrl = data.next ? (base_url + data.next) : null;
+        const nextUrl = data.next ? (baseUrl + data.next) : null;
         if (!(pageResults instanceof Array)) throw "Invalid results set";
         results.push(...pageResults);
         if (nextUrl) await _fetchNext(nextUrl);
@@ -54,13 +54,13 @@ const _networkAction = (fn, ...args) => async (dispatch, getState) => {
         fnResult = fnResult(dispatch, getState);
     }
 
-    const {types, params, url, base_url, req, err, onSuccess, paginated} = fnResult;
+    const {types, params, url, baseUrl, req, err, onSuccess, paginated} = fnResult;
     let {parse} = fnResult;
     if (!parse) parse = r => r.json();
 
     dispatch({type: types.REQUEST, ...params});
     try {
-        const data = await (paginated ? _paginatedNetworkFetch : _unpaginatedNetworkFetch)(url, base_url, req, parse);
+        const data = await (paginated ? _paginatedNetworkFetch : _unpaginatedNetworkFetch)(url, baseUrl, req, parse);
         dispatch({
             type: types.RECEIVE,
             ...params,


### PR DESCRIPTION
- bento-v2 compatibility
- necessary when there's a difference between a "global" base-path and a per-service base path, thus bento_web cannot fully rely on the path that is returned in the "next" value of the json response to construct a url for the next page