### PR TITLE
Gordon/improved variant search

### DIFF
--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -28,7 +28,7 @@ class DiscoveryQueryBuilder extends Component {
 
         this.handleAddDataTypeQueryForm = this.handleAddDataTypeQueryForm.bind(this);
         this.handleTabsEdit = this.handleTabsEdit.bind(this);
-        this.handleVariantHiddenFieldChange = this.handleVariantHiddenFieldChange.bind(this)
+        this.handleVariantHiddenFieldChange = this.handleVariantHiddenFieldChange.bind(this);
 
         this.forms = {};
     }
@@ -148,7 +148,7 @@ class DiscoveryQueryBuilder extends Component {
                                      formValues={d.formValues}
                                      loading={this.props.searchLoading}
                                      wrappedComponentRef={form => this.forms[d.dataType.id] = form}
-                                     onChange={fields => this.handleFormChange(d.dataType, fields)} 
+                                     onChange={fields => this.handleFormChange(d.dataType, fields)}
                                      handleVariantHiddenFieldChange={this.handleVariantHiddenFieldChange}
                                      />
             </Tabs.TabPane>

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -28,6 +28,7 @@ class DiscoveryQueryBuilder extends Component {
 
         this.handleAddDataTypeQueryForm = this.handleAddDataTypeQueryForm.bind(this);
         this.handleTabsEdit = this.handleTabsEdit.bind(this);
+        this.handleVariantHiddenFieldChange = this.handleVariantHiddenFieldChange.bind(this)
 
         this.forms = {};
     }
@@ -105,6 +106,10 @@ class DiscoveryQueryBuilder extends Component {
         this.props.updateDataTypeQueryForm(dataType, fields);
     }
 
+    handleVariantHiddenFieldChange(fields) {
+        this.props.updateDataTypeQueryForm(this.props.dataTypesByID["variant"], fields);
+    }
+
     handleSchemasToggle() {
         this.setState({schemasModalShown: !this.state.schemasModalShown});
     }
@@ -143,7 +148,9 @@ class DiscoveryQueryBuilder extends Component {
                                      formValues={d.formValues}
                                      loading={this.props.searchLoading}
                                      wrappedComponentRef={form => this.forms[d.dataType.id] = form}
-                                     onChange={fields => this.handleFormChange(d.dataType, fields)} />
+                                     onChange={fields => this.handleFormChange(d.dataType, fields)} 
+                                     handleVariantHiddenFieldChange={this.handleVariantHiddenFieldChange}
+                                     />
             </Tabs.TabPane>
         ));
 

--- a/src/components/discovery/DiscoverySearchCondition.js
+++ b/src/components/discovery/DiscoverySearchCondition.js
@@ -137,12 +137,11 @@ class DiscoverySearchCondition extends Component {
                    placeholder="value"
                    onChange={this.handleSearchValue}
                    value={this.getSearchValue()}
-                   hidden={this.props.hidden}
                    />    
         );
     }
 
