### PR TITLE
Improved "view summary" modal

### DIFF
--- a/src/components/OverviewContent.js
+++ b/src/components/OverviewContent.js
@@ -8,8 +8,7 @@ import OverviewSettingsControl from "./overview/OverviewSettingsControl";
 import { SITE_NAME } from "../constants";
 import ExperimentsSummary from "./overview/ExperimentsSummary";
 import { Modal, Button } from "antd";
-
-const DEFAULT_OTHER_THRESHOLD_PERCENTAGE = 4;
+import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../constants";
 
 class OverviewContent extends Component {
     constructor(props) {

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -146,7 +146,8 @@ class ExplorerDatasetSearch extends Component {
                         </Spin>
                     </div>
                 </Typography.Title>
-                {this.state.summaryModalVisible && <SearchSummaryModal searchResults={this.props.searchResults}
+                {this.state.summaryModalVisible &&
+                <SearchSummaryModal searchResults={this.props.searchResults}
                                     visible={this.state.summaryModalVisible}
                                     onCancel={() => this.setState({summaryModalVisible: false})} />}
                 <SearchTracksModal searchResults={this.props.searchResults}

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -146,9 +146,9 @@ class ExplorerDatasetSearch extends Component {
                         </Spin>
                     </div>
                 </Typography.Title>
-                <SearchSummaryModal searchResults={this.props.searchResults}
+                {this.state.summaryModalVisible && <SearchSummaryModal searchResults={this.props.searchResults}
                                     visible={this.state.summaryModalVisible}
-                                    onCancel={() => this.setState({summaryModalVisible: false})} />
+                                    onCancel={() => this.setState({summaryModalVisible: false})} />}
                 <SearchTracksModal searchResults={this.props.searchResults}
                                    visible={this.state.tracksModalVisible}
                                    onCancel={() => this.setState({tracksModalVisible: false})} />

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -19,9 +19,15 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
         return Object.keys(obj).map(k => ({"name": k, "value": obj[k]}));
     };
 
-    const histogramFormat = (ages) => {
-        return Object.keys(ages).map(age => {
-            return {ageBin: age, count: ageBinCounts[age]};
+    const histogramFormat = (ageCounts) => {
+
+        // only show age 110+ if present
+        if (!ageCounts[110]) {
+            delete ageCounts[110];
+        }
+
+        return Object.keys(ageCounts).map(age => {
+            return {ageBin: age, count: ageCounts[age]};
         });
     };
 

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -17,7 +17,28 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
 
     const pieChartFormat = (obj) => {
         return Object.keys(obj).map(k => ({"name": k, "value": obj[k]}));
-    }
+    };
+
+    const histogramFormat = (ages) => {
+        return Object.keys(ages).map(age => {
+            return {ageBin: age, count: ageBinCounts[age]};
+        });
+    };
+
+    const ageBinCounts = {
+        0: 0,
+        10: 0,
+        20: 0,
+        30: 0,
+        40: 0,
+        50: 0,
+        60: 0,
+        70: 0,
+        80: 0,
+        90: 0,
+        100: 0,
+        110: 0,
+    };
 
     // Individuals summary
     const numIndividualsBySex = Object.fromEntries(SEX_VALUES.map(v => [v, 0]));
@@ -41,6 +62,14 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
             numIndividualsBySex[r.individual.sex]++;
         }
 
+        if (r.individual.age) {
+            const {age, start, end} = r.individual.age;
+            if (age) {
+                const ageBin = 10 * Math.floor(parse(age).years / 10);
+                ageBinCounts[ageBin] += 1;
+            }
+        }
+
         (r.phenotypic_features || []).forEach(pf => {
             // TODO: Better ontology awareness - label vs id, translation, etc.
             numPhenoFeatsByType[pf.type.label] = (numPhenoFeatsByType[pf.type.label] || 0) + 1;
@@ -58,9 +87,9 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
             numSamplesByHistologicalDiagnosis[histDiagKey] = (numSamplesByHistologicalDiagnosis[histDiagKey] || 0) + 1;
         });
     });
-q
 
-    const sexPieChart = pieChartFormat(numIndividualsBySex)
+    const sexPieChartData = pieChartFormat(numIndividualsBySex);
+    const ageHistogramData = histogramFormat(ageBinCounts);
 
     return searchResults ? <Modal title="Search Results" {...props} width={960} footer={null}>
         <Row gutter={16}>
@@ -87,14 +116,22 @@ q
                 />
         <Divider />
 
-        {(sexPieChart.length > 0) ? <>
+        {(sexPieChartData.length > 0) ? <>
 
             <Typography.Title level={4}>Overview: Individuals</Typography.Title>
             <Row gutter={16}>
                 <Col span={12} style={{ textAlign: "center" }} >
                 <CustomPieChart
                   title="Sex"
-                  data={sexPieChart}
+                  data={sexPieChartData}
+                  chartHeight={CHART_HEIGHT}
+                  chartAspectRatio={CHART_ASPECT_RATIO}
+                />
+                </Col>
+                <Col span={12} style={{ textAlign: "center" }} >
+                <Histogram
+                  title="Ages"
+                  data={ageHistogramData}
                   chartHeight={CHART_HEIGHT}
                   chartAspectRatio={CHART_ASPECT_RATIO}
                 />

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -10,6 +10,7 @@ import {DEFAULT_OTHER_THRESHOLD_PERCENTAGE} from "../../constants";
 
 const CHART_HEIGHT = 300;
 const CHART_ASPECT_RATIO = 1.8;
+const MODAL_WIDTH = 1000;
 
 const SearchSummaryModal = ({searchResults, ...props}) => {
     const otherThresholdPercentage =
@@ -120,8 +121,8 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
     const experimentsByTypeData = mapNameValueFields(numExperimentsByType, thresholdProportion);
 
     return searchResults ? (
-      <Modal title="Search Results" {...props} width={960} footer={null}>
-        <Row gutter={16}>
+      <Modal title="Search Results" {...props} width={MODAL_WIDTH} footer={null} style={{padding: "10px"}}>
+        <Row gutter={16} style={{display: "flex", flexWrap: "wrap"}}>
           <Col span={7}>
             <Statistic title="Individuals" value={searchFormattedResults.length} />
           </Col>
@@ -140,7 +141,7 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
         <Divider />
           <>
             <Typography.Title level={4}>Individuals</Typography.Title>
-            <Row gutter={16}>
+            <Row gutter={[0, 16]}>
               {sexDataNonEmpty && <Col span={12} style={{ textAlign: "center" }}>
                 <CustomPieChart
                   title="Sex"
@@ -180,7 +181,7 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
             </Row>
             <Divider />
             <Typography.Title level={4}>Biosamples</Typography.Title>
-            <Row gutter={16}>
+            <Row gutter={[0, 16]}>
               {Boolean(biosamplesByTissueData.length) && (
                 <Col span={12} style={{ textAlign: "center" }}>
                   <CustomPieChart
@@ -204,7 +205,7 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
             </Row>
                 <Divider />
                 <Typography.Title level={4}>Experiments</Typography.Title>
-                <Row gutter={16}>
+                <Row gutter={[0, 16]}>
                 {Boolean(experimentsByTypeData.length) && (
                 <Col span={12} style={{ textAlign: "center" }}>
                   <CustomPieChart

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -107,6 +107,7 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
     });
 
     const sexPieChartData = mapNameValueFields(numIndividualsBySex, thresholdProportion);
+    const sexDataNonEmpty = sexPieChartData.some(s => s.value > 0);
     const ageHistogramData = histogramFormat(ageBinCounts);
     const histogramHasData = ageHistogramData.some(a => a.count > 0);
     const phenotypicFeaturesData = mapNameValueFields(numPhenoFeatsByType, thresholdProportion);
@@ -134,19 +135,17 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
           </Col>
         </Row>
         <Divider />
-
-        {sexPieChartData.length > 0 ? (
           <>
             <Typography.Title level={4}>Individuals</Typography.Title>
             <Row gutter={16}>
-              <Col span={12} style={{ textAlign: "center" }}>
+              {sexDataNonEmpty && <Col span={12} style={{ textAlign: "center" }}>
                 <CustomPieChart
                   title="Sex"
                   data={sexPieChartData}
                   chartHeight={CHART_HEIGHT}
                   chartAspectRatio={CHART_ASPECT_RATIO}
                 />
-              </Col>
+              </Col>}
               {Boolean(diseasesData.length) && (
                 <Col span={12} style={{ textAlign: "center" }}>
                   <CustomPieChart
@@ -215,7 +214,6 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
               )}
                 </Row>
           </>
-        ) : null}
       </Modal>
     ) : null;
 };

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -1,42 +1,10 @@
 import React from "react";
-
-import {parse, toSeconds} from "iso8601-duration";
-
+import {parse} from "iso8601-duration";
 import {Col, Divider, Modal, Row, Statistic, Typography} from "antd";
-
-import {VictoryAxis, VictoryBar, VictoryChart, VictoryHistogram, VictoryLabel, VictoryPie} from "victory";
-import VictoryPieWrapSVG from "../VictoryPieWrapSVG";
-
+import CustomPieChart from "../overview/CustomPieChart";
+import Histogram from "../overview/Histogram";
 import {KARYOTYPIC_SEX_VALUES, SEX_VALUES} from "../../dataTypes/phenopacket";
-import {
-    VICTORY_BAR_CONTAINER_PROPS,
-    VICTORY_BAR_PROPS,
-    VICTORY_BAR_TITLE_PROPS,
-    VICTORY_BAR_X_AXIS_PROPS,
-    VICTORY_HIST_CONTAINER_PROPS,
-    VICTORY_HIST_PROPS,
-    VICTORY_PIE_LABEL_PROPS,
-    VICTORY_PIE_PROPS,
-} from "../../styles/victory";
 import {explorerSearchResultsPropTypesShape} from "../../propTypes";
-
-
-const numObjectToVictoryArray = numObj => Object.entries(numObj)
-    .filter(e => e[1] > 0)
-    .map(([x, y]) => ({x, y}));
-
-
-// Bins of 10 years
-// TODO: Deal with start/end - for now, weight based on bin overlap?
-const AGE_HISTOGRAM_BINS = [...Array(10).keys()].map(i => i * 10);
-
-
-const ageAndDOBToApproxYears = (age, dob = null) => {
-    const parsedAge = parse(age);
-    const parsedAgeSeconds = toSeconds(parsedAge, dob);
-    // Convert # of seconds to "normalized" years TODO: Sketchy logic
-    return parsedAgeSeconds / (60 * 60 * 24 * 365.2422);
-};
 
 
 const SearchSummaryModal = ({searchResults, ...props}) => {

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -71,7 +71,11 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
             const {age} = r.individual.age;
             if (age) {
                 const ageBin = 10 * Math.floor(parse(age).years / 10);
-                ageBinCounts[ageBin] += 1;
+                if (ageBin < 0 || ageBin > 110) {
+                    console.error(`age out of range: ${age}`);
+                } else {
+                    ageBinCounts[ageBin] += 1;
+                }
             }
         }
 

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -108,6 +108,7 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
 
     const sexPieChartData = mapNameValueFields(numIndividualsBySex, thresholdProportion);
     const ageHistogramData = histogramFormat(ageBinCounts);
+    const histogramHasData = ageHistogramData.some(a => a.count > 0);
     const phenotypicFeaturesData = mapNameValueFields(numPhenoFeatsByType, thresholdProportion);
     const diseasesData = mapNameValueFields(numDiseasesByTerm, thresholdProportion);
     const biosamplesByTissueData = mapNameValueFields(numSamplesByTissue, thresholdProportion);
@@ -166,14 +167,14 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
                   />
                 </Col>
               )}
-              <Col span={12} style={{ textAlign: "center" }}>
+              {histogramHasData && <Col span={12} style={{ textAlign: "center" }}>
                 <Histogram
                   title="Ages"
                   data={ageHistogramData}
                   chartHeight={CHART_HEIGHT}
                   chartAspectRatio={CHART_ASPECT_RATIO}
                 />
-              </Col>
+              </Col>}
             </Row>
             <Divider />
             <Typography.Title level={4}>Biosamples</Typography.Title>

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -1,27 +1,27 @@
 import React from "react";
-import { useSelector } from "react-redux";
 import {parse} from "iso8601-duration";
 import {Col, Divider, Modal, Row, Statistic, Typography} from "antd";
 import CustomPieChart from "../overview/CustomPieChart";
 import Histogram from "../overview/Histogram";
-import {KARYOTYPIC_SEX_VALUES, SEX_VALUES} from "../../dataTypes/phenopacket";
+import {SEX_VALUES} from "../../dataTypes/phenopacket";
 import {explorerSearchResultsPropTypesShape} from "../../propTypes";
-import {mapNameValueFields} from "../../utils/mapNameValueFields"
-import {DEFAULT_OTHER_THRESHOLD_PERCENTAGE} from "../../constants"
+import {mapNameValueFields} from "../../utils/mapNameValueFields";
+import {DEFAULT_OTHER_THRESHOLD_PERCENTAGE} from "../../constants";
 
 const CHART_HEIGHT = 300;
 const CHART_ASPECT_RATIO = 1.8;
 
 const SearchSummaryModal = ({searchResults, ...props}) => {
-    const otherThresholdPercentage = JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE; 
-    const thresholdProportion = otherThresholdPercentage/100
+    const otherThresholdPercentage =
+      JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE;
+    const thresholdProportion = otherThresholdPercentage / 100;
     const searchFormattedResults = searchResults.searchFormattedResults || [];
 
     // this doesn't work, many searches incorrectly return all experiments instead of a subset
     // const experiments = searchResults?.results?.results?.experiment || [];
 
     // instead pull experiments from phenopackets
-    const experiments = searchFormattedResults.flatMap(r => r.experiments)
+    const experiments = searchFormattedResults.flatMap(r => r.experiments);
 
     const histogramFormat = (ageCounts) => {
         // only show age 110+ if present
@@ -63,8 +63,8 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
     const numSamplesByTissue = {};
     const numSamplesByHistologicalDiagnosis = {};
 
-    // Experiments summary 
-    const numExperimentsByType = {}
+    // Experiments summary
+    const numExperimentsByType = {};
 
     searchFormattedResults.forEach(r => {
         if (r.individual) {
@@ -113,8 +113,11 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
     const phenotypicFeaturesData = mapNameValueFields(numPhenoFeatsByType, thresholdProportion);
     const diseasesData = mapNameValueFields(numDiseasesByTerm, thresholdProportion);
     const biosamplesByTissueData = mapNameValueFields(numSamplesByTissue, thresholdProportion);
-    const biosamplesByHistologicalDiagnosisData = mapNameValueFields(numSamplesByHistologicalDiagnosis, thresholdProportion);
-    const experimentsByTypeData = mapNameValueFields(numExperimentsByType, thresholdProportion)
+    const biosamplesByHistologicalDiagnosisData = mapNameValueFields(
+        numSamplesByHistologicalDiagnosis,
+        thresholdProportion
+    );
+    const experimentsByTypeData = mapNameValueFields(numExperimentsByType, thresholdProportion);
 
     return searchResults ? (
       <Modal title="Search Results" {...props} width={960} footer={null}>
@@ -126,8 +129,8 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
             <Statistic
               title="Biosamples"
               value={searchFormattedResults
-                .map((i) => (i.biosamples || []).length)
-                .reduce((s, v) => s + v, 0)}
+                  .map((i) => (i.biosamples || []).length)
+                  .reduce((s, v) => s + v, 0)}
             />
           </Col>
           <Col span={7}>
@@ -211,7 +214,7 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
                     chartAspectRatio={CHART_ASPECT_RATIO}
                   />
                 </Col>
-              )}
+                )}
                 </Row>
           </>
       </Modal>

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -7,15 +7,20 @@ import {KARYOTYPIC_SEX_VALUES, SEX_VALUES} from "../../dataTypes/phenopacket";
 import {explorerSearchResultsPropTypesShape} from "../../propTypes";
 
 
-const SearchSummaryModal = ({searchResults, ...props}) => {
-    const searchFormattedResults = searchResults.searchFormattedResults || [];
+const CHART_HEIGHT = 300;
+const CHART_ASPECT_RATIO = 1.8;
 
-    console.log(searchFormattedResults);
+const SearchSummaryModal = ({searchResults, ...props}) => {
+
+    const searchFormattedResults = searchResults.searchFormattedResults || [];
+    const experiments = searchResults?.results?.results?.experiment || [];
+
+    const pieChartFormat = (obj) => {
+        return Object.keys(obj).map(k => ({"name": k, "value": obj[k]}));
+    }
 
     // Individuals summary
-
     const numIndividualsBySex = Object.fromEntries(SEX_VALUES.map(v => [v, 0]));
-    const numIndividualsByKaryotype = Object.fromEntries(KARYOTYPIC_SEX_VALUES.map(v => [v, 0]));
 
     // - Phenotypic features summary
     const numPhenoFeatsByType = {};
@@ -27,7 +32,6 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
     // TODO: More ontology aware
 
     const numSamplesByTissue = {};
-    const numSamplesByTaxonomy = {};
     const numSamplesByHistologicalDiagnosis = {};
 
     const ageAtCollectionHistogram = [];
@@ -35,7 +39,6 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
     searchFormattedResults.forEach(r => {
         if (r.individual) {
             numIndividualsBySex[r.individual.sex]++;
-            numIndividualsByKaryotype[r.individual.karyotypic_sex]++;
         }
 
         (r.phenotypic_features || []).forEach(pf => {
@@ -50,132 +53,55 @@ const SearchSummaryModal = ({searchResults, ...props}) => {
 
         (r.biosamples || []).forEach(b => {
             const tissueKey = (b.sampled_tissue || {}).label || "N/A";
-            const taxonomyKey = (b.taxonomy || {}).label || "N/A";
             const histDiagKey = (b.histological_diagnosis || {}).label || "N/A";
             numSamplesByTissue[tissueKey] = (numSamplesByTissue[tissueKey] || 0) + 1;
-            numSamplesByTaxonomy[taxonomyKey] = (numSamplesByTaxonomy[taxonomyKey] || 0) + 1;
             numSamplesByHistologicalDiagnosis[histDiagKey] = (numSamplesByHistologicalDiagnosis[histDiagKey] || 0) + 1;
-
-            if (b.individual_age_at_collection) {
-                let individualBirth = (r.individual || {}).date_of_birth;
-                if (individualBirth) {
-                    individualBirth = new Date(Date.parse(individualBirth));
-                }
-
-                const {age, start, end} = b.individual_age_at_collection;
-                if (age) {
-                    ageAtCollectionHistogram.push({x: ageAndDOBToApproxYears(age, individualBirth)});
-                } else if (start.age && end.age) {
-                    const startYears = ageAndDOBToApproxYears(start.age, individualBirth);
-                    const endYears = ageAndDOBToApproxYears(end.age, individualBirth);
-
-                    // Push average of years TODO: Better bin calculation?
-                    ageAtCollectionHistogram.push({x: (startYears + endYears) / 2});
-                }
-            }
         });
     });
+q
 
-    const individualsBySex = numObjectToVictoryArray(numIndividualsBySex);
-    const individualsByKaryotype = numObjectToVictoryArray(numIndividualsByKaryotype);
-    const phenoFeatsByType = numObjectToVictoryArray(numPhenoFeatsByType);
-    const diseasesByTerm = numObjectToVictoryArray(numDiseasesByTerm);
-    const samplesByTissue = numObjectToVictoryArray(numSamplesByTissue);
-    const samplesByTaxonomy = numObjectToVictoryArray(numSamplesByTaxonomy);
-
-    // TODO: Procedures: account for both code and (if specified) body_site
-    //  e.g. "Biopsy" or "Biopsy on X body site" - maybe stacked bar or grouped bar chart?
+    const sexPieChart = pieChartFormat(numIndividualsBySex)
 
     return searchResults ? <Modal title="Search Results" {...props} width={960} footer={null}>
         <Row gutter={16}>
-            <Col span={12}>
+            <Col span={7}>
                 <Statistic title="Individuals" value={searchFormattedResults.length} />
             </Col>
-            <Col span={12}>
+            <Col span={7}>
                 <Statistic title="Biosamples"
                            value={searchFormattedResults
                                .map(i => (i.biosamples || []).length)
                                .reduce((s, v) => s + v, 0)} />
             </Col>
+            <Col span={7}>
+            <Statistic title="Experiments" value={experiments.length} />
+            </Col>
+
         </Row>
-        {(individualsBySex.length > 0 && individualsByKaryotype.length > 0) ? <>
-            {/* TODO: Deduplicate with phenopacket summary */}
-            <Divider />
+        <Divider />
+        <CustomPieChart
+                  title="Diseases"
+                  data={[]}
+                  chartHeight={50}
+                  chartAspectRatio={4}
+                />
+        <Divider />
+
+        {(sexPieChart.length > 0) ? <>
+
             <Typography.Title level={4}>Overview: Individuals</Typography.Title>
             <Row gutter={16}>
-                <Col span={12}>
-                    <VictoryPieWrapSVG>
-                        <VictoryPie data={individualsBySex} {...VICTORY_PIE_PROPS} />
-                        <VictoryLabel text="SEX" {...VICTORY_PIE_LABEL_PROPS} />
-                    </VictoryPieWrapSVG>
-                </Col>
-                <Col span={12}>
-                    <VictoryPieWrapSVG>
-                        <VictoryPie data={individualsByKaryotype} {...VICTORY_PIE_PROPS} />
-                        <VictoryLabel text="KARYOTYPE" {...VICTORY_PIE_LABEL_PROPS} />
-                    </VictoryPieWrapSVG>
-                </Col>
-                <Col span={12}>
-                    <VictoryChart {...VICTORY_BAR_CONTAINER_PROPS}>
-                        <VictoryAxis {...VICTORY_BAR_X_AXIS_PROPS} />
-                        <VictoryBar data={diseasesByTerm} {...VICTORY_BAR_PROPS} />
-                        <VictoryLabel text="DISEASE" {...VICTORY_BAR_TITLE_PROPS} />
-                    </VictoryChart>
-                </Col>
-                <Col span={12}>
-                    <VictoryChart {...VICTORY_BAR_CONTAINER_PROPS}>
-                        <VictoryAxis {...VICTORY_BAR_X_AXIS_PROPS} />
-                        <VictoryBar data={phenoFeatsByType} {...VICTORY_BAR_PROPS} />
-                        <VictoryLabel text="PHENOTYPIC FEATURE" {...VICTORY_BAR_TITLE_PROPS} />
-                    </VictoryChart>
+                <Col span={12} style={{ textAlign: "center" }} >
+                <CustomPieChart
+                  title="Sex"
+                  data={sexPieChart}
+                  chartHeight={CHART_HEIGHT}
+                  chartAspectRatio={CHART_ASPECT_RATIO}
+                />
                 </Col>
             </Row>
         </> : null}
-        {samplesByTissue.length > 0 ? <>
-            {/* TODO: Deduplicate with phenopacket summary */}
-            <Divider />
-            <Typography.Title level={4}>Overview: Biosamples</Typography.Title>
-            <Row gutter={16}>
-                <Col span={12}>
-                    <VictoryPieWrapSVG>
-                        <VictoryPie data={samplesByTissue} {...VICTORY_PIE_PROPS} />
-                        <VictoryLabel text="TISSUE" {...VICTORY_PIE_LABEL_PROPS} />
-                    </VictoryPieWrapSVG>
-                </Col>
-                <Col span={12}>
-                    <VictoryPieWrapSVG>
-                        <VictoryPie data={samplesByTaxonomy} {...VICTORY_PIE_PROPS} />
-                        <VictoryLabel text="TAXONOMY" {...VICTORY_PIE_LABEL_PROPS} />
-                    </VictoryPieWrapSVG>
-                </Col>
-            </Row>
-            <Row gutter={16}>
-                <Col span={12}>
-                    <VictoryChart {...VICTORY_HIST_CONTAINER_PROPS}>
-                        <VictoryAxis tickValues={AGE_HISTOGRAM_BINS}
-                                     label="Age (Years)"
-                                     height={200}
-                                     style={{
-                                         axisLabel: {fontFamily: "monospace"},
-                                         tickLabels: {fontFamily: "monospace"}
-                                     }} />
-                        <VictoryAxis dependentAxis={true}
-                                     label="Count"
-                                     style={{
-                                         axisLabel: {fontFamily: "monospace"},
-                                         tickLabels: {fontFamily: "monospace"}
-                                     }} />
-                        <VictoryHistogram data={ageAtCollectionHistogram}
-                                          bins={AGE_HISTOGRAM_BINS}
-                                          {...VICTORY_HIST_PROPS} />
-                        <VictoryLabel text="AGE AT COLLECTION" {...VICTORY_BAR_TITLE_PROPS} />
-                    </VictoryChart>
-                </Col>
-                <Col span={12}>
-                    {/* TODO: histological_diagnosis pie chart */}
-                </Col>
-            </Row>
-        </> : null}
+
     </Modal> : null;
 };
 

--- a/src/components/overview/CustomPieChart.js
+++ b/src/components/overview/CustomPieChart.js
@@ -57,6 +57,10 @@ class CustomPieChart extends React.Component {
     onClick = (data) => {
         const { history, setAutoQueryPageTransition, autoQueryDataType } = this.props;
 
+        if (!setAutoQueryPageTransition) {
+            return;
+        }
+
         setAutoQueryPageTransition(
             window.location.href,
             autoQueryDataType,

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,3 +13,5 @@ export const FORM_MODE_EDIT = "edit";
 export const EM_DASH = "—";
 
 export const BENTO_BLUE = "#1990ff";
+
+export const DEFAULT_OTHER_THRESHOLD_PERCENTAGE = 4;


### PR DESCRIPTION
improved / repaired version of "View Summary" modal for visual overview of search results. Pie charts and histogram are now the same format as in the front page overview. 

- all charts are conditionally rendered (empty charts will not appear)
- Pie charts use the same "Other" threshold that can be set on the Overview page. 