### PR TITLE
reorder search fields and rename free text search

### DIFF
--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -160,7 +160,7 @@ class DiscoveryQueryBuilder extends Component {
                                       onCancel={this.handleSchemasToggle} />
 
             <Typography.Title level={3} style={{marginBottom: "1.5rem"}}>
-                Data Type Queries
+                Advanced Search
                 {addConditionsOnDataType()}
                 <Button style={{float: "right", marginRight: "1em"}}
                         onClick={this.handleSchemasToggle}><Icon type="table" /> Explore Data Types</Button>

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -110,6 +110,7 @@ class ExplorerDatasetSearch extends Component {
 
         return <>
             <Typography.Title level={4}>Explore Dataset {selectedDataset.title}</Typography.Title>
+            <SearchAllRecords datasetID={this.props.match.params.dataset}/>
             <DiscoveryQueryBuilder isInternal={true}
                                    dataTypeForms={this.props.dataTypeForms}
                                    onSubmit={this.resetPageNumber}
@@ -117,7 +118,6 @@ class ExplorerDatasetSearch extends Component {
                                    addDataTypeQueryForm={this.props.addDataTypeQueryForm}
                                    updateDataTypeQueryForm={this.props.updateDataTypeQueryForm}
                                    removeDataTypeQueryForm={this.props.removeDataTypeQueryForm} />
-            <SearchAllRecords datasetID={this.props.match.params.dataset}/>
             {this.props.searchResults ? <>
                 <Typography.Title level={4}>
                     Showing results {showingResults}-{Math.min(this.state.currentPage * this.state.pageSize,

--- a/src/components/explorer/SearchAllRecords.js
+++ b/src/components/explorer/SearchAllRecords.js
@@ -21,7 +21,7 @@ class SearchAllRecords extends Component {
         return (
       <Card style={{ marginBottom: "1.5em" }}>
         <Typography.Title level={3} style={{ marginBottom: "1.5rem" }}>
-          Search All Fields
+          Text Search
         </Typography.Title>
         <Search
           placeholder="Search"


### PR DESCRIPTION
- rename "Data Type Queries" to "Advanced Search"
- rename "Search All Fields" to "Text Search"
- move Text Search above Advanced Search
- replaces pr #124