### PR TITLE
Gordon/biosamples experiments

### DIFF
--- a/src/components/explorer/ExplorerIndividualContent.js
+++ b/src/components/explorer/ExplorerIndividualContent.js
@@ -17,6 +17,7 @@ import SitePageHeader from "../SitePageHeader";
 import IndividualOverview from "./IndividualOverview";
 import IndividualPhenotypicFeatures from "./IndividualPhenotypicFeatures";
 import IndividualBiosamples from "./IndividualBiosamples";
+import IndividualExperiments from "./IndividualExperiments";
 import IndividualDiseases from "./IndividualDiseases";
 import IndividualMetadata from "./IndividualMetadata";
 import IndividualVariants from "./IndividualVariants";
@@ -73,6 +74,7 @@ class ExplorerIndividualContent extends Component {
         const overviewUrl = withURLPrefix(individualID, "overview");
         const pfeaturesUrl = withURLPrefix(individualID, "phenotypicfeatures");
         const biosamplesUrl = withURLPrefix(individualID, "biosamples");
+        const experimentsUrl = withURLPrefix(individualID, "experiments");
         const variantsUrl = withURLPrefix(individualID, "variants");
         const genesUrl = withURLPrefix(individualID, "genes");
         const diseasesUrl = withURLPrefix(individualID, "diseases");
@@ -80,7 +82,8 @@ class ExplorerIndividualContent extends Component {
         const individualMenu = [
             {url: overviewUrl, style: {marginLeft: "4px"}, text: "Overview",},
             {url: pfeaturesUrl, text: "Phenotypic Features",},
-            {url: biosamplesUrl, text: "Biosamples & Experiments",},
+            {url: biosamplesUrl, text: "Biosamples",},
+            {url: experimentsUrl, text: "Experiments",},
             {url: variantsUrl, text: "Variants",},
             {url: genesUrl, text: "Genes",},
             {url: diseasesUrl, text: "Diseases",},
@@ -112,6 +115,9 @@ class ExplorerIndividualContent extends Component {
                         </Route>
                         <Route path={biosamplesUrl.replace(":", "\\:")}>
                             <IndividualBiosamples individual={individual} />
+                        </Route>
+                        <Route path={experimentsUrl.replace(":", "\\:")}>
+                            <IndividualExperiments individual={individual} />
                         </Route>
                         <Route path={variantsUrl.replace(":", "\\:")}>
                             <IndividualVariants individual={individual} />

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -21,7 +21,7 @@ class IndividualBiosamples extends Component {
         const experimentsData = biosamplesData.flatMap((b) => b?.experiments ?? []);
 
         return (
-            <>
+            <div style={{display: "inline-block"}}>
         {biosamplesData.map((b) => (
           <Descriptions
             title={`Biosample ${b.id}`}
@@ -62,7 +62,7 @@ class IndividualBiosamples extends Component {
             <Descriptions.Item label="Available Experiments">experiments with links todo</Descriptions.Item>
           </Descriptions>
         ))}
-            </>
+            </div>
         );
     }
 }

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -13,11 +13,7 @@ class IndividualBiosamples extends Component {
 
     constructor(props) {
         super(props);
-
         this.state = {};
-
-    // Ensure user is at the top of the page after transition
-        window.scrollTo(0, 0);
     }
 
     render() {

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -21,7 +21,7 @@ class IndividualBiosamples extends Component {
         const experimentsData = biosamplesData.flatMap((b) => b?.experiments ?? []);
 
         return (
-            <div style={{display: "inline-block"}}>
+            <div className="biosamples-descriptions" style={{display: "inline-block"}}>
         {biosamplesData.map((b) => (
           <Descriptions
             title={`Biosample ${b.id}`}

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -4,19 +4,18 @@ import { connect } from "react-redux";
 import { Table } from "antd";
 import { Descriptions } from "antd";
 import { withRouter } from "react-router-dom";
-import ReactJson from "react-json-view";
 import { EM_DASH } from "../../constants";
 import { renderOntologyTerm } from "./ontologies";
 import { individualPropTypesShape } from "../../propTypes";
-
 import { performDownloadFromDrsIfPossible } from "../../modules/drs/actions";
-
 import PropTypes from "prop-types";
+import JsonView from "./JsonView";
 
 // TODO: Only show biosamples from the relevant dataset, if specified;
 //  highlight those found in search results, if specified
 
 class IndividualBiosamples extends Component {
+
   BIOSAMPLE_COLUMNS = [
       {
           title: "ID",
@@ -63,12 +62,13 @@ class IndividualBiosamples extends Component {
           key: "extra_properties",
           render: (_, individual) =>
               (individual ?? {}).hasOwnProperty("extra_properties") &&
-              Object.keys(individual.extra_properties).length
-                  ? (
-                      <div>
-                          <pre>{JSON.stringify(individual.extra_properties, null, 2)}</pre>
-                      </div>
-                  ) : EM_DASH,
+        Object.keys(individual.extra_properties).length ? (
+          <div>
+            <JsonView inputJson={individual.extra_properties} />
+          </div>
+                  ) : (
+                      EM_DASH
+                  ),
       },
       {
           title: "Download",
@@ -121,18 +121,9 @@ class IndividualBiosamples extends Component {
           <Descriptions.Item label="Molecule Ontology">
             {(e ?? {}).hasOwnProperty("molecule_ontology") && e.molecule_ontology.length ? (
               <div>
-                <pre>
-                  {e.molecule_ontology.map((m) => (
-                    <ReactJson
-                      src={m}
-                      displayDataTypes={false}
-                      name={false}
-                      collapsed={1}
-                      enableClipboard={false}
-                      key={m.id}
-                    />
+                  {e.molecule_ontology.map((m, i) => (
+                    <JsonView inputJson={m} key={i} />
                   ))}
-                </pre>
               </div>
             ) : (
                 EM_DASH
@@ -141,69 +132,37 @@ class IndividualBiosamples extends Component {
           <Descriptions.Item label="Extration Protocol">
             {e?.extraction_protocol || EM_DASH}
           </Descriptions.Item>
-          <Descriptions.Item label="Instrument">{
-            ((e ?? {}).hasOwnProperty("instrument") && Object.keys(e.instrument).length)
-                ?  <div>
-                    <pre>
-                          <ReactJson src={e.instrument}
-                                     displayDataTypes={false}
-                                     name={false}
-                                     collapsed={1}
-                                     enableClipboard={false}
-                          />
-                    </pre>
-                   </div>
-                : EM_DASH
-        }</Descriptions.Item>
+          <Descriptions.Item label="Instrument">
+            {(e ?? {}).hasOwnProperty("instrument") && Object.keys(e.instrument).length ? (
+                  <JsonView inputJson={e.instrument} />
+            ) : (
+                EM_DASH
+            )}
+          </Descriptions.Item>
           <Descriptions.Item label="Experiment Ontology">
             {(e ?? {}).hasOwnProperty("experiment_ontology") && e.experiment_ontology.length ? (
               <div>
-                <pre>
-                  {e.experiment_ontology.map((m) => (
-                    <ReactJson
-                      src={m}
-                      displayDataTypes={false}
-                      name={false}
-                      collapsed={1}
-                      enableClipboard={false}
-                      key={m.id}
-                    />
+                  {e.experiment_ontology.map((m, i) => (
+                    <JsonView inputJson={m} key={i}/>
                   ))}
-                </pre>
               </div>
             ) : (
                 EM_DASH
             )}
           </Descriptions.Item>
-          <Descriptions.Item label="Extra Properties">{
-            ((e ?? {}).hasOwnProperty("extra_properties") && Object.keys(e.extra_properties).length)
-                ?  <div>
-                    <pre>
-                          <ReactJson src={e.extra_properties}
-                                     displayDataTypes={false}
-                                     name={false}
-                                     collapsed={1}
-                                     enableClipboard={false}
-                          />
-                    </pre>
-                   </div>
-                : EM_DASH
-        }</Descriptions.Item>
+          <Descriptions.Item label="Extra Properties">
+            {(e ?? {}).hasOwnProperty("extra_properties") && Object.keys(e.extra_properties).length ? (
+                <JsonView inputJson={e.extra_properties} />
+            ) : (
+                EM_DASH
+            )}
+          </Descriptions.Item>
           <Descriptions.Item label="Experiment Results">
             {(e ?? {}).hasOwnProperty("experiment_results") && e.experiment_results.length ? (
               <div>
-                <pre>
-                  {e.experiment_results.map((m) => (
-                    <ReactJson
-                      src={m}
-                      displayDataTypes={false}
-                      name={false}
-                      collapsed={1}
-                      enableClipboard={false}
-                      key={m.id}
-                    />
+                  {e.experiment_results.map((m, i) => (
+                    <JsonView inputJson={m} key={i}/>
                   ))}
-                </pre>
               </div>
             ) : (
                 EM_DASH

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -3,7 +3,6 @@ import { Descriptions } from "antd";
 import { EM_DASH } from "../../constants";
 import { renderOntologyTerm } from "./ontologies";
 import { individualPropTypesShape } from "../../propTypes";
-import PropTypes from "prop-types";
 import JsonView from "./JsonView";
 
 // TODO: Only show biosamples from the relevant dataset, if specified;
@@ -18,7 +17,7 @@ class IndividualBiosamples extends Component {
 
     render() {
         const biosamplesData = (this.props.individual?.phenopackets ?? []).flatMap((p) => p.biosamples);
-        const experimentsData = biosamplesData.flatMap((b) => b?.experiments ?? []);
+        // const experimentsData = biosamplesData.flatMap((b) => b?.experiments ?? []);
 
         return (
             <div className="biosamples-descriptions" style={{display: "inline-block"}}>
@@ -49,7 +48,8 @@ class IndividualBiosamples extends Component {
               {b.individual_age_at_collection
                   ? b.individual_age_at_collection.hasOwnProperty("age")
                       ? b.individual_age_at_collection.age
-                      : `Between ${b.individual_age_at_collection.start.age} and ${b.individual_age_at_collection.end.age}`
+                      : `Between ${b.individual_age_at_collection.start.age}` +
+                      `and ${b.individual_age_at_collection.end.age}`
                   : EM_DASH}
             </Descriptions.Item>
             <Descriptions.Item label="Extra Properties">

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -69,7 +69,6 @@ class IndividualBiosamples extends Component {
 
 IndividualBiosamples.propTypes = {
     individual: individualPropTypesShape,
-    performDownloadFromDrsIfPossible: PropTypes.func.isRequired,
 };
 
 export default IndividualBiosamples;

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -1,13 +1,8 @@
 import React, { Component } from "react";
-import { connect } from "react-redux";
-
-import { Table } from "antd";
 import { Descriptions } from "antd";
-import { withRouter } from "react-router-dom";
 import { EM_DASH } from "../../constants";
 import { renderOntologyTerm } from "./ontologies";
 import { individualPropTypesShape } from "../../propTypes";
-import { performDownloadFromDrsIfPossible } from "../../modules/drs/actions";
 import PropTypes from "prop-types";
 import JsonView from "./JsonView";
 
@@ -16,181 +11,64 @@ import JsonView from "./JsonView";
 
 class IndividualBiosamples extends Component {
 
-  BIOSAMPLE_COLUMNS = [
-      {
-          title: "ID",
-          key: "id",
-          render: (_, individual) => individual.id,
-          sorter: (a, b) => a.id.localeCompare(b.id),
-          defaultSortOrder: "ascend",
-      },
-      {
-          title: "Sampled Tissue",
-          key: "sampled_tissue",
-          render: (_, individual) => renderOntologyTerm(individual.sampled_tissue),
-      },
-      {
-          title: "Procedure",
-          key: "procedure",
-          render: (_, individual) => (
-              <>
-          <strong>Code:</strong> {renderOntologyTerm(individual.procedure.code)}
-          <br />
-          {individual.procedure.body_site ? (
-              <>
-              <br />
-              <strong>Body Site:</strong> {renderOntologyTerm(individual.procedure.body_site)}
-              </>
-          ) : null}
-              </>
-          ),
-      },
-      {
-          title: "Ind. Age at Collection",
-          key: "individual_age_at_collection",
-          render: (_, individual) => {
-              const age = individual.individual_age_at_collection;
-              return age
-                  ? age.hasOwnProperty("age")
-                      ? age.age
-                      : `Between ${age.start.age} and ${age.end.age}`
-                  : EM_DASH;
-          },
-      },
-      {
-          title: "Extra Properties",
-          key: "extra_properties",
-          render: (_, individual) =>
-              (individual ?? {}).hasOwnProperty("extra_properties") &&
-        Object.keys(individual.extra_properties).length ? (
-          <div>
-            <JsonView inputJson={individual.extra_properties} />
-          </div>
-                  ) : (
-                      EM_DASH
-                  ),
-      },
-      {
-          title: "Download",
-          key: "extra_properties",
-          render: (_, individual) =>
-              (individual ?? {}).hasOwnProperty("experiments") && Object.keys(individual.experiments).length
-                  ? individual.experiments.flatMap((exp) =>
-                      (exp ?? {}).hasOwnProperty("experiment_results") && Object.keys(exp.experiment_results).length
-                          ? exp.experiment_results
-                              .flatMap((result) =>
-                                  (result ?? {}).hasOwnProperty("filename") && Object.keys(result.filename).length
-                                      ? result.filename
-                                      : EM_DASH
-                              )
-                              .filter(isKindOfVcf)
-                              .flatMap((name) => (
-                      <div>
-                        <a onClick={async () => this.props.performDownloadFromDrsIfPossible(name)}>{name}</a>
-                      </div>
-                              ))
-                          : EM_DASH
-                  )
-                  : EM_DASH,
-      },
-  ];
+    constructor(props) {
+        super(props);
 
-  constructor(props) {
-      super(props);
-
-      this.state = {};
+        this.state = {};
 
     // Ensure user is at the top of the page after transition
-      window.scrollTo(0, 0);
-  }
+        window.scrollTo(0, 0);
+    }
 
-  render() {
-      const biosamplesData = (this.props.individual?.phenopackets ?? []).flatMap((p) => p.biosamples);
-      const experimentsData = biosamplesData.flatMap((b) => b?.experiments ?? []);
+    render() {
+        const biosamplesData = (this.props.individual?.phenopackets ?? []).flatMap((p) => p.biosamples);
+        const experimentsData = biosamplesData.flatMap((b) => b?.experiments ?? []);
 
-      const experimentLayouts = (experimentsData ?? []).flatMap((e) => {
-          return (
-        <Descriptions layout="vertical" bordered={true} size="middle">
-          <Descriptions.Item label="Experiment Type">{e?.experiment_type || EM_DASH}</Descriptions.Item>
-          <Descriptions.Item label="Study Type">{e?.study_type || EM_DASH}</Descriptions.Item>
-          <Descriptions.Item label="Library Layout">{e?.library_layout || EM_DASH}</Descriptions.Item>
-          <Descriptions.Item label="Library Selection">{e?.library_selection || EM_DASH}</Descriptions.Item>
-          <Descriptions.Item label="Library Source">{e?.library_source || EM_DASH}</Descriptions.Item>
-          <Descriptions.Item label="Library Strategy">{e?.library_strategy || EM_DASH}</Descriptions.Item>
-          <Descriptions.Item label="Molecule">{e?.molecule || EM_DASH}</Descriptions.Item>
-          <Descriptions.Item label="Molecule Ontology">
-            {(e ?? {}).hasOwnProperty("molecule_ontology") && e.molecule_ontology.length ? (
+        return (
+            <>
+        {biosamplesData.map((b) => (
+          <Descriptions
+            title={`Biosample ${b.id}`}
+            layout="horizontal"
+            bordered={true}
+            column={1}
+            size="small"
+            key={b.id}
+          >
+            <Descriptions.Item label="ID">{b.id}</Descriptions.Item>
+            <Descriptions.Item label="Sampled Tissue">
+              {renderOntologyTerm(b.sampled_tissue)}
+            </Descriptions.Item>
+            <Descriptions.Item label="Procedure">
               <div>
-                  {e.molecule_ontology.map((m, i) => (
-                    <JsonView inputJson={m} key={i} />
-                  ))}
+                <strong>Code:</strong> {renderOntologyTerm(b.procedure.code)}
+                {b.procedure.body_site ? (
+                  <div>
+                    <strong>Body Site:</strong> {renderOntologyTerm(b.procedure.body_site)}
+                  </div>
+                ) : null}
               </div>
-            ) : (
-                EM_DASH
-            )}
-          </Descriptions.Item>
-          <Descriptions.Item label="Extration Protocol">
-            {e?.extraction_protocol || EM_DASH}
-          </Descriptions.Item>
-          <Descriptions.Item label="Instrument">
-            {(e ?? {}).hasOwnProperty("instrument") && Object.keys(e.instrument).length ? (
-                  <JsonView inputJson={e.instrument} />
-            ) : (
-                EM_DASH
-            )}
-          </Descriptions.Item>
-          <Descriptions.Item label="Experiment Ontology">
-            {(e ?? {}).hasOwnProperty("experiment_ontology") && e.experiment_ontology.length ? (
-              <div>
-                  {e.experiment_ontology.map((m, i) => (
-                    <JsonView inputJson={m} key={i}/>
-                  ))}
-              </div>
-            ) : (
-                EM_DASH
-            )}
-          </Descriptions.Item>
-          <Descriptions.Item label="Extra Properties">
-            {(e ?? {}).hasOwnProperty("extra_properties") && Object.keys(e.extra_properties).length ? (
-                <JsonView inputJson={e.extra_properties} />
-            ) : (
-                EM_DASH
-            )}
-          </Descriptions.Item>
-          <Descriptions.Item label="Experiment Results">
-            {(e ?? {}).hasOwnProperty("experiment_results") && e.experiment_results.length ? (
-              <div>
-                  {e.experiment_results.map((m, i) => (
-                    <JsonView inputJson={m} key={i}/>
-                  ))}
-              </div>
-            ) : (
-                EM_DASH
-            )}
-          </Descriptions.Item>
-        </Descriptions>
-          );
-      });
-
-      return (
-          <>
-        <Table
-          bordered
-          size="middle"
-          pagination={{ pageSize: 25 }}
-          columns={this.BIOSAMPLE_COLUMNS}
-          rowKey="id"
-          dataSource={biosamplesData}
-        />
-
-        {experimentLayouts}
-          </>
-      );
-  }
-}
-
-function isKindOfVcf(filename) {
-    return filename.toLowerCase().includes(".vcf");
+            </Descriptions.Item>
+            <Descriptions.Item label="Ind. Age At Collection">
+              {b.individual_age_at_collection
+                  ? b.individual_age_at_collection.hasOwnProperty("age")
+                      ? b.individual_age_at_collection.age
+                      : `Between ${b.individual_age_at_collection.start.age} and ${b.individual_age_at_collection.end.age}`
+                  : EM_DASH}
+            </Descriptions.Item>
+            <Descriptions.Item label="Extra Properties">
+              {b.hasOwnProperty("extra_properties") && Object.keys(b.extra_properties).length ? (
+                <JsonView inputJson={b.extra_properties} />
+              ) : (
+                  EM_DASH
+              )}
+            </Descriptions.Item>
+            <Descriptions.Item label="Available Experiments">experiments with links todo</Descriptions.Item>
+          </Descriptions>
+        ))}
+            </>
+        );
+    }
 }
 
 IndividualBiosamples.propTypes = {
@@ -198,6 +76,4 @@ IndividualBiosamples.propTypes = {
     performDownloadFromDrsIfPossible: PropTypes.func.isRequired,
 };
 
-export default withRouter(connect(null, {
-    performDownloadFromDrsIfPossible
-})(IndividualBiosamples));
+export default IndividualBiosamples;

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -1,9 +1,12 @@
 import React, { Component } from "react";
-import { Descriptions, Popover, Table, Typography } from "antd";
+import { Descriptions, Icon, Popover, Table, Typography } from "antd";
 import { BENTO_BLUE, EM_DASH } from "../../constants";
 import { individualPropTypesShape } from "../../propTypes";
 import { performDownloadFromDrsIfPossible } from "../../modules/drs/actions";
 import JsonView from "./JsonView";
+import { withRouter } from "react-router-dom";
+import {connect} from "react-redux";
+import PropTypes from "prop-types";
 
 class IndividualExperiments extends Component {
     constructor(props) {
@@ -41,10 +44,11 @@ class IndividualExperiments extends Component {
             {
                 title: "Download",
                 key: "download",
+                align: "center",
                 render: (_, result) =>
                     isDownloadable(result) ? (
             <div>
-              <a onClick={async () => performDownloadFromDrsIfPossible(result.filename)}>download</a>
+              <a onClick={async () => this.props.performDownloadFromDrsIfPossible(result.filename)}><Icon type={"cloud-download"} /></a>
             </div>
                     ) : (
                         EM_DASH
@@ -154,7 +158,7 @@ class IndividualExperiments extends Component {
                     </Descriptions>
                   </Descriptions.Item>
                 </Descriptions>
-                <Descriptions layout="vertical" bordered={true} column={1} size="small" key={e.id}>
+                <Descriptions layout="vertical" bordered={true} column={1} size="small" >
                   <Descriptions.Item>
                     <Descriptions layout="horizontal" bordered={true} column={1} size="small">
                       <Descriptions.Item label="Experiment Type">{e.experiment_type}</Descriptions.Item>
@@ -208,6 +212,10 @@ function isDownloadable(result) {
 
 IndividualExperiments.propTypes = {
     individual: individualPropTypesShape,
+    performDownloadFromDrsIfPossible: PropTypes.func.isRequired,
 };
 
-export default IndividualExperiments;
+export default withRouter(connect(null, {
+    performDownloadFromDrsIfPossible
+})(IndividualExperiments));
+

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -54,9 +54,36 @@ class IndividualExperiments extends Component {
                 title: "Other Details",
                 key: "other_details",
                 render: (_, result) => (
-          <Popover placement="leftTop" title={"content title"} content={"content content"} trigger="click">
-            Other Details
-          </Popover>
+              <Popover
+                placement="leftTop"
+                title={`Experiment Results: ${result.file_format}`}
+                content={
+                  <div className="other-details">
+                <Descriptions
+                  layout="horizontal"
+                  bordered={true}
+                  colon={false}
+                  column={1}
+                  size="small"
+                >
+                  <Descriptions.Item label="id">{result.id}</Descriptions.Item>
+                  <Descriptions.Item label="identifier">{result.identifier}</Descriptions.Item>
+                  <Descriptions.Item label="description">{result.description}</Descriptions.Item>
+                  <Descriptions.Item label="filename">{result.filename}</Descriptions.Item>
+                  <Descriptions.Item label="file format">{result.file_format}</Descriptions.Item>
+                  <Descriptions.Item label="data output type">{result.data_output_type}</Descriptions.Item>
+                  <Descriptions.Item label="usage">{result.usage}</Descriptions.Item>
+                  <Descriptions.Item label="creation date">{result.creation_date}</Descriptions.Item>
+                  <Descriptions.Item label="created by">{result.created_by}</Descriptions.Item>
+                  <Descriptions.Item label="created">{result.created}</Descriptions.Item>
+                  <Descriptions.Item label="updated">{result.updated}</Descriptions.Item>
+                  </Descriptions>
+                  </div>
+                  }
+                trigger="click"
+              >
+               <p className="other-details-click"> click here </p>
+              </Popover>
                 ),
             },
         ];

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { Descriptions, Popover, Table, Typography } from "antd";
-import { EM_DASH } from "../../constants";
+import { BENTO_BLUE, EM_DASH } from "../../constants";
 import { individualPropTypesShape } from "../../propTypes";
 import { performDownloadFromDrsIfPossible } from "../../modules/drs/actions";
 import JsonView from "./JsonView";
@@ -15,7 +15,7 @@ class IndividualExperiments extends Component {
         const biosamplesData = (this.props.individual?.phenopackets ?? []).flatMap((p) => p.biosamples);
         const experimentsData = biosamplesData.flatMap((b) => b?.experiments ?? []);
 
-        console.log({ experimentsData: experimentsData });
+        const titleStyle = { fontSize: "16px", fontWeight: "bold", color: BENTO_BLUE };
 
         const EXPERIMENT_RESULTS_COLUMNS = [
             {
@@ -65,11 +65,14 @@ class IndividualExperiments extends Component {
             <>
         {experimentsData.map((e) => (
           <div key={e.id}>
-            <Typography.Title level={4}>
+            <div className="experiment-titles">
+            <Typography.Text
+              style={titleStyle}
+            >
               {`${e.experiment_type} (Biosample ${e.biosample})`}{" "}
-            </Typography.Title>
-            <div style={{ display: "flex" }}>
-              <div>
+            </Typography.Text>
+            </div>
+            <div className="experimentSummary">
                 <Descriptions
                   layout="vertical"
                   bordered={true}
@@ -93,7 +96,6 @@ class IndividualExperiments extends Component {
                       </Descriptions>
                     ))}
                   </Descriptions.Item>
-
                   <Descriptions.Item>
                     {e.experiment_ontology.map((eo) => (
                       <Descriptions
@@ -125,40 +127,42 @@ class IndividualExperiments extends Component {
                     </Descriptions>
                   </Descriptions.Item>
                 </Descriptions>
-              </div>
-              <Descriptions layout="vertical" bordered={true} column={1} size="small" key={e.id}>
-                <Descriptions.Item>
-                  <Descriptions layout="horizontal" bordered={true} column={1} size="small">
-                    <Descriptions.Item label="Experiment Type">{e.experiment_type}</Descriptions.Item>
-                    <Descriptions.Item label="Study Type">{e.study_type}</Descriptions.Item>
-                    <Descriptions.Item label="Extraction Protocol">{e.extraction_protocol}</Descriptions.Item>
-                    <Descriptions.Item label="Library Layout">{e.library_layout}</Descriptions.Item>
-                    <Descriptions.Item label="Library Selection">{e.library_selection}</Descriptions.Item>
-                    <Descriptions.Item label="Library Source">{e.library_source}</Descriptions.Item>
-                    <Descriptions.Item label="Library Strategy">{e.library_strategy}</Descriptions.Item>
-                  </Descriptions>
-                </Descriptions.Item>
-
-                <Descriptions.Item>
-                  <Descriptions
-                    title="Extra Properties"
-                    layout="horizontal"
-                    bordered={true}
-                    column={1}
-                    size="small"
-                  >
-                    <Descriptions.Item>
-                      <JsonView inputJson={e.extra_properties} />
-                    </Descriptions.Item>
-                  </Descriptions>
-                </Descriptions.Item>
-              </Descriptions>
+                <Descriptions layout="vertical" bordered={true} column={1} size="small" key={e.id}>
+                  <Descriptions.Item>
+                    <Descriptions layout="horizontal" bordered={true} column={1} size="small">
+                      <Descriptions.Item label="Experiment Type">{e.experiment_type}</Descriptions.Item>
+                      <Descriptions.Item label="Study Type">{e.study_type}</Descriptions.Item>
+                      <Descriptions.Item label="Extraction Protocol">
+                        {e.extraction_protocol}
+                      </Descriptions.Item>
+                      <Descriptions.Item label="Library Layout">{e.library_layout}</Descriptions.Item>
+                      <Descriptions.Item label="Library Selection">{e.library_selection}</Descriptions.Item>
+                      <Descriptions.Item label="Library Source">{e.library_source}</Descriptions.Item>
+                      <Descriptions.Item label="Library Strategy">{e.library_strategy}</Descriptions.Item>
+                    </Descriptions>
+                  </Descriptions.Item>
+                  <Descriptions.Item>
+                    <Descriptions
+                      title="Extra Properties"
+                      layout="horizontal"
+                      bordered={true}
+                      column={1}
+                      size="small"
+                    >
+                      <Descriptions.Item>
+                        <JsonView inputJson={e.extra_properties} />
+                      </Descriptions.Item>
+                    </Descriptions>
+                  </Descriptions.Item>
+                </Descriptions>
             </div>
-            <Typography.Title level={4}>Results </Typography.Title>
+            <div className="experiment-titles">
+            <Typography.Text style={titleStyle} level={4}> { `${e.experiment_type} - Results` }</Typography.Text>
+            </div>
             <Table
               bordered
               size="small"
-              pagination={{ pageSize: 25 }}
+              pagination={false}
               columns={EXPERIMENT_RESULTS_COLUMNS}
               rowKey="filename"
               dataSource={e.experiment_results}

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -1,0 +1,182 @@
+import React, { Component } from "react";
+import { Descriptions, Popover, Table, Typography } from "antd";
+import { EM_DASH } from "../../constants";
+import { individualPropTypesShape } from "../../propTypes";
+import { performDownloadFromDrsIfPossible } from "../../modules/drs/actions";
+import JsonView from "./JsonView";
+
+class IndividualExperiments extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        const biosamplesData = (this.props.individual?.phenopackets ?? []).flatMap((p) => p.biosamples);
+        const experimentsData = biosamplesData.flatMap((b) => b?.experiments ?? []);
+
+        console.log({ experimentsData: experimentsData });
+
+        const EXPERIMENT_RESULTS_COLUMNS = [
+            {
+                title: "Result File",
+                key: "result_file",
+                render: (_, result) => result.file_format,
+            },
+            {
+                title: "Creation Date",
+                key: "creation_date",
+                render: (_, result) => result.creation_date,
+            },
+            {
+                title: "Description",
+                key: "description",
+                render: (_, result) => result.description,
+            },
+            {
+                title: "Filename",
+                key: "filename",
+                render: (_, result) => result.filename,
+            },
+            {
+                title: "Download",
+                key: "download",
+                render: (_, result) =>
+                    isDownloadable(result) ? (
+            <div>
+              <a onClick={async () => performDownloadFromDrsIfPossible(result.filename)}>download</a>
+            </div>
+                    ) : (
+                        EM_DASH
+                    ),
+            },
+            {
+                title: "Other Details",
+                key: "other_details",
+                render: (_, result) => (
+          <Popover placement="leftTop" title={"content title"} content={"content content"} trigger="click">
+            Other Details
+          </Popover>
+                ),
+            },
+        ];
+
+        return (
+            <>
+        {experimentsData.map((e) => (
+          <div key={e.id}>
+            <Typography.Title level={4}>
+              {`${e.experiment_type} (Biosample ${e.biosample})`}{" "}
+            </Typography.Title>
+            <div style={{ display: "flex" }}>
+              <div>
+                <Descriptions
+                  layout="vertical"
+                  bordered={true}
+                  colon={false}
+                  column={1}
+                  size="small"
+                  key={e.id}
+                >
+                  <Descriptions.Item>
+                    {e.molecule_ontology.map((mo) => (
+                      <Descriptions
+                        title="Molecule Ontology"
+                        layout="horizontal"
+                        bordered={true}
+                        column={1}
+                        size="small"
+                        key={mo.id}
+                      >
+                        <Descriptions.Item label="id">{mo.id}</Descriptions.Item>
+                        <Descriptions.Item label="label">{mo.label}</Descriptions.Item>
+                      </Descriptions>
+                    ))}
+                  </Descriptions.Item>
+
+                  <Descriptions.Item>
+                    {e.experiment_ontology.map((eo) => (
+                      <Descriptions
+                        title="Experiment Ontology"
+                        layout="horizontal"
+                        bordered={true}
+                        column={1}
+                        size="small"
+                        key={eo.id}
+                      >
+                        <Descriptions.Item label="id">{eo.id}</Descriptions.Item>
+                        <Descriptions.Item label="label">{eo.label}</Descriptions.Item>
+                      </Descriptions>
+                    ))}
+                  </Descriptions.Item>
+                  <Descriptions.Item>
+                    <Descriptions
+                      title="Instrument"
+                      layout="horizontal"
+                      bordered={true}
+                      column={1}
+                      size="small"
+                    >
+                      <Descriptions.Item label="id">{e.instrument.id}</Descriptions.Item>
+                      <Descriptions.Item label="identifier">{e.instrument.identifier}</Descriptions.Item>
+                      <Descriptions.Item label="platform">{e.instrument.platform}</Descriptions.Item>
+                      <Descriptions.Item label="created">{e.instrument.created}</Descriptions.Item>
+                      <Descriptions.Item label="updated">{e.instrument.updated}</Descriptions.Item>
+                    </Descriptions>
+                  </Descriptions.Item>
+                </Descriptions>
+              </div>
+              <Descriptions layout="vertical" bordered={true} column={1} size="small" key={e.id}>
+                <Descriptions.Item>
+                  <Descriptions layout="horizontal" bordered={true} column={1} size="small">
+                    <Descriptions.Item label="Experiment Type">{e.experiment_type}</Descriptions.Item>
+                    <Descriptions.Item label="Study Type">{e.study_type}</Descriptions.Item>
+                    <Descriptions.Item label="Extraction Protocol">{e.extraction_protocol}</Descriptions.Item>
+                    <Descriptions.Item label="Library Layout">{e.library_layout}</Descriptions.Item>
+                    <Descriptions.Item label="Library Selection">{e.library_selection}</Descriptions.Item>
+                    <Descriptions.Item label="Library Source">{e.library_source}</Descriptions.Item>
+                    <Descriptions.Item label="Library Strategy">{e.library_strategy}</Descriptions.Item>
+                  </Descriptions>
+                </Descriptions.Item>
+
+                <Descriptions.Item>
+                  <Descriptions
+                    title="Extra Properties"
+                    layout="horizontal"
+                    bordered={true}
+                    column={1}
+                    size="small"
+                  >
+                    <Descriptions.Item>
+                      <JsonView inputJson={e.extra_properties} />
+                    </Descriptions.Item>
+                  </Descriptions>
+                </Descriptions.Item>
+              </Descriptions>
+            </div>
+            <Typography.Title level={4}>Results </Typography.Title>
+            <Table
+              bordered
+              size="small"
+              pagination={{ pageSize: 25 }}
+              columns={EXPERIMENT_RESULTS_COLUMNS}
+              rowKey="filename"
+              dataSource={e.experiment_results}
+            />
+          </div>
+        ))}
+            </>
+        );
+    }
+}
+
+// expand here accordingly
+function isDownloadable(result) {
+    return result.file_format.toLowerCase() === "vcf" || result.filename.toLowerCase().includes(".vcf");
+}
+
+IndividualExperiments.propTypes = {
+    individual: individualPropTypesShape,
+};
+
+export default IndividualExperiments;

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -48,7 +48,9 @@ class IndividualExperiments extends Component {
                 render: (_, result) =>
                     isDownloadable(result) ? (
             <div>
-              <a onClick={async () => this.props.performDownloadFromDrsIfPossible(result.filename)}><Icon type={"cloud-download"} /></a>
+              <a onClick={async () => this.props.performDownloadFromDrsIfPossible(result.filename)}>
+                <Icon type={"cloud-download"} />
+              </a>
             </div>
                     ) : (
                         EM_DASH

--- a/src/components/explorer/JsonView.js
+++ b/src/components/explorer/JsonView.js
@@ -1,0 +1,64 @@
+import React from "react";
+import ReactJson from "react-json-view";
+import PropTypes from "prop-types";
+
+const background = "white";
+const keyText = "#252525";
+const valueText = "#595959";
+const itemCountText = "#b2b2b2";
+const expandIcon = "gray";
+// const bentoMenuBlue = "#1890ff"
+
+// partial guide to theme colours:
+// 00 background
+// 02 vertical indent line
+// 04 item count
+// 07 keys
+// 09 string values
+// 0B float values
+// 0C array indexes
+// 0D expand icon when uncollapsed
+// 0E expand icon when collapsed
+// 0F int values
+// other values unused in our case (all marked "black")
+
+const theme = {
+    base00: background,
+    base01: "black",
+    base02: background,
+    base03: "black",
+    base04: itemCountText,
+    base05: "black",
+    base06: "black",
+    base07: keyText,
+    base08: "black",
+    base09: valueText,
+    base0A: "black",
+    base0B: valueText,
+    base0C: keyText,
+    base0D: expandIcon,
+    base0E: expandIcon,
+    base0F: valueText,
+};
+
+const JsonView = ({ inputJson }) => {
+    return (
+    <ReactJson
+      src={inputJson}
+      displayDataTypes={false}
+      displayObjectSize={true}
+      enableClipboard={false}
+      indentWidth={2}
+      name={false}
+      collapsed={1}
+      quotesOnKeys={false}
+      theme={theme}
+    />
+    );
+};
+
+JsonView.propTypes = {
+    inputJson: PropTypes.object,
+};
+
+export default JsonView;

--- a/src/components/explorer/explorer.css
+++ b/src/components/explorer/explorer.css
@@ -3,9 +3,39 @@
 .ant-spin-nested-loading > div:first-child,
 .ant-spin-spinning,
 .ant-spin-container {
-    display: inline !important;
+  display: inline !important;
 }
 
 .ant-table-row.ant-table-row-level-0 {
-    vertical-align: top !important;
+  vertical-align: top !important;
+}
+
+/* styling for Biosamples and Experiments tabs */
+
+.ant-descriptions-item-no-label {
+  display: none;
+}
+
+.ant-descriptions-item-label {
+  width: 200px;
+}
+
+.ant-descriptions-title {
+  margin: 0;
+  padding-left: 15px;
+  background-color: #fafafa;
+}
+
+.ant-descriptions-view {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.ant-descriptions-title {
+  border: 1px solid #e8e8e8;
+  border-bottom: 0;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }

--- a/src/components/explorer/explorer.css
+++ b/src/components/explorer/explorer.css
@@ -78,3 +78,11 @@
   color: #1990ff;
 }
 
+.other-details .ant-descriptions-item-label{
+  padding-right: 10px !important;
+}
+
+.other-details-click {
+  color: #1990ff;
+}
+

--- a/src/components/explorer/explorer.css
+++ b/src/components/explorer/explorer.css
@@ -16,26 +16,65 @@
   display: none;
 }
 
-.ant-descriptions-item-label {
+.ant-descriptions-item-label.ant-descriptions-item-colon {
   width: 200px;
+  padding: 8px 16px !important;
+}
+
+.ant-descriptions-bordered.ant-descriptions-small .ant-descriptions-item-label, .ant-descriptions-bordered.ant-descriptions-small .ant-descriptions-item-content {
+  padding: 0;
+}
+
+/* selector for nested descriptions */
+.ant-descriptions-view .ant-descriptions-view .ant-descriptions-item-content {
+  padding: 8px 16px;
+} 
+
+.ant-descriptions-title {
+  margin: 0;
+  padding-left: 15px;
+  background-color: #fafafa;
+  font-size: 14px;
 }
 
 .ant-descriptions-title {
   margin: 0;
   padding-left: 15px;
   background-color: #fafafa;
+  font-size: 14px;
 }
 
 .ant-descriptions-view {
-  border-top-left-radius: 0px;
-  border-top-right-radius: 0px;
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-radius: 0;
+  margin-bottom: 5px;
 }
 
 .ant-descriptions-title {
   border: 1px solid #e8e8e8;
   border-bottom: 0;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
+  border-radius: 0;
 }
+
+.experimentSummary {
+  display: flex;
+  margin-bottom: 15px;
+}
+
+/* collapse borders on adjacent items */
+/* needs a more permanent solution that doesn't rely on right child being smaller */
+.experimentSummary > :last-child * {
+  border-left: 0;
+}
+
+.experiment-titles {
+  padding: 0px 0px 8px 17px;
+} 
+
+.biosamples-descriptions {
+  display: inline-block;
+}
+
+.biosamples-descriptions .ant-descriptions-title {
+  color: #1990ff;
+}
+

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,3 +11,5 @@ export const FORM_MODE_ADD = "add";
 export const FORM_MODE_EDIT = "edit";
 
 export const EM_DASH = "—";
+
+export const BENTO_BLUE = "#1990ff";


### PR DESCRIPTION
Separate individual biosamples and experiments views into two different tabs. 
- new layout for both tabs
- more readable left->right layout for data display
- standardized json appearance 
- new text colours, should be standardized across other tabs
- file download: move to Experiments page, easily expanded for new file types

- todos: igv display, link to experiments page from biosamples 