### PR TITLE
widen experiment pie charts

### DIFF
--- a/src/components/overview/ExperimentsSummary.js
+++ b/src/components/overview/ExperimentsSummary.js
@@ -33,7 +33,7 @@ class ExperimentsSummary2 extends Component {
             phenotypicFeaturesThresholdSliderValue: 0.01,
             chartPadding:  "1rem",
             chartHeight: 300,
-            chartAspectRatio: 1.6,
+            chartAspectRatio: 1.8,
             chartLabelPaddingTop: 3,
             chartLabelPaddingLeft: 3,
         };


### PR DESCRIPTION
widen Experiment pie charts, the labels are cropped in staging. Widths are now the same as in the Clinical Summary