-    getInputStyle = (valueWidth, div = 1) => ({width: `calc(${100 / div}% - ${valueWidth / div}px)`, display: this.props.hidden? "none" : "inline-block"});
+    getInputStyle = (valueWidth, div = 1) => ({width: `calc(${100 / div}% - ${valueWidth / div}px)`});
 
     render() {
         const conditionType = this.props.conditionType ?? "data-type";
@@ -163,7 +162,7 @@ class DiscoverySearchCondition extends Component {
 
         const schemaTreeSelect = (fieldKey, fieldSchemaKey, schema, style) => (
             <SchemaTreeSelect
-                style={{float: "left", ...style, display: this.props.hidden? "none" : "inline-block"}}
+                style={{float: "left", ...style}}
                 disabled={!canRemove}
                 schema={schema}
                 isExcluded={this.props.isExcluded}
@@ -190,7 +189,7 @@ class DiscoverySearchCondition extends Component {
                 }
             )}
             {canNegate ? (  // Negation
-                <Select style={{width: `${NEGATION_WIDTH}px`, float: "left", display: this.props.hidden? "none" : "inline-block"}}
+                <Select style={{width: `${NEGATION_WIDTH}px`, float: "left"}}
                         value={this.state.negated ? "neg" : "pos"}
                         onChange={this.handleNegation}
                         >
@@ -199,10 +198,9 @@ class DiscoverySearchCondition extends Component {
                 </Select>
             ) : null}
             {this.equalsOnly() ? null : (  // Operation select
-                <Select style={{width: `${OPERATION_WIDTH}px`, float: "left", display: this.props.hidden? "none" : "inline-block" }}
+                <Select style={{width: `${OPERATION_WIDTH}px`, float: "left"}}
                         value={this.state.operation}
                         onChange={this.handleOperation}
-                        hidden={this.props.hidden}
                         >
                     {operationOptions}
                 </Select>
@@ -220,7 +218,6 @@ class DiscoverySearchCondition extends Component {
                         style={{width: `${CLOSE_WIDTH}px`}}
                         disabled={this.props.removeDisabled}
                         onClick={this.props.onRemoveClick ?? nop} 
-                        hidden={this.props.hidden}
                         />
             ) : null}
         </Input.Group>;

--- a/src/components/discovery/DiscoverySearchCondition.js
+++ b/src/components/discovery/DiscoverySearchCondition.js
@@ -123,9 +123,9 @@ class DiscoverySearchCondition extends Component {
             // Prefix select keys in case there's a "blank" item in the enum, which throws an error
             return (
                  <Select style={this.getInputStyle(valueWidth)} onChange={this.handleSearchSelectValue}
-                        value={this.getSearchValue()} showSearch
-                        filterOption={(i, o) =>
-                            o.props.children.toLocaleLowerCase().includes(i.toLocaleLowerCase())}>
+                         value={this.getSearchValue()} showSearch
+                         filterOption={(i, o) =>
+                             o.props.children.toLocaleLowerCase().includes(i.toLocaleLowerCase())}>
                     {(this.state.fieldSchema.type === "boolean" ? BOOLEAN_OPTIONS : this.state.fieldSchema.enum)
                         .map(v => <Select.Option key={`_${v}`} value={v}>{v}</Select.Option>)}
                 </Select>
@@ -137,7 +137,7 @@ class DiscoverySearchCondition extends Component {
                    placeholder="value"
                    onChange={this.handleSearchValue}
                    value={this.getSearchValue()}
-                   />    
+                   />
         );
     }
 
@@ -217,7 +217,7 @@ class DiscoverySearchCondition extends Component {
                         icon="close"
                         style={{width: `${CLOSE_WIDTH}px`}}
                         disabled={this.props.removeDisabled}
-                        onClick={this.props.onRemoveClick ?? nop} 
+                        onClick={this.props.onRemoveClick ?? nop}
                         />
             ) : null}
         </Input.Group>;

--- a/src/components/discovery/DiscoverySearchCondition.js
+++ b/src/components/discovery/DiscoverySearchCondition.js
@@ -11,15 +11,10 @@ import {constFn, id, nop} from "../../utils/misc";
 
 
 const BOOLEAN_OPTIONS = ["true", "false"];
-
-
 const DATA_TYPE_FIELD_WIDTH = 224;
 const NEGATION_WIDTH = 88;
 const OPERATION_WIDTH = 116;
 const CLOSE_WIDTH = 50;
-
-
-const getInputStyle = (valueWidth, div = 1) => ({width: `calc(${100 / div}% - ${valueWidth / div}px)`});
 
 const toStringOrNull = x => x === null ? null : x.toString();
 
@@ -127,7 +122,7 @@ class DiscoverySearchCondition extends Component {
         if (this.state.fieldSchema.hasOwnProperty("enum") || this.state.fieldSchema.type === "boolean") {
             // Prefix select keys in case there's a "blank" item in the enum, which throws an error
             return (
-                <Select style={getInputStyle(valueWidth)} onChange={this.handleSearchSelectValue}
+                 <Select style={this.getInputStyle(valueWidth)} onChange={this.handleSearchSelectValue}
                         value={this.getSearchValue()} showSearch
                         filterOption={(i, o) =>
                             o.props.children.toLocaleLowerCase().includes(i.toLocaleLowerCase())}>
@@ -138,12 +133,16 @@ class DiscoverySearchCondition extends Component {
         }
 
         return (
-            <Input style={getInputStyle(valueWidth)}
+            <Input style={this.getInputStyle(valueWidth)}
                    placeholder="value"
                    onChange={this.handleSearchValue}
-                   value={this.getSearchValue()} />
+                   value={this.getSearchValue()}
+                   hidden={this.props.hidden}
+                   />    
         );
     }
+
+    getInputStyle = (valueWidth, div = 1) => ({width: `calc(${100 / div}% - ${valueWidth / div}px)`, display: this.props.hidden? "none" : "inline-block"});
 
     render() {
         const conditionType = this.props.conditionType ?? "data-type";
@@ -164,7 +163,7 @@ class DiscoverySearchCondition extends Component {
 
         const schemaTreeSelect = (fieldKey, fieldSchemaKey, schema, style) => (
             <SchemaTreeSelect
-                style={{float: "left", ...style}}
+                style={{float: "left", ...style, display: this.props.hidden? "none" : "inline-block"}}
                 disabled={!canRemove}
                 schema={schema}
                 isExcluded={this.props.isExcluded}
@@ -184,24 +183,27 @@ class DiscoverySearchCondition extends Component {
                 conditionType === "join" ? this.props.joinedSchema : this.state.dataType?.schema,
                 {
                     ...(conditionType === "join"
-                        ? getInputStyle(valueWidth,2)
+                        ? this.getInputStyle(valueWidth,2)
                         : {width: `${DATA_TYPE_FIELD_WIDTH}px`}),
                     borderTopRightRadius: "0",
                     borderBottomRightRadius: "0"
                 }
             )}
             {canNegate ? (  // Negation
-                <Select style={{width: `${NEGATION_WIDTH}px`, float: "left"}}
+                <Select style={{width: `${NEGATION_WIDTH}px`, float: "left", display: this.props.hidden? "none" : "inline-block"}}
                         value={this.state.negated ? "neg" : "pos"}
-                        onChange={this.handleNegation}>
+                        onChange={this.handleNegation}
+                        >
                     <Select.Option key="pos">is</Select.Option>
                     <Select.Option key="neg">is not</Select.Option>
                 </Select>
             ) : null}
             {this.equalsOnly() ? null : (  // Operation select
-                <Select style={{width: `${OPERATION_WIDTH}px`, float: "left"}}
+                <Select style={{width: `${OPERATION_WIDTH}px`, float: "left", display: this.props.hidden? "none" : "inline-block" }}
                         value={this.state.operation}
-                        onChange={this.handleOperation}>
+                        onChange={this.handleOperation}
+                        hidden={this.props.hidden}
+                        >
                     {operationOptions}
                 </Select>
             )}
@@ -210,14 +212,16 @@ class DiscoverySearchCondition extends Component {
                     "field2",
                     "fieldSchema2",
                     this.props.joinedSchema,
-                    {...getInputStyle(valueWidth, 2), borderRadius: "0"}
+                    {...this.getInputStyle(valueWidth, 2), borderRadius: "0"}
                 ) : this.getRHSInput(valueWidth)}
             {canRemove ? (  // Condition removal button
                 <Button type="danger"
                         icon="close"
                         style={{width: `${CLOSE_WIDTH}px`}}
                         disabled={this.props.removeDisabled}
-                        onClick={this.props.onRemoveClick ?? nop} />
+                        onClick={this.props.onRemoveClick ?? nop} 
+                        hidden={this.props.hidden}
+                        />
             ) : null}
         </Input.Group>;
     }

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import {Button, Form, Icon} from "antd";
 
 import {getFieldSchema, getFields} from "../../utils/schema";
-import {DEFAULT_SEARCH_PARAMETERS, OP_EQUALS} from "../../utils/search";
+import {DEFAULT_SEARCH_PARAMETERS, OP_EQUALS, OP_LESS_THAN_OR_EQUAL, OP_GREATER_THAN_OR_EQUAL} from "../../utils/search";
 
 import DiscoverySearchCondition, {getSchemaTypeTransformer} from "./DiscoverySearchCondition";
 import VariantSearchHeader from "./VariantSearchHeader";
@@ -128,11 +128,10 @@ class DiscoverySearchForm extends Component {
                 ...(conditionType === "data-type" ? {} : {field2}),
                 fieldSchema,
                 negated: false,
-                operation: fieldSchema?.search?.operations?.[0] ?? OP_EQUALS,
+                operation:  this.getInitialOperator(field, fieldSchema),
                 ...(conditionType === "data-type" ? {searchValue: ""} : {})
             },
         };
-
 
         // Initialize new condition, otherwise the state won't get it
         this.props.form.getFieldDecorator(`conditions[${newKey}]`, {
@@ -190,8 +189,22 @@ class DiscoverySearchForm extends Component {
         return this.state.isVariantSearch ? "" : this.state.conditionsHelp[key] ?? undefined
     }
 
-    getInitialValues = (key) => {
-        // replace code below
+    getInitialOperator = (field, fieldSchema) => {
+        if (!this.state.isVariantSearch) {
+            return fieldSchema?.search?.operations?.[0] ?? OP_EQUALS
+        }
+
+        switch (field) {
+          case "[dataset item].start":
+            return OP_GREATER_THAN_OR_EQUAL;
+
+          case "[dataset item].end":
+            return OP_LESS_THAN_OR_EQUAL;
+
+          // assemblyID, chromosome, genotype 
+          default:
+            return OP_EQUALS;
+        }        
     }
 
     render() {

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -7,7 +7,7 @@ import {getFieldSchema, getFields} from "../../utils/schema";
 import {DEFAULT_SEARCH_PARAMETERS, OP_EQUALS} from "../../utils/search";
 
 import DiscoverySearchCondition, {getSchemaTypeTransformer} from "./DiscoverySearchCondition";
-
+import VariantSearchHeader from "./VariantSearchHeader";
 
 // noinspection JSUnusedGlobalSymbols
 const CONDITION_RULES = [
@@ -204,6 +204,7 @@ class DiscoverySearchForm extends Component {
         ));
 
         return <Form onSubmit={this.onSubmit}>
+            {this.props.dataType.id==="variant" && <VariantSearchHeader/>}
             {formItems}
             <Form.Item wrapperCol={{
                 xl: {span: 24},

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -173,13 +173,6 @@ class DiscoverySearchForm extends Component {
         this.setState({variantSearchValues: {...this.state.variantSearchValues, ...values}})
     }
     
-    // hide first five variant search fields
-    // these appear in the submitted form but not in the UI
-    // their values are controlled by VariantSearchHeader
-    hideField = (fieldNum) => {
-        return this.state.isVariantSearch && fieldNum < NUM_HIDDEN_VARIANT_FORM_ITEMS
-    }
-
     // don't count hidden variant fields
     getLabel = (i) => {
         return this.state.isVariantSearch? `Condition ${i - 1}` : `Condition ${i + 1}`

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -45,7 +45,7 @@ class DiscoverySearchForm extends Component {
         this.getDataTypeFieldSchema = this.getDataTypeFieldSchema.bind(this);
         this.addCondition = this.addCondition.bind(this);
         this.removeCondition = this.removeCondition.bind(this);
-        this.setVariantSearchValues = this.setVariantSearchValues.bind(this)
+        this.addVariantSearchValues = this.addVariantSearchValues.bind(this)
     }
 
     componentDidMount() {
@@ -156,10 +156,8 @@ class DiscoverySearchForm extends Component {
         return ["internal", "none"].includes(fs.search?.queryable);
     }
 
-    // user-friendly variant search 
-    setVariantSearchValues(value) {
-        console.log({settingVariantSearchValues: value})
-        this.setState({variantSearchValues: value})
+    addVariantSearchValues(values) {
+        this.setState({variantSearchValues: {...this.state.variantSearchValues, ...values}})
     }
     
     render() {
@@ -213,7 +211,7 @@ class DiscoverySearchForm extends Component {
         return <Form onSubmit={this.onSubmit}>
             {this.props.dataType.id === "variant" && (
               <VariantSearchHeader
-                setVariantSearchValues={this.setVariantSearchValues}
+              addVariantSearchValues={this.addVariantSearchValues}
                 dataType={this.props.dataType}
               />
             )}

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -177,7 +177,8 @@ class DiscoverySearchForm extends Component {
         return toReturn
     }
 
-    addVariantSearchValues = async (values) => {
+    // fill hidden variant forms according to input in user-friendly variant search
+    addVariantSearchValues = (values) => {
         this.setState({variantSearchValues: {...this.state.variantSearchValues, ...values}})
 
         const {assemblyId, name, chrom, start, end, genotype_type } = values;
@@ -186,19 +187,28 @@ class DiscoverySearchForm extends Component {
         const fields = this.props.formValues
         console.log({fields: fields})
 
-        console.log(`previous assembly ID was ${fields.conditions[0].value.searchValue}`)
+       let updatedConditionsArray = fields.conditions
 
-        if (values.assemblyId) {
-          const updatedConditionsArray = this.updateConditions(fields.conditions, "[dataset item].assembly_id", assemblyId);
-
-          const updatedFields = {
-            keys: fields.keys,
-            conditions: updatedConditionsArray,
-          };
-
-        //   await?
-        this.props.handleVariantHiddenFieldChange(updatedFields);
+        if (assemblyId){
+            updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].assembly_id", assemblyId);
         }
+
+        if (genotype_type){
+            updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].calls.[item].genotype_type", genotype_type);
+        }
+
+        if (chrom && start && end) {
+            updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].chromosome", chrom);
+            updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].start", start);
+            updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].end", end);
+        }
+
+        const updatedFields = {
+          keys: fields.keys,
+          conditions: updatedConditionsArray,
+        };
+
+        this.props.handleVariantHiddenFieldChange(updatedFields);
 
 
         // values to change are:
@@ -304,7 +314,7 @@ class DiscoverySearchForm extends Component {
             </Form.Item>
         ));
 
-        //for variants, only standard search fields shown should be the user-added ones
+        //for variant search, only show user-added fields, hide everything else
         const nonHiddenFields = formItems.slice(NUM_HIDDEN_VARIANT_FORM_ITEMS)                            
 
         return <Form onSubmit={this.onSubmit}>

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -169,8 +169,64 @@ class DiscoverySearchForm extends Component {
         "[dataset item].calls.[item].genotype_type",
     ]    
 
-    addVariantSearchValues(values) {
+    updateConditions = (conditions, fieldName, newValue) => {
+        console.log({CONDITIONSIN: conditions})
+        const toReturn = conditions.map(c => c.value.field === fieldName ? ({...c,  value: {...c.value, searchValue: newValue }})  : c)
+        console.log({CONDITIONSOUT: toReturn})
+
+        return toReturn
+    }
+
+    addVariantSearchValues = async (values) => {
         this.setState({variantSearchValues: {...this.state.variantSearchValues, ...values}})
+
+        const {assemblyId, name, chrom, start, end, genotype_type } = values;
+        console.log({gotValues: values})
+
+        const fields = this.props.formValues
+        console.log({fields: fields})
+
+        console.log(`previous assembly ID was ${fields.conditions[0].value.searchValue}`)
+
+        if (values.assemblyId) {
+          const updatedConditionsArray = this.updateConditions(fields.conditions, "[dataset item].assembly_id", assemblyId);
+
+          const updatedFields = {
+            keys: fields.keys,
+            conditions: updatedConditionsArray,
+          };
+
+        //   await?
+        this.props.handleVariantHiddenFieldChange(updatedFields);
+        }
+
+
+        // values to change are:
+        // value.field === '[dataset item].assembly_id'
+        // change value.searchValue = new assembly ID
+
+        // 1: value.field = "[dataset item].chromosome"
+        // set value.searchValue to chrom
+
+        // 2: value.field = "[dataset item].start"
+        // set value.searchValue to start
+
+        // 3: value.field = "[dataset item].end"
+        // set value.searchValue to end
+
+        // 4: value.field = "[dataset item].calls.[item].genotype_type"
+        // set searchValue to genotype
+
+
+
+        
+        // this.props.form.validateFields((err, vvv) => {
+        //     if (!err) {
+        //       console.log("Received values of form");
+        //       console.log({vvv: vvv})
+        //     }
+        //   });
+
     }
     
     // don't count hidden variant fields

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -57,6 +57,18 @@ class DiscoverySearchForm extends Component {
                 getFieldSchema(this.props.dataType.schema, f).search?.required ?? false)
             : [];
 
+            //this adds an array of four strings:
+            // 0: "[dataset item].assembly_id"
+            // 1: "[dataset item].chromosome"
+            // 2: "[dataset item].start"
+            // 3: "[dataset item].calls.[item].genotype_type"
+
+        console.log("MOUNT")
+        console.log({requiredFields: requiredFields})    
+
+        // filter out required variant fields
+        // replace with custom variant search fields
+
         const stateUpdates = requiredFields.map(c => this.addCondition(c, undefined, true));
 
         // Add a single default condition if necessary
@@ -187,6 +199,7 @@ class DiscoverySearchForm extends Component {
                 })(
                     <DiscoverySearchCondition conditionType={this.props.conditionType ?? "data-type"}
                                               dataType={this.props.dataType}
+                                              hidden={false}
                                               isExcluded={f => existingUniqueFields.includes(f) ||
                                                   (!this.props.isInternal && this.isNotPublic(f))}
                                               onFieldChange={change => this.handleFieldChange(k, change)}

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -4,12 +4,17 @@ import PropTypes from "prop-types";
 import {Button, Form, Icon} from "antd";
 
 import {getFieldSchema, getFields} from "../../utils/schema";
-import {DEFAULT_SEARCH_PARAMETERS, OP_EQUALS, OP_LESS_THAN_OR_EQUAL, OP_GREATER_THAN_OR_EQUAL} from "../../utils/search";
+import {
+    DEFAULT_SEARCH_PARAMETERS,
+    OP_EQUALS,
+    OP_LESS_THAN_OR_EQUAL,
+    OP_GREATER_THAN_OR_EQUAL,
+} from "../../utils/search";
 
 import DiscoverySearchCondition, {getSchemaTypeTransformer} from "./DiscoverySearchCondition";
 import VariantSearchHeader from "./VariantSearchHeader";
 
-const NUM_HIDDEN_VARIANT_FORM_ITEMS = 5
+const NUM_HIDDEN_VARIANT_FORM_ITEMS = 5;
 
 // noinspection JSUnusedGlobalSymbols
 const CONDITION_RULES = [
@@ -40,14 +45,19 @@ class DiscoverySearchForm extends Component {
     constructor(props) {
         super(props);
 
-        this.state = {conditionsHelp: {}, fieldSchemas: {}, variantSearchValues: {}, isVariantSearch: props.dataType.id === "variant"};
+        this.state = {
+            conditionsHelp: {},
+            fieldSchemas: {},
+            variantSearchValues: {},
+            isVariantSearch: props.dataType.id === "variant",
+        };
         this.initialValues = {};
 
         this.handleFieldChange = this.handleFieldChange.bind(this);
         this.getDataTypeFieldSchema = this.getDataTypeFieldSchema.bind(this);
         this.addCondition = this.addCondition.bind(this);
         this.removeCondition = this.removeCondition.bind(this);
-        this.addVariantSearchValues = this.addVariantSearchValues.bind(this)
+        this.addVariantSearchValues = this.addVariantSearchValues.bind(this);
     }
 
     componentDidMount() {
@@ -60,8 +70,8 @@ class DiscoverySearchForm extends Component {
             : [];
 
         const stateUpdates = this.state.isVariantSearch
-          ? this.hiddenVariantSearchFields().map((c) => this.addCondition(c, undefined, true))
-          : requiredFields.map((c) => this.addCondition(c, undefined, true));
+            ? this.hiddenVariantSearchFields().map((c) => this.addCondition(c, undefined, true))
+            : requiredFields.map((c) => this.addCondition(c, undefined, true));
 
         // Add a single default condition if necessary
         if (requiredFields.length === 0 && this.props.conditionType !== "join") {
@@ -167,30 +177,40 @@ class DiscoverySearchForm extends Component {
         "[dataset item].start",
         "[dataset item].end",
         "[dataset item].calls.[item].genotype_type",
-    ]    
+    ]
 
     updateConditions = (conditions, fieldName, newValue) => {
-        console.log({CONDITIONSIN: conditions})
-        const toReturn = conditions.map(c => c.value.field === fieldName ? ({...c,  value: {...c.value, searchValue: newValue }})  : c)
-        console.log({CONDITIONSOUT: toReturn})
+        console.log({CONDITIONSIN: conditions});
+        const toReturn = conditions.map((c) =>
+            c.value.field === fieldName ? { ...c, value: { ...c.value, searchValue: newValue } } : c
+        );
+        console.log({CONDITIONSOUT: toReturn});
 
-        return toReturn
+        return toReturn;
     }
 
     // fill hidden variant forms according to input in user-friendly variant search
     addVariantSearchValues = (values) => {
-        this.setState({variantSearchValues: {...this.state.variantSearchValues, ...values}})
+        this.setState({variantSearchValues: {...this.state.variantSearchValues, ...values}});
 
-        const {assemblyId, name, chrom, start, end, genotype_type } = values;
-        const fields = this.props.formValues
-        let updatedConditionsArray = fields.conditions
+        const {assemblyId, chrom, start, end, genotypeType } = values;
+        const fields = this.props.formValues;
+        let updatedConditionsArray = fields.conditions;
 
-        if (assemblyId){
-            updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].assembly_id", assemblyId);
+        if (assemblyId) {
+            updatedConditionsArray = this.updateConditions(
+                updatedConditionsArray,
+                "[dataset item].assembly_id",
+                assemblyId
+            );
         }
 
-        if (genotype_type){
-            updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].calls.[item].genotype_type", genotype_type);
+        if (genotypeType) {
+            updatedConditionsArray = this.updateConditions(
+                updatedConditionsArray,
+                "[dataset item].calls.[item].genotype_type",
+                genotypeType
+            );
         }
 
         if (chrom && start && end) {
@@ -200,38 +220,38 @@ class DiscoverySearchForm extends Component {
         }
 
         const updatedFields = {
-          keys: fields.keys,
-          conditions: updatedConditionsArray,
+            keys: fields.keys,
+            conditions: updatedConditionsArray,
         };
 
         this.props.handleVariantHiddenFieldChange(updatedFields);
     }
-    
+
     // don't count hidden variant fields
     getLabel = (i) => {
-        return this.state.isVariantSearch? `Condition ${i - 1}` : `Condition ${i + 1}`
+        return this.state.isVariantSearch ? `Condition ${i - 1}` : `Condition ${i + 1}`;
     }
 
     getHelpText = (key) => {
-        return this.state.isVariantSearch ? "" : this.state.conditionsHelp[key] ?? undefined
+        return this.state.isVariantSearch ? "" : this.state.conditionsHelp[key] ?? undefined;
     }
 
     getInitialOperator = (field, fieldSchema) => {
         if (!this.state.isVariantSearch) {
-            return fieldSchema?.search?.operations?.[0] ?? OP_EQUALS
+            return fieldSchema?.search?.operations?.[0] ?? OP_EQUALS;
         }
 
         switch (field) {
-          case "[dataset item].start":
-            return OP_GREATER_THAN_OR_EQUAL;
+            case "[dataset item].start":
+                return OP_GREATER_THAN_OR_EQUAL;
 
-          case "[dataset item].end":
-            return OP_LESS_THAN_OR_EQUAL;
+            case "[dataset item].end":
+                return OP_LESS_THAN_OR_EQUAL;
 
-          // assemblyID, chromosome, genotype 
-          default:
-            return OP_EQUALS;
-        }        
+          // assemblyID, chromosome, genotype
+            default:
+                return OP_EQUALS;
+        }
     }
 
     render() {
@@ -283,16 +303,16 @@ class DiscoverySearchForm extends Component {
         ));
 
         //for variant search, only show user-added fields, hide everything else
-        const nonHiddenFields = formItems.slice(NUM_HIDDEN_VARIANT_FORM_ITEMS)                            
+        const nonHiddenFields = formItems.slice(NUM_HIDDEN_VARIANT_FORM_ITEMS);
 
         return <Form onSubmit={this.onSubmit}>
             {this.props.dataType.id === "variant" && (
               <VariantSearchHeader
               addVariantSearchValues={this.addVariantSearchValues}
-                dataType={this.props.dataType}
+              dataType={this.props.dataType}
               />
             )}
-            {this.state.isVariantSearch? nonHiddenFields : formItems}
+            {this.state.isVariantSearch ? nonHiddenFields : formItems}
             <Form.Item wrapperCol={{
                 xl: {span: 24},
                 xxl: {offset: 3, span: 18}
@@ -309,7 +329,8 @@ DiscoverySearchForm.propTypes = {
     conditionType: PropTypes.oneOf(["data-type", "join"]),
     dataType: PropTypes.object,  // TODO: Shape?
     isInternal: PropTypes.bool,
-    // TODO
+    formValues: PropTypes.object,
+    handleVariantHiddenFieldChange: PropTypes.func,
 };
 
 export default Form.create({

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -182,12 +182,8 @@ class DiscoverySearchForm extends Component {
         this.setState({variantSearchValues: {...this.state.variantSearchValues, ...values}})
 
         const {assemblyId, name, chrom, start, end, genotype_type } = values;
-        console.log({gotValues: values})
-
         const fields = this.props.formValues
-        console.log({fields: fields})
-
-       let updatedConditionsArray = fields.conditions
+        let updatedConditionsArray = fields.conditions
 
         if (assemblyId){
             updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].assembly_id", assemblyId);
@@ -209,34 +205,6 @@ class DiscoverySearchForm extends Component {
         };
 
         this.props.handleVariantHiddenFieldChange(updatedFields);
-
-
-        // values to change are:
-        // value.field === '[dataset item].assembly_id'
-        // change value.searchValue = new assembly ID
-
-        // 1: value.field = "[dataset item].chromosome"
-        // set value.searchValue to chrom
-
-        // 2: value.field = "[dataset item].start"
-        // set value.searchValue to start
-
-        // 3: value.field = "[dataset item].end"
-        // set value.searchValue to end
-
-        // 4: value.field = "[dataset item].calls.[item].genotype_type"
-        // set searchValue to genotype
-
-
-
-        
-        // this.props.form.validateFields((err, vvv) => {
-        //     if (!err) {
-        //       console.log("Received values of form");
-        //       console.log({vvv: vvv})
-        //     }
-        //   });
-
     }
     
     // don't count hidden variant fields

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -38,13 +38,14 @@ class DiscoverySearchForm extends Component {
     constructor(props) {
         super(props);
 
-        this.state = {conditionsHelp: {}, fieldSchemas: {}};
+        this.state = {conditionsHelp: {}, fieldSchemas: {}, variantSearchValues: {}};
         this.initialValues = {};
 
         this.handleFieldChange = this.handleFieldChange.bind(this);
         this.getDataTypeFieldSchema = this.getDataTypeFieldSchema.bind(this);
         this.addCondition = this.addCondition.bind(this);
         this.removeCondition = this.removeCondition.bind(this);
+        this.setVariantSearchValues = this.setVariantSearchValues.bind(this)
     }
 
     componentDidMount() {
@@ -155,6 +156,12 @@ class DiscoverySearchForm extends Component {
         return ["internal", "none"].includes(fs.search?.queryable);
     }
 
+    // user-friendly variant search 
+    setVariantSearchValues(value) {
+        console.log({settingVariantSearchValues: value})
+        this.setState({variantSearchValues: value})
+    }
+    
     render() {
         const getCondition = ck => this.props.form.getFieldValue(`conditions[${ck}]`);
 
@@ -204,7 +211,12 @@ class DiscoverySearchForm extends Component {
         ));
 
         return <Form onSubmit={this.onSubmit}>
-            {this.props.dataType.id==="variant" && <VariantSearchHeader/>}
+            {this.props.dataType.id === "variant" && (
+              <VariantSearchHeader
+                setVariantSearchValues={this.setVariantSearchValues}
+                dataType={this.props.dataType}
+              />
+            )}
             {formItems}
             <Form.Item wrapperCol={{
                 xl: {span: 24},

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -7,9 +7,27 @@ import { performGohanGeneSearchIfPossible } from "../../modules/discovery/action
 // TODOs: 
 // style options
 // tabbing away should select ?
-
+// stop showing options on position notation
 
 const { Option } = AutoComplete;
+
+const optionStyle = {
+  backgroundColor: "hotpink"
+}
+
+// const GeneDropdownOption = ({gene}) => {
+
+//   const {assemblyId, name, chrom, start, end} = gene;
+//   console.log({assemblyId: assemblyId, name: name, chrom: chrom, start: start, end: end})
+
+//   return <p>{gene.name}</p>
+// }
+
+const geneOptionText = (gene) => {
+  const {assemblyId, name, chrom, start, end} = gene;
+  return `${gene.name} chromosome: ${gene.chrom} start: ${gene.start} end: ${gene.end}`
+}
+
 
 const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
   // const [input, setInput] = useState(""); //needed?
@@ -29,6 +47,9 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
     // handle position notation
     if(value.includes(':')){
       parsePosition(value)
+
+      // also stop showing dropdown
+
       return
     }
 
@@ -39,11 +60,13 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
     const locus = options.props?.locus
     
     // todo: "locus" may be array of multiple items if users tabs away 
+    console.log({selectValue: value, selectOptions: options})
 
     // may not need error checking here, since this is user selection, not user input
     if (!locus){
       return
     }
+
     addVariantSearchValues({...locus})
   } 
 
@@ -51,13 +74,28 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
     setAutoCompleteOptions((geneSearchResults ?? []).sort((a, b) => (a.name > b.name) ? 1 : -1))
   }, [geneSearchResults])
 
-  return <AutoComplete
-    options={autoCompleteOptions}
-    onChange={handleChange}
-    onSelect={handleSelect}
+  console.log({autoCompleteOptions: autoCompleteOptions})
+  
+  return (
+    <AutoComplete
+      options={autoCompleteOptions}
+      onChange={handleChange}
+      onSelect={handleSelect}
+      // dropdownMenuStyle={}
+      // backfill={true}
     >
-      {showAutoCompleteOptions && autoCompleteOptions.map((r, i) => <Option key={r.name} value={r.name} locus={r} >{`${r.name} chromosome: ${r.chrom} start: ${r.start} end: ${r.end}`}</Option>)}
-      </AutoComplete>
+      {showAutoCompleteOptions &&
+        autoCompleteOptions.map((g, i) => (
+          <Option
+            key={`${g.name}_${g.assemblyId}`}
+            value={g.name}
+            label={`${g.name} chrom: ${g.chrom}`}
+            locus={g}
+            // style={optionStyle}
+          >{geneOptionText(g)}</Option>
+        ))}
+    </AutoComplete>
+  );
 };
 
 export default LocusSearch;

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -1,38 +1,48 @@
 import React, {useEffect, useState} from "react";
 import { AutoComplete, Form } from "antd";
 import { useDispatch, useSelector } from "react-redux";
+import { performGohanGeneSearchIfPossible } from "../../modules/discovery/actions";
+
+
+// TODOs: 
+// take assembly as required prop
+// style options
+// fill form data
+
 const { Option } = AutoComplete;
-
-// change to Form.item
-
-
 
 const LocusSearch = () => {
   const [input, setInput] = useState("");
-  // const geneSearchResults = useSelector((state) => state...... );
+  const [autoCompleteOptions, setAutoCompleteOptions] = useState([])
+  const geneSearchResults = useSelector((state) => state.discovery.geneNameSearchResponse);
   const dispatch = useDispatch();
 
-  const handleSearch = (value) => {
+  const handleChange = (value) => {
+
     setInput(value)
-    // dispatch search
-    console.log(`handleSearch value: ${value}`)
+    if (!value.length){
+      return
+    }
+    dispatch(performGohanGeneSearchIfPossible(value))
   } 
 
   const handleSelect = (value, option) => {
     console.log(`handleSelect, value: ${value}, option: ${option}`)
   } 
   
-  // useEffect(() => {
+  useEffect(() => {
+    setAutoCompleteOptions((geneSearchResults ?? []).sort((a, b) => (a.name > b.name) ? 1 : -1))
 
-  // }, [geneSearchResults])
+    console.log({geneSearchResultsFromComponent: geneSearchResults})
+  }, [geneSearchResults])
 
   return <AutoComplete
-    // options={geneSearchResults}
-    onSearch={handleSearch}
+    options={autoCompleteOptions}
+    onChange={handleChange}
     onSelect={handleSelect}
-    />
+    >
+      {autoCompleteOptions.map((r, i) => <Option key={r.name+r.assemblyId} value={r.name+r.assemblyId}>{`${r.name} chromosome: ${r.chrom} start: ${r.start} end: ${r.end}`}</Option>)}
+      </AutoComplete>
 };
-
-
 
 export default LocusSearch;

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -15,22 +15,12 @@ const optionStyle = {
   backgroundColor: "hotpink"
 }
 
-// const GeneDropdownOption = ({gene}) => {
-
-//   const {assemblyId, name, chrom, start, end} = gene;
-//   console.log({assemblyId: assemblyId, name: name, chrom: chrom, start: start, end: end})
-
-//   return <p>{gene.name}</p>
-// }
-
 const geneDropdownText = (g) => {
   return `${g.name} chromosome: ${g.chrom} start: ${g.start} end: ${g.end}`
 }
 
-
-
 const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
-  // const [input, setInput] = useState(""); //needed?
+  const [input, setInput] = useState(""); 
   const [autoCompleteOptions, setAutoCompleteOptions] = useState([])
   const geneSearchResults = useSelector((state) => state.discovery.geneNameSearchResponse);
   const dispatch = useDispatch();
@@ -39,17 +29,17 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
 
   const handleChange = (value) => {
 
-    // setInput(value)
-    if (!value.length || !showAutoCompleteOptions){
-      return
-    }
+    console.log(`got input ${value}`)
+    setInput(value)
 
     // handle position notation
     if(value.includes(':')){
       parsePosition(value)
+      setAutoCompleteOptions([])
+      return
+    }
 
-      // also stop showing dropdown
-
+    if (!value.length || !showAutoCompleteOptions){
       return
     }
 
@@ -57,11 +47,12 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
   } 
 
   const handleSelect = (value, options) => {
-    const locus = options.props?.locus
-    
+
     // todo: "locus" may be array of multiple items if users tabs away 
     console.log({selectValue: value, selectOptions: options})
 
+    const locus = options.props?.locus
+    
     // may not need error checking here, since this is user selection, not user input
     if (!locus){
       return
@@ -69,6 +60,11 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
 
     addVariantSearchValues({...locus})
   } 
+
+  const handleSearch = (value) => {
+    console.log(`handleSearch: ${value}`)
+  }
+
 
   useEffect(() => {
     setAutoCompleteOptions((geneSearchResults ?? []).sort((a, b) => (a.name > b.name) ? 1 : -1))
@@ -79,6 +75,8 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
       options={autoCompleteOptions}
       onChange={handleChange}
       onSelect={handleSelect}
+      onSearch={handleSearch}
+
       // dropdownMenuStyle={}
       // backfill={true}
     >
@@ -102,4 +100,25 @@ function parsePosition(value) {
 
   // todo
   // parse "chr:start-end" notation and call setVariantSearchValues()
+
+
+  const parse = /(?:CHR|chr)([0-9]{1,2}|X|x|Y|y|M|m):(\d+)-(\d+)/
+
+  const result = parse.exec(value)
+
+
+  // quit if null
+
+  const chrom = result[1]
+  const start = result[2]
+  const end = result[3]
+
+  // do some basic error checking before adding
+
+
+
+  addVariantSearchValues({chrom: chrom, start: start, end: end})
+
+
+  
 }

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -62,7 +62,9 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
       return
     }
 
-    addVariantSearchValues({...locus})
+    // don't use locus.assemblyId, since this is the lookup value 
+    const {chrom, start, end} = locus
+    addVariantSearchValues({chrom: chrom, start: start, end: end})
   } 
 
   const handleSearch = (value) => {

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -1,19 +1,12 @@
 import React, {useEffect, useState} from "react";
-import { AutoComplete, Form } from "antd";
+import { AutoComplete } from "antd";
 import { useDispatch, useSelector } from "react-redux";
 import { performGohanGeneSearchIfPossible } from "../../modules/discovery/actions";
 
-
 // TODOs: 
 // style options
-// tabbing away should select ?
-// stop showing options on position notation
 
 const { Option } = AutoComplete;
-
-const optionStyle = {
-  backgroundColor: "hotpink"
-}
 
 const geneDropdownText = (g) => {
   return `${g.name} chromosome: ${g.chrom} start: ${g.start} end: ${g.end}`
@@ -26,6 +19,21 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
   const dispatch = useDispatch();
 
   const showAutoCompleteOptions = assemblyId==="GRCh37" || assemblyId==="GRCh38"
+
+  const parsePosition = (value) => {
+    const parse = /(?:CHR|chr)([0-9]{1,2}|X|x|Y|y|M|m):(\d+)-(\d+)/
+    const result = parse.exec(value)
+  
+    if (!result){
+      return
+    }
+    
+    let chrom = result[1].toUpperCase() //for eg 'x', has no effect on numbers
+    const start = Number(result[2])
+    const end = Number(result[3])
+    
+    addVariantSearchValues({chrom: chrom, start: start, end: end})
+  }
 
   const handleChange = (value) => {
 
@@ -47,10 +55,6 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
   } 
 
   const handleSelect = (value, options) => {
-
-    // todo: "locus" may be array of multiple items if users tabs away 
-    console.log({selectValue: value, selectOptions: options})
-
     const locus = options.props?.locus
     
     // may not need error checking here, since this is user selection, not user input
@@ -65,7 +69,6 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
     console.log(`handleSearch: ${value}`)
   }
 
-
   useEffect(() => {
     setAutoCompleteOptions((geneSearchResults ?? []).sort((a, b) => (a.name > b.name) ? 1 : -1))
   }, [geneSearchResults])
@@ -76,7 +79,6 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
       onChange={handleChange}
       onSelect={handleSelect}
       onSearch={handleSearch}
-
       // dropdownMenuStyle={}
       // backfill={true}
     >
@@ -95,30 +97,3 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
 };
 
 export default LocusSearch;
-
-function parsePosition(value) {
-
-  // todo
-  // parse "chr:start-end" notation and call setVariantSearchValues()
-
-
-  const parse = /(?:CHR|chr)([0-9]{1,2}|X|x|Y|y|M|m):(\d+)-(\d+)/
-
-  const result = parse.exec(value)
-
-
-  // quit if null
-
-  const chrom = result[1]
-  const start = result[2]
-  const end = result[3]
-
-  // do some basic error checking before adding
-
-
-
-  addVariantSearchValues({chrom: chrom, start: start, end: end})
-
-
-  
-}

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -23,10 +23,10 @@ const optionStyle = {
 //   return <p>{gene.name}</p>
 // }
 
-const geneOptionText = (gene) => {
-  const {assemblyId, name, chrom, start, end} = gene;
-  return `${gene.name} chromosome: ${gene.chrom} start: ${gene.start} end: ${gene.end}`
+const geneDropdownText = (g) => {
+  return `${g.name} chromosome: ${g.chrom} start: ${g.start} end: ${g.end}`
 }
+
 
 
 const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
@@ -73,8 +73,6 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
   useEffect(() => {
     setAutoCompleteOptions((geneSearchResults ?? []).sort((a, b) => (a.name > b.name) ? 1 : -1))
   }, [geneSearchResults])
-
-  console.log({autoCompleteOptions: autoCompleteOptions})
   
   return (
     <AutoComplete
@@ -92,7 +90,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
             label={`${g.name} chrom: ${g.chrom}`}
             locus={g}
             // style={optionStyle}
-          >{geneOptionText(g)}</Option>
+          >{geneDropdownText(g)}</Option>
         ))}
     </AutoComplete>
   );

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -37,7 +37,6 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
 
   const handleChange = (value) => {
 
-    console.log(`got input ${value}`)
     setInput(value)
 
     // handle position notation
@@ -67,10 +66,6 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
     addVariantSearchValues({chrom: chrom, start: start, end: end})
   } 
 
-  const handleSearch = (value) => {
-    console.log(`handleSearch: ${value}`)
-  }
-
   useEffect(() => {
     setAutoCompleteOptions((geneSearchResults ?? []).sort((a, b) => (a.name > b.name) ? 1 : -1))
   }, [geneSearchResults])
@@ -80,7 +75,6 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
       options={autoCompleteOptions}
       onChange={handleChange}
       onSelect={handleSelect}
-      onSearch={handleSearch}
       // dropdownMenuStyle={}
       // backfill={true}
     >

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -1,0 +1,38 @@
+import React, {useEffect, useState} from "react";
+import { AutoComplete, Form } from "antd";
+import { useDispatch, useSelector } from "react-redux";
+const { Option } = AutoComplete;
+
+// change to Form.item
+
+
+
+const LocusSearch = () => {
+  const [input, setInput] = useState("");
+  // const geneSearchResults = useSelector((state) => state...... );
+  const dispatch = useDispatch();
+
+  const handleSearch = (value) => {
+    setInput(value)
+    // dispatch search
+    console.log(`handleSearch value: ${value}`)
+  } 
+
+  const handleSelect = (value, option) => {
+    console.log(`handleSelect, value: ${value}, option: ${option}`)
+  } 
+  
+  // useEffect(() => {
+
+  // }, [geneSearchResults])
+
+  return <AutoComplete
+    // options={geneSearchResults}
+    onSearch={handleSearch}
+    onSelect={handleSelect}
+    />
+};
+
+
+
+export default LocusSearch;

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -1,76 +1,74 @@
 import React, {useEffect, useState} from "react";
 import { AutoComplete } from "antd";
 import { useDispatch, useSelector } from "react-redux";
+import PropTypes from "prop-types";
 import { performGohanGeneSearchIfPossible } from "../../modules/discovery/actions";
 
-// TODOs: 
+// TODOs:
 // style options
 
 const { Option } = AutoComplete;
 
 const geneDropdownText = (g) => {
-  return `${g.name} chromosome: ${g.chrom} start: ${g.start} end: ${g.end}`
-}
+    return `${g.name} chromosome: ${g.chrom} start: ${g.start} end: ${g.end}`;
+};
 
 const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
-  const [input, setInput] = useState(""); 
-  const [autoCompleteOptions, setAutoCompleteOptions] = useState([])
-  const geneSearchResults = useSelector((state) => state.discovery.geneNameSearchResponse);
-  const dispatch = useDispatch();
+    const [autoCompleteOptions, setAutoCompleteOptions] = useState([]);
+    const geneSearchResults = useSelector((state) => state.discovery.geneNameSearchResponse);
+    const dispatch = useDispatch();
 
-  const showAutoCompleteOptions = assemblyId==="GRCh37" || assemblyId==="GRCh38"
+    const showAutoCompleteOptions = assemblyId === "GRCh37" || assemblyId === "GRCh38";
 
-  const parsePosition = (value) => {
-    const parse = /(?:CHR|chr)([0-9]{1,2}|X|x|Y|y|M|m):(\d+)-(\d+)/
-    const result = parse.exec(value)
-  
-    if (!result){
-      return
-    }
-    
-    let chrom = result[1].toUpperCase() //for eg 'x', has no effect on numbers
-    const start = Number(result[2])
-    const end = Number(result[3])
-    
-    addVariantSearchValues({chrom: chrom, start: start, end: end})
-  }
+    const parsePosition = (value) => {
+        const parse = /(?:CHR|chr)([0-9]{1,2}|X|x|Y|y|M|m):(\d+)-(\d+)/;
+        const result = parse.exec(value);
 
-  const handleChange = (value) => {
+        if (!result) {
+            return;
+        }
 
-    setInput(value)
+        const chrom = result[1].toUpperCase(); //for eg 'x', has no effect on numbers
+        const start = Number(result[2]);
+        const end = Number(result[3]);
+
+        addVariantSearchValues({chrom: chrom, start: start, end: end});
+    };
+
+    const handleChange = (value) => {
 
     // handle position notation
-    if(value.includes(':')){
-      parsePosition(value)
-      setAutoCompleteOptions([])
-      return
-    }
+        if (value.includes(":")) {
+            parsePosition(value);
+            setAutoCompleteOptions([]);
+            return;
+        }
 
-    if (!value.length || !showAutoCompleteOptions){
-      return
-    }
+        if (!value.length || !showAutoCompleteOptions) {
+            return;
+        }
 
-    dispatch(performGohanGeneSearchIfPossible(value, assemblyId))
-  } 
+        dispatch(performGohanGeneSearchIfPossible(value, assemblyId));
+    };
 
-  const handleSelect = (value, options) => {
-    const locus = options.props?.locus
-    
+    const handleSelect = (value, options) => {
+        const locus = options.props?.locus;
+
     // may not need error checking here, since this is user selection, not user input
-    if (!locus){
-      return
-    }
+        if (!locus) {
+            return;
+        }
 
-    // don't use locus.assemblyId, since this is the lookup value 
-    const {chrom, start, end} = locus
-    addVariantSearchValues({chrom: chrom, start: start, end: end})
-  } 
+    // don't use locus.assemblyId, since this is the lookup value
+        const {chrom, start, end} = locus;
+        addVariantSearchValues({chrom: chrom, start: start, end: end});
+    };
 
-  useEffect(() => {
-    setAutoCompleteOptions((geneSearchResults ?? []).sort((a, b) => (a.name > b.name) ? 1 : -1))
-  }, [geneSearchResults])
-  
-  return (
+    useEffect(() => {
+        setAutoCompleteOptions((geneSearchResults ?? []).sort((a, b) => (a.name > b.name) ? 1 : -1));
+    }, [geneSearchResults]);
+
+    return (
     <AutoComplete
       options={autoCompleteOptions}
       onChange={handleChange}
@@ -79,7 +77,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
       // backfill={true}
     >
       {showAutoCompleteOptions &&
-        autoCompleteOptions.map((g, i) => (
+        autoCompleteOptions.map((g) => (
           <Option
             key={`${g.name}_${g.assemblyId}`}
             value={g.name}
@@ -89,7 +87,13 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
           >{geneDropdownText(g)}</Option>
         ))}
     </AutoComplete>
-  );
+    );
 };
+
+LocusSearch.propTypes = {
+    assemblyId: PropTypes.string,
+    addVariantSearchValues: PropTypes.func,
+};
+
 
 export default LocusSearch;

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -11,7 +11,7 @@ import { performGohanGeneSearchIfPossible } from "../../modules/discovery/action
 
 const { Option } = AutoComplete;
 
-const LocusSearch = ({assemblyId, setVariantSearchValues}) => {
+const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
   // const [input, setInput] = useState(""); //needed?
   const [autoCompleteOptions, setAutoCompleteOptions] = useState([])
   const geneSearchResults = useSelector((state) => state.discovery.geneNameSearchResponse);
@@ -44,7 +44,7 @@ const LocusSearch = ({assemblyId, setVariantSearchValues}) => {
     if (!locus){
       return
     }
-    setVariantSearchValues(locus)
+    addVariantSearchValues({...locus})
   } 
 
   useEffect(() => {

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -1,15 +1,11 @@
-import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { Input, Form, Select } from "antd";
-import DiscoverySearchCondition from "./DiscoverySearchCondition";
+import React, { useState } from "react";
+import { Form, Select } from "antd";
 import LocusSearch from "./LocusSearch";
 
 const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
 
   // or default to GRCh37?
   const [assemblyId, setAssemblyId] = useState(null)
-  const [variantGenotype, setVariantGenotype] = useState(null)
-
   const assemblySchema = dataType.schema?.properties?.assembly_id
   const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type
 
@@ -18,12 +14,21 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
   const wrapperCol = {lg: { span: 24 }, xl: { span: 20 }, xxl: { span: 18 }}
 
   const handleAssemblyIdChange = (value) => {
-    // temp: treat "Other" as equivalent to GRCh37
-    // requires fixes elsewhere in Bento
+
+    // temp workaround for bug in Bento back end:
+    // files ingested with GRCh37 reference need to be searched using assemblyId "Other"
+
+    // so if assembly is "Other", pass that value to the form, but use
+    // "GRCh37" as the reference for gene lookup in Gohan
+
+    let geneLookupValue = value
+
     if (value==="Other"){
-      value = "GRCh37"
+      geneLookupValue = "GRCh37"
     }
-    setAssemblyId(value)
+
+    addVariantSearchValues({assemblyId: value})
+    setAssemblyId(geneLookupValue) 
   }
 
   const handleGenotypeChange = (value) => {
@@ -32,7 +37,6 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
 
 // Select needs
 // style
-// onChange
 // getSearchValue ??
 
   return (<>

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -1,44 +1,45 @@
 import React, { useState } from "react";
 import { Form, Select } from "antd";
+import PropTypes from "prop-types";
 import LocusSearch from "./LocusSearch";
 
 const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
 
   // or default to GRCh37?
-  const [lookupAssemblyId, setLookupAssemblyId] = useState(null)
-  const assemblySchema = dataType.schema?.properties?.assembly_id
-  const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type
+    const [lookupAssemblyId, setLookupAssemblyId] = useState(null);
+    const assemblySchema = dataType.schema?.properties?.assembly_id;
+    const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type;
 
   // hardcoded style from DiscoverySearchForm, change to params
-  const labelCol = {lg: { span: 24 }, xl: { span: 4 }, xxl: { span: 3 }}
-  const wrapperCol = {lg: { span: 24 }, xl: { span: 20 }, xxl: { span: 18 }}
+    const labelCol = {lg: { span: 24 }, xl: { span: 4 }, xxl: { span: 3 }};
+    const wrapperCol = {lg: { span: 24 }, xl: { span: 20 }, xxl: { span: 18 }};
 
-  const handleAssemblyIdChange = (value) => {
+    const handleAssemblyIdChange = (value) => {
 
-    addVariantSearchValues({assemblyId: value})
+        addVariantSearchValues({assemblyId: value});
 
     // temp workaround for bug in Bento back end:
     // files ingested with GRCh37 reference need to be searched using assemblyId "Other"
 
     // so if assembly is "Other", pass that value to the form, but use
     // "GRCh37" as the reference for gene lookup in Gohan
-    if (value==="Other"){
-      setLookupAssemblyId("GRCh37") 
-      return
-    }
+        if (value === "Other") {
+            setLookupAssemblyId("GRCh37");
+            return;
+        }
 
-    setLookupAssemblyId(value) 
-  }
+        setLookupAssemblyId(value);
+    };
 
-  const handleGenotypeChange = (value) => {
-    addVariantSearchValues({genotype_type: value})
-  }
+    const handleGenotypeChange = (value) => {
+        addVariantSearchValues({genotypeType: value});
+    };
 
 // Select needs
 // style
 // getSearchValue ??
 
-  return (<>
+    return (<>
     <Form.Item
       labelCol={labelCol}
       wrapperCol={wrapperCol}
@@ -55,7 +56,7 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
         labelCol={labelCol}
         wrapperCol={wrapperCol}
         label={"Gene / position"}
-        help={`Enter gene name (eg "BRCA1") or position ("chr17:41195311-41278381")`}
+        help={"Enter gene name (eg \"BRCA1\") or position (\"chr17:41195311-41278381\")"}
     >
       <LocusSearch assemblyId={lookupAssemblyId} addVariantSearchValues={addVariantSearchValues} />
     </Form.Item>
@@ -72,7 +73,12 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
       </Select>
     </Form.Item>
     </>
-  );
+    );
+};
+
+VariantSearchHeader.propTypes = {
+    dataType: PropTypes.object,
+    addVariantSearchValues: PropTypes.func,
 };
 
 export default VariantSearchHeader;

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -21,14 +21,14 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
     // so if assembly is "Other", pass that value to the form, but use
     // "GRCh37" as the reference for gene lookup in Gohan
 
-    let geneLookupValue = value
+    let geneLookupAssembly = value
 
     if (value==="Other"){
-      geneLookupValue = "GRCh37"
+      geneLookupAssembly = "GRCh37"
     }
 
     addVariantSearchValues({assemblyId: value})
-    setAssemblyId(geneLookupValue) 
+    setAssemblyId(geneLookupAssembly) 
   }
 
   const handleGenotypeChange = (value) => {

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -4,10 +4,11 @@ import { Input, Form, Select } from "antd";
 import DiscoverySearchCondition from "./DiscoverySearchCondition";
 import LocusSearch from "./LocusSearch";
 
+const VariantSearchHeader = ({dataType, setVariantSearchValues}) => {
 
-const VariantSearchHeader = ({dataType}) => {
 
-  console.log({variant_header_dataType: dataType})
+  // default to GRCh37
+  const [assemblyId, setAssemblyId] = useState("GRCh37")
 
   const assemblySchema = dataType.schema?.properties?.assembly_id
   const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type
@@ -17,6 +18,24 @@ const VariantSearchHeader = ({dataType}) => {
   const labelCol = {lg: { span: 24 }, xl: { span: 4 }, xxl: { span: 3 }}
   const wrapperCol = {lg: { span: 24 }, xl: { span: 20 }, xxl: { span: 18 }}
 
+
+  const handleAssemblyIdChange = (value) => {
+    // temp: treat "Other" as equivalent to GRCh37
+    // requires fixes elsewhere in Bento
+    if (value==="Other"){
+      value = "GRCh37"
+    }
+
+    setAssemblyId(value)
+    console.log(`assembly change: ${value}`)
+  }
+
+// Select needs
+// style
+// onChange
+// getSearchValue ??
+
+
   return (<>
     <Form.Item
       labelCol={labelCol}
@@ -24,17 +43,19 @@ const VariantSearchHeader = ({dataType}) => {
       label={"Assembly ID"}
       help={assemblySchema.description}
     >
-      <Select>
+      <Select
+        onChange={handleAssemblyIdChange}
+      >
        {assemblySchema.enum.map(v => <Select.Option key={v} value={v}>{v}</Select.Option>)}
       </Select>
     </Form.Item>
     <Form.Item
         labelCol={labelCol}
         wrapperCol={wrapperCol}
-        label={"Locus search"}
+        label={"Locus"}
         help={`Enter gene name (eg "BRCA1") or position ("chr17:41195311-41278381")`}
     >
-      <LocusSearch/>
+      <LocusSearch assemblyId={assemblyId}/>
     </Form.Item>
     <Form.Item
       labelCol={labelCol}

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Input, Form, Select } from "antd";
+import DiscoverySearchCondition from "./DiscoverySearchCondition";
+import LocusSearch from "./LocusSearch";
+
+
+const VariantSearchHeader = ({dataType}) => {
+
+  console.log({variant_header_dataType: dataType})
+
+  const assemblySchema = dataType.schema?.properties?.assembly_id
+  const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type
+  console.log({assemblySchema:assemblySchema, genotypeSchema: genotypeSchema})
+
+  // hardcoded style from DiscoverySearchForm, change to params
+  const labelCol = {lg: { span: 24 }, xl: { span: 4 }, xxl: { span: 3 }}
+  const wrapperCol = {lg: { span: 24 }, xl: { span: 20 }, xxl: { span: 18 }}
+
+  return (<>
+    <Form.Item
+      labelCol={labelCol}
+      wrapperCol={wrapperCol}
+      label={"Assembly ID"}
+      help={assemblySchema.description}
+    >
+      <Select>
+       {assemblySchema.enum.map(v => <Select.Option key={v} value={v}>{v}</Select.Option>)}
+      </Select>
+    </Form.Item>
+    <Form.Item
+        labelCol={labelCol}
+        wrapperCol={wrapperCol}
+        label={"Locus search"}
+        help={`Enter gene name (eg "BRCA1") or position ("chr17:41195311-41278381")`}
+    >
+      <LocusSearch/>
+    </Form.Item>
+    <Form.Item
+      labelCol={labelCol}
+      wrapperCol={wrapperCol}
+      label={"Genotype"}
+      help={genotypeSchema.description}
+    >
+      <Select>
+       {genotypeSchema.enum.map(v => <Select.Option key={v} value={v}>{v}</Select.Option>)}
+      </Select>
+    </Form.Item>
+    </>
+  );
+};
+
+export default VariantSearchHeader;

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -5,7 +5,7 @@ import LocusSearch from "./LocusSearch";
 const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
 
   // or default to GRCh37?
-  const [assemblyId, setAssemblyId] = useState(null)
+  const [lookupAssemblyId, setLookupAssemblyId] = useState(null)
   const assemblySchema = dataType.schema?.properties?.assembly_id
   const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type
 
@@ -15,20 +15,19 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
 
   const handleAssemblyIdChange = (value) => {
 
+    addVariantSearchValues({assemblyId: value})
+
     // temp workaround for bug in Bento back end:
     // files ingested with GRCh37 reference need to be searched using assemblyId "Other"
 
     // so if assembly is "Other", pass that value to the form, but use
     // "GRCh37" as the reference for gene lookup in Gohan
-
-    let geneLookupAssembly = value
-
     if (value==="Other"){
-      geneLookupAssembly = "GRCh37"
+      setLookupAssemblyId("GRCh37") 
+      return
     }
 
-    addVariantSearchValues({assemblyId: value})
-    setAssemblyId(geneLookupAssembly) 
+    setLookupAssemblyId(value) 
   }
 
   const handleGenotypeChange = (value) => {
@@ -58,7 +57,7 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
         label={"Locus"}
         help={`Enter gene name (eg "BRCA1") or position ("chr17:41195311-41278381")`}
     >
-      <LocusSearch assemblyId={assemblyId} addVariantSearchValues={addVariantSearchValues} />
+      <LocusSearch assemblyId={lookupAssemblyId} addVariantSearchValues={addVariantSearchValues} />
     </Form.Item>
     <Form.Item
       labelCol={labelCol}

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -7,17 +7,15 @@ import LocusSearch from "./LocusSearch";
 const VariantSearchHeader = ({dataType, setVariantSearchValues}) => {
 
 
-  // default to GRCh37
-  const [assemblyId, setAssemblyId] = useState("GRCh37")
+  // or default to GRCh37?
+  const [assemblyId, setAssemblyId] = useState(null)
 
   const assemblySchema = dataType.schema?.properties?.assembly_id
   const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type
-  console.log({assemblySchema:assemblySchema, genotypeSchema: genotypeSchema})
 
   // hardcoded style from DiscoverySearchForm, change to params
   const labelCol = {lg: { span: 24 }, xl: { span: 4 }, xxl: { span: 3 }}
   const wrapperCol = {lg: { span: 24 }, xl: { span: 20 }, xxl: { span: 18 }}
-
 
   const handleAssemblyIdChange = (value) => {
     // temp: treat "Other" as equivalent to GRCh37
@@ -55,7 +53,7 @@ const VariantSearchHeader = ({dataType, setVariantSearchValues}) => {
         label={"Locus"}
         help={`Enter gene name (eg "BRCA1") or position ("chr17:41195311-41278381")`}
     >
-      <LocusSearch assemblyId={assemblyId}/>
+      <LocusSearch assemblyId={assemblyId} setVariantSearchValues={setVariantSearchValues} />
     </Form.Item>
     <Form.Item
       labelCol={labelCol}

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -4,11 +4,11 @@ import { Input, Form, Select } from "antd";
 import DiscoverySearchCondition from "./DiscoverySearchCondition";
 import LocusSearch from "./LocusSearch";
 
-const VariantSearchHeader = ({dataType, setVariantSearchValues}) => {
-
+const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
 
   // or default to GRCh37?
   const [assemblyId, setAssemblyId] = useState(null)
+  const [variantGenotype, setVariantGenotype] = useState(null)
 
   const assemblySchema = dataType.schema?.properties?.assembly_id
   const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type
@@ -23,16 +23,17 @@ const VariantSearchHeader = ({dataType, setVariantSearchValues}) => {
     if (value==="Other"){
       value = "GRCh37"
     }
-
     setAssemblyId(value)
-    console.log(`assembly change: ${value}`)
+  }
+
+  const handleGenotypeChange = (value) => {
+    addVariantSearchValues({genotype_type: value})
   }
 
 // Select needs
 // style
 // onChange
 // getSearchValue ??
-
 
   return (<>
     <Form.Item
@@ -53,7 +54,7 @@ const VariantSearchHeader = ({dataType, setVariantSearchValues}) => {
         label={"Locus"}
         help={`Enter gene name (eg "BRCA1") or position ("chr17:41195311-41278381")`}
     >
-      <LocusSearch assemblyId={assemblyId} setVariantSearchValues={setVariantSearchValues} />
+      <LocusSearch assemblyId={assemblyId} addVariantSearchValues={addVariantSearchValues} />
     </Form.Item>
     <Form.Item
       labelCol={labelCol}
@@ -61,7 +62,9 @@ const VariantSearchHeader = ({dataType, setVariantSearchValues}) => {
       label={"Genotype"}
       help={genotypeSchema.description}
     >
-      <Select>
+      <Select
+        onChange={handleGenotypeChange}
+      >
        {genotypeSchema.enum.map(v => <Select.Option key={v} value={v}>{v}</Select.Option>)}
       </Select>
     </Form.Item>

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -54,7 +54,7 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
     <Form.Item
         labelCol={labelCol}
         wrapperCol={wrapperCol}
-        label={"Locus"}
+        label={"Gene / position"}
         help={`Enter gene name (eg "BRCA1") or position ("chr17:41195311-41278381")`}
     >
       <LocusSearch assemblyId={lookupAssemblyId} addVariantSearchValues={addVariantSearchValues} />

--- a/src/modules/discovery/actions.js
+++ b/src/modules/discovery/actions.js
@@ -17,12 +17,26 @@ export const REMOVE_ALL_DATA_TYPE_QUERY_FORMS = "DISCOVERY.REMOVE_ALL_DATA_TYPE_
 
 export const UPDATE_JOIN_QUERY_FORM = "DISCOVERY.UPDATE_JOIN_QUERY_FORM";
 
+export const PERFORM_GOHAN_GENE_SEARCH = createNetworkActionTypes("GOHAN_GENE_SEARCH");
+
+export const performGohanGeneSearchIfPossible = (searchTerm) => (dispatch, getState) => {
+    const gohanUrl = getState()?.services?.gohan?.url
+    const bentoBaseUrl = `${getState().nodeInfo.data.CHORD_URL}`
+    const queryString = `/genes/search?term=${searchTerm}`
+    const searchUrl = gohanUrl ? `${gohanUrl}${queryString}` : `${bentoBaseUrl}api/gohan${queryString}`
+    dispatch(performGohanGeneSearch(searchUrl))
+}
+
+const performGohanGeneSearch = networkAction((searchUrl) => () => ({
+    types: PERFORM_GOHAN_GENE_SEARCH,
+    url: searchUrl,
+    err: "error performing Gohan gene search",
+}));
 
 export const selectSearch = searchIndex => ({
     type: SELECT_SEARCH,
     searchIndex,
 });
-
 
 const performSearch = networkAction((dataTypeQueries, joinQuery = null) => (dispatch, getState) => ({
     types: PERFORM_SEARCH,

--- a/src/modules/discovery/actions.js
+++ b/src/modules/discovery/actions.js
@@ -20,12 +20,12 @@ export const UPDATE_JOIN_QUERY_FORM = "DISCOVERY.UPDATE_JOIN_QUERY_FORM";
 export const PERFORM_GOHAN_GENE_SEARCH = createNetworkActionTypes("GOHAN_GENE_SEARCH");
 
 export const performGohanGeneSearchIfPossible = (searchTerm, assemblyId) => (dispatch, getState) => {
-    const gohanUrl = getState()?.services?.gohan?.url
-    const bentoBaseUrl = `${getState().nodeInfo.data.CHORD_URL}`
-    const queryString = `/genes/search?term=${searchTerm}&assemblyId=${assemblyId}`
-    const searchUrl = gohanUrl ? `${gohanUrl}${queryString}` : `${bentoBaseUrl}api/gohan${queryString}`
-    dispatch(performGohanGeneSearch(searchUrl))
-}
+    const gohanUrl = getState()?.services?.gohan?.url;
+    const bentoBaseUrl = `${getState().nodeInfo.data.CHORD_URL}`;
+    const queryString = `/genes/search?term=${searchTerm}&assemblyId=${assemblyId}`;
+    const searchUrl = gohanUrl ? `${gohanUrl}${queryString}` : `${bentoBaseUrl}api/gohan${queryString}`;
+    dispatch(performGohanGeneSearch(searchUrl));
+};
 
 const performGohanGeneSearch = networkAction((searchUrl) => () => ({
     types: PERFORM_GOHAN_GENE_SEARCH,

--- a/src/modules/discovery/actions.js
+++ b/src/modules/discovery/actions.js
@@ -19,10 +19,10 @@ export const UPDATE_JOIN_QUERY_FORM = "DISCOVERY.UPDATE_JOIN_QUERY_FORM";
 
 export const PERFORM_GOHAN_GENE_SEARCH = createNetworkActionTypes("GOHAN_GENE_SEARCH");
 
-export const performGohanGeneSearchIfPossible = (searchTerm) => (dispatch, getState) => {
+export const performGohanGeneSearchIfPossible = (searchTerm, assemblyId) => (dispatch, getState) => {
     const gohanUrl = getState()?.services?.gohan?.url
     const bentoBaseUrl = `${getState().nodeInfo.data.CHORD_URL}`
-    const queryString = `/genes/search?term=${searchTerm}`
+    const queryString = `/genes/search?term=${searchTerm}&assemblyId=${assemblyId}`
     const searchUrl = gohanUrl ? `${gohanUrl}${queryString}` : `${bentoBaseUrl}api/gohan${queryString}`
     dispatch(performGohanGeneSearch(searchUrl))
 }

--- a/src/modules/discovery/reducers.js
+++ b/src/modules/discovery/reducers.js
@@ -10,6 +10,8 @@ import {
     REMOVE_ALL_DATA_TYPE_QUERY_FORMS,
 
     UPDATE_JOIN_QUERY_FORM,
+
+    PERFORM_GOHAN_GENE_SEARCH,
 } from "./actions";
 
 import {
@@ -27,6 +29,8 @@ export const discovery = (
 
         searches: [],
         selectedSearch: null,
+
+        geneNameSearchResponse: {},
     },
     action
 ) => {
@@ -62,6 +66,12 @@ export const discovery = (
                 ...state,
                 joinFormValues: simpleDeepCopy(action.fields)  // TODO: Hack-y deep clone
             };
+
+        case PERFORM_GOHAN_GENE_SEARCH.RECEIVE:
+            return {
+                ...state,
+                geneNameSearchResponse: action.data.results
+            }
 
         default:
             return state;

--- a/src/modules/discovery/reducers.js
+++ b/src/modules/discovery/reducers.js
@@ -71,7 +71,7 @@ export const discovery = (
             return {
                 ...state,
                 geneNameSearchResponse: action.data.results
-            }
+            };
 
         default:
             return state;

--- a/src/modules/discovery/reducers.js
+++ b/src/modules/discovery/reducers.js
@@ -30,7 +30,7 @@ export const discovery = (
         searches: [],
         selectedSearch: null,
 
-        geneNameSearchResponse: {},
+        geneNameSearchResponse: [],
     },
     action
 ) => {


### PR DESCRIPTION
User-friendly variant search, with three labelled fields: "Assembly ID", "Gene / position", and "Genotype".

The "Gene / position" field does autocomplete lookups for gene symbols using Gohan API. It also handles position notation, eg: "chr17:41195311-41278381"

TODOS
- [ ] form validation
- [ ] error checking

