### PR TITLE
allow sorting on all search results columns

### DIFF
--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -42,15 +42,14 @@ const SEARCH_RESULT_COLUMNS = [
             {samples.map(b => b.id).join(", ")}
         </>,
         sorter: (a, b) => a.biosamples.length - b.biosamples.length,
-        sortDirections: ['descend', 'ascend', 'descend'],
-    
+        sortDirections: ["descend", "ascend", "descend"],
     },
     {
         title: "Experiments",
         dataIndex: "experiments",
         render: experiments => <>{experiments.length} Experiment{experiments.length === 1 ? "" : "s"}</>,
         sorter: (a, b) => a.experiments.length - b.experiments.length,
-        sortDirections: ['descend', 'ascend', 'descend'],
+        sortDirections: ["descend", "ascend", "descend"],
     },
 ];
 


### PR DESCRIPTION
Allow sorting by all columns in search results table. 

`sortDirections: ['descend', 'ascend', 'descend']` is an Ant Design workaround that keeps the column from going back to the default unsorted state once you have chosen a sort order. 