### PR TITLE
improvements to "Other" pie chart category, plus bugfixes

### DIFF
--- a/src/components/OverviewContent.js
+++ b/src/components/OverviewContent.js
@@ -6,16 +6,10 @@ import ClinicalSummary from "./overview/ClinicalSummary";
 import VariantsSummary from "./overview/VariantsSummary";
 import { SITE_NAME } from "../constants";
 import ExperimentsSummary from "./overview/ExperimentsSummary";
-import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../constants";
 
 class OverviewContent extends Component {
     constructor(props) {
         super(props);
-        const threshold =
-      JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE;
-        this.state = {
-            otherThresholdPercentage: threshold,
-        };
     }
 
     componentDidMount() {

--- a/src/components/OverviewContent.js
+++ b/src/components/OverviewContent.js
@@ -37,9 +37,9 @@ class OverviewContent extends Component {
         </div>
         <Layout>
           <Layout.Content style={{ background: "white", padding: "32px 24px 4px" }}>
-            <ClinicalSummary otherThresholdPercentage={this.state.otherThresholdPercentage} />
+            <ClinicalSummary  />
             <Divider />
-            <ExperimentsSummary otherThresholdPercentage={this.state.otherThresholdPercentage} />
+            <ExperimentsSummary />
             <Divider />
             <VariantsSummary />
           </Layout.Content>

--- a/src/components/OverviewContent.js
+++ b/src/components/OverviewContent.js
@@ -6,7 +6,6 @@ import ClinicalSummary from "./overview/ClinicalSummary";
 import VariantsSummary from "./overview/VariantsSummary";
 import { SITE_NAME } from "../constants";
 import ExperimentsSummary from "./overview/ExperimentsSummary";
-import { Button } from "antd";
 import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../constants";
 
 class OverviewContent extends Component {
@@ -35,13 +34,6 @@ class OverviewContent extends Component {
           }}
         >
           <SitePageHeader title="Overview" style={{ border: "none" }} />
-          <Button
-            type="button"
-            icon="setting"
-            size={"small"}
-            style={{ alignSelf: "center", marginRight: "25px" }}
-            onClick={this.openModal}
-          />
         </div>
         <Layout>
           <Layout.Content style={{ background: "white", padding: "32px 24px 4px" }}>

--- a/src/components/OverviewContent.js
+++ b/src/components/OverviewContent.js
@@ -1,97 +1,57 @@
-import React, {Component} from "react";
-import {Layout, Divider} from "antd";
+import React, { Component } from "react";
+import { Layout, Divider } from "antd";
 
 import SitePageHeader from "./SitePageHeader";
 import ClinicalSummary from "./overview/ClinicalSummary";
 import VariantsSummary from "./overview/VariantsSummary";
-import OverviewSettingsControl from "./overview/OverviewSettingsControl";
 import { SITE_NAME } from "../constants";
 import ExperimentsSummary from "./overview/ExperimentsSummary";
-import { Modal, Button } from "antd";
+import { Button } from "antd";
 import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../constants";
 
 class OverviewContent extends Component {
     constructor(props) {
         super(props);
-        const startThreshold =
-          JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE;
+        const threshold =
+      JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE;
         this.state = {
-            otherThresholdPercentage: startThreshold,
-            previousThresholdPercentage: startThreshold,
-            modalVisible: false,
+            otherThresholdPercentage: threshold,
         };
-        this.setOtherThresholdPercentage = this.setOtherThresholdPercentage.bind(this);
-        this.openModal = this.openModal.bind(this);
-        this.setValueAndCloseModal = this.setValueAndCloseModal.bind(this);
-        this.cancelModal = this.cancelModal.bind(this);
     }
 
     componentDidMount() {
         document.title = `${SITE_NAME} - Overview`;
     }
 
-    setOtherThresholdPercentage(value) {
-        this.setState({otherThresholdPercentage: value});
-    }
-
-    openModal() {
-        this.setState({modalVisible: true});
-        // save threshold in case user cancels
-        this.setState({previousThresholdPercentage: this.state.otherThresholdPercentage});
-    }
-
-    setValueAndCloseModal() {
-        localStorage.setItem("otherThresholdPercentage", JSON.stringify(this.state.otherThresholdPercentage) );
-        this.setState({modalVisible: false});
-    }
-
-    cancelModal() {
-        this.setState({modalVisible: false});
-        this.setState({otherThresholdPercentage: this.state.previousThresholdPercentage});
-    }
-
     render() {
         return (
             <>
-            <div
-              style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  background: "white",
-                  borderBottom: "1px solid rgb(232, 232, 232)",
-              }}
-            >
-              <SitePageHeader title="Overview" style={{ border: "none" }} />
-              <Button
-                type="button"
-                icon="setting"
-                size={"small"}
-                style={{ alignSelf: "center", marginRight: "25px" }}
-                onClick={this.openModal}
-              />
-            </div>
-            <Modal
-              visible={this.state.modalVisible}
-              closable={false}
-              destroyOnClose={true}
-              onOk={this.setValueAndCloseModal}
-              onCancel={this.cancelModal}
-            >
-              <OverviewSettingsControl
-                otherThresholdPercentage={this.state.otherThresholdPercentage}
-                setOtherThresholdPercentage={this.setOtherThresholdPercentage}
-                setValueAndCloseModal={this.setValueAndCloseModal}
-              />
-            </Modal>
-            <Layout>
-              <Layout.Content style={{ background: "white", padding: "32px 24px 4px" }}>
-                <ClinicalSummary otherThresholdPercentage={this.state.otherThresholdPercentage} />
-                <Divider />
-                <ExperimentsSummary otherThresholdPercentage={this.state.otherThresholdPercentage} />
-                <Divider />
-                <VariantsSummary />
-              </Layout.Content>
-            </Layout>
+        <div
+          style={{
+              display: "flex",
+              justifyContent: "space-between",
+              background: "white",
+              borderBottom: "1px solid rgb(232, 232, 232)",
+          }}
+        >
+          <SitePageHeader title="Overview" style={{ border: "none" }} />
+          <Button
+            type="button"
+            icon="setting"
+            size={"small"}
+            style={{ alignSelf: "center", marginRight: "25px" }}
+            onClick={this.openModal}
+          />
+        </div>
+        <Layout>
+          <Layout.Content style={{ background: "white", padding: "32px 24px 4px" }}>
+            <ClinicalSummary otherThresholdPercentage={this.state.otherThresholdPercentage} />
+            <Divider />
+            <ExperimentsSummary otherThresholdPercentage={this.state.otherThresholdPercentage} />
+            <Divider />
+            <VariantsSummary />
+          </Layout.Content>
+        </Layout>
             </>
         );
     }

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Link, withRouter } from "react-router-dom";
 import PropTypes from "prop-types";
-import { Badge, Icon, Layout, Menu, Modal } from "antd";
+import { Badge, Icon, Layout, Menu } from "antd";
 
 import { showNotificationDrawer } from "../modules/notifications/actions";
 import { SIGN_OUT_URL } from "../constants";
@@ -11,45 +11,23 @@ import { BASE_PATH, signInURLWithRedirect, withBasePath } from "../utils/url";
 import { nodeInfoDataPropTypesShape, notificationPropTypesShape, userPropTypesShape } from "../propTypes";
 import logo from "../images/logo.png";
 import OverviewSettingsControl from "./overview/OverviewSettingsControl";
-import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../constants";
 
 const customHeader = process.env.CUSTOM_HEADER ?? "";
 
 class SiteHeader extends Component {
     constructor() {
         super();
-        const startThreshold =
-      JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE;
+
         this.state = {
-            current: "mail",
-            otherThresholdPercentage: startThreshold,
-            previousThresholdPercentage: startThreshold,
-            modalVisible: false,
+            modalVisible: false
         };
-        this.setOtherThresholdPercentage = this.setOtherThresholdPercentage.bind(this);
-        this.openModal = this.openModal.bind(this);
-        this.setValueAndCloseModal = this.setValueAndCloseModal.bind(this);
-        this.cancelModal = this.cancelModal.bind(this);
+        this.toggleModalVisibility = this.toggleModalVisibility.bind(this);
     }
 
-    setOtherThresholdPercentage(value) {
-        this.setState({ otherThresholdPercentage: value });
-    }
-
-    openModal() {
-        this.setState({ modalVisible: true });
-    // save threshold in case user cancels
-        this.setState({ previousThresholdPercentage: this.state.otherThresholdPercentage });
-    }
-
-    setValueAndCloseModal() {
-        localStorage.setItem("otherThresholdPercentage", JSON.stringify(this.state.otherThresholdPercentage));
-        this.setState({ modalVisible: false });
-    }
-
-    cancelModal() {
-        this.setState({ modalVisible: false });
-        this.setState({ otherThresholdPercentage: this.state.previousThresholdPercentage });
+    toggleModalVisibility() {
+        this.setState({
+            modalVisible: !this.state.modalVisible
+        });
     }
 
     render() {
@@ -154,51 +132,42 @@ class SiteHeader extends Component {
                 style: { float: "right" },
                 icon: <Icon type="setting" />,
                 text: <span className="nav-text">Settings</span>,
-                onClick: this.openModal,
+                onClick: this.toggleModalVisibility,                //xxxxxxxxx
                 key: "settings",
             },
         ];
 
         return (
             <>
-        <Layout.Header>
-          <Link to={BASE_PATH}>
-            <div
-              style={{
-                  margin: "0 15px 0 0",
-                  float: "left",
-              }}
-            >
-              <img style={{ height: "35px" }} src={logo} alt="logo" />
-            </div>
-          </Link>
-          {customHeader && (
-            <h3 style={{ color: "rgba(255, 255, 255, 0.95)", float: "left", margin: "0 10px 0 -10px" }}>
-              {customHeader}
-            </h3>
-          )}
-          <Menu
-            theme="dark"
-            mode="horizontal"
-            selectedKeys={matchingMenuKeys(menuItems)}
-            style={{ lineHeight: "64px" }}
-          >
-            {menuItems.map((i) => renderMenuItem(i))}
-          </Menu>
-        </Layout.Header>
-        <Modal
-          visible={this.state.modalVisible}
-          closable={false}
-          destroyOnClose={true}
-          onOk={this.setValueAndCloseModal}
-          onCancel={this.cancelModal}
-        >
-          <OverviewSettingsControl
-            otherThresholdPercentage={this.state.otherThresholdPercentage}
-            setOtherThresholdPercentage={this.setOtherThresholdPercentage}
-            setValueAndCloseModal={this.setValueAndCloseModal}
-          />
-        </Modal>
+            <Layout.Header>
+              <Link to={BASE_PATH}>
+                <div
+                  style={{
+                      margin: "0 15px 0 0",
+                      float: "left",
+                  }}
+                >
+                  <img style={{ height: "35px" }} src={logo} alt="logo" />
+                </div>
+              </Link>
+              {customHeader && (
+                <h3 style={{ color: "rgba(255, 255, 255, 0.95)", float: "left", margin: "0 10px 0 -10px" }}>
+                  {customHeader}
+                </h3>
+              )}
+              <Menu
+                theme="dark"
+                mode="horizontal"
+                selectedKeys={matchingMenuKeys(menuItems)}
+                style={{ lineHeight: "64px" }}
+              >
+                {menuItems.map((i) => renderMenuItem(i))}
+              </Menu>
+            </Layout.Header>
+            <OverviewSettingsControl
+              modalVisible={this.state.modalVisible}
+              toggleModalVisibility={this.toggleModalVisibility}
+            />
             </>
         );
     }
@@ -221,4 +190,4 @@ const mapStateToProps = (state) => ({
     isOwner: (state.auth.user || {}).chord_user_role === "owner",
 });
 
-export default withRouter(connect(mapStateToProps, { showNotificationDrawer })(SiteHeader));
+export default withRouter(connect(mapStateToProps, { showNotificationDrawer, })(SiteHeader));

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -1,27 +1,55 @@
-import React, {Component} from "react";
-import {connect} from "react-redux";
-import {Link, withRouter} from "react-router-dom";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Link, withRouter } from "react-router-dom";
 import PropTypes from "prop-types";
+import { Badge, Icon, Layout, Menu, Modal } from "antd";
 
-import {Badge, Icon, Layout, Menu} from "antd";
-
-
-import {showNotificationDrawer} from "../modules/notifications/actions";
-
-import {SIGN_OUT_URL} from "../constants";
-import {matchingMenuKeys, renderMenuItem} from "../utils/menu";
-import {BASE_PATH, signInURLWithRedirect, withBasePath} from "../utils/url";
-import {nodeInfoDataPropTypesShape, notificationPropTypesShape, userPropTypesShape} from "../propTypes";
+import { showNotificationDrawer } from "../modules/notifications/actions";
+import { SIGN_OUT_URL } from "../constants";
+import { matchingMenuKeys, renderMenuItem } from "../utils/menu";
+import { BASE_PATH, signInURLWithRedirect, withBasePath } from "../utils/url";
+import { nodeInfoDataPropTypesShape, notificationPropTypesShape, userPropTypesShape } from "../propTypes";
 import logo from "../images/logo.png";
+import OverviewSettingsControl from "./overview/OverviewSettingsControl";
+import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../constants";
 
 const customHeader = process.env.CUSTOM_HEADER ?? "";
 
 class SiteHeader extends Component {
     constructor() {
         super();
+        const startThreshold =
+      JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE;
         this.state = {
             current: "mail",
+            otherThresholdPercentage: startThreshold,
+            previousThresholdPercentage: startThreshold,
+            modalVisible: false,
         };
+        this.setOtherThresholdPercentage = this.setOtherThresholdPercentage.bind(this);
+        this.openModal = this.openModal.bind(this);
+        this.setValueAndCloseModal = this.setValueAndCloseModal.bind(this);
+        this.cancelModal = this.cancelModal.bind(this);
+    }
+
+    setOtherThresholdPercentage(value) {
+        this.setState({ otherThresholdPercentage: value });
+    }
+
+    openModal() {
+        this.setState({ modalVisible: true });
+    // save threshold in case user cancels
+        this.setState({ previousThresholdPercentage: this.state.otherThresholdPercentage });
+    }
+
+    setValueAndCloseModal() {
+        localStorage.setItem("otherThresholdPercentage", JSON.stringify(this.state.otherThresholdPercentage));
+        this.setState({ modalVisible: false });
+    }
+
+    cancelModal() {
+        this.setState({ modalVisible: false });
+        this.setState({ otherThresholdPercentage: this.state.previousThresholdPercentage });
     }
 
     render() {
@@ -30,108 +58,151 @@ class SiteHeader extends Component {
                 url: withBasePath("overview"),
                 icon: <Icon type="user" />,
                 text: <span className="nav-text">Overview</span>,
+                key: "overview",
             },
             {
                 url: withBasePath("data/sets"),
                 icon: <Icon type="file-search" />,
                 text: <span className="nav-text">Datasets</span>,
+                key: "datasets",
             },
             {
                 url: withBasePath("data/explorer"),
                 icon: <Icon type="bar-chart" />,
                 text: <span className="nav-text">Explorer</span>,
                 disabled: !this.props.isOwner,
+                key: "explorer",
             },
             {
                 url: withBasePath("admin"),
                 icon: <Icon type="user" />,
-                text:  <span className="nav-text">Admin</span>,
+                text: <span className="nav-text">Admin</span>,
                 disabled: !this.props.isOwner,
-                children: [{
-                    key: "admin-services",
-                    url: withBasePath("admin/services"),
-                    icon: <Icon type="dashboard" />,
-                    text: <span className="nav-text">Services</span>,
-                    disabled: !this.props.isOwner,
-                },{
-                    key: "admin-data-manager",
-                    url: withBasePath("admin/data/manager"),
-                    icon: <Icon type="folder-open" />,
-                    text: <span className="nav-text">Data Manager</span>,
-                    disabled: !this.props.isOwner,
-                },{
-                    key: "admin-peers",
-                    url: withBasePath("admin/peers"),
-                    icon: <Icon type="apartment" />,
-                    text: <span className="nav-text">Peers</span>,
-                    disabled: !this.props.isOwner,
-                },]
+                children: [
+                    {
+                        key: "admin-services",
+                        url: withBasePath("admin/services"),
+                        icon: <Icon type="dashboard" />,
+                        text: <span className="nav-text">Services</span>,
+                        disabled: !this.props.isOwner,
+                    },
+                    {
+                        key: "admin-data-manager",
+                        url: withBasePath("admin/data/manager"),
+                        icon: <Icon type="folder-open" />,
+                        text: <span className="nav-text">Data Manager</span>,
+                        disabled: !this.props.isOwner,
+                    },
+                    {
+                        key: "admin-peers",
+                        url: withBasePath("admin/peers"),
+                        icon: <Icon type="apartment" />,
+                        text: <span className="nav-text">Peers</span>,
+                        disabled: !this.props.isOwner,
+                    },
+                ],
             },
-            ...(this.props.user ? [{
-                key: "user-menu",
-                style: {float: "right"},
-                icon: <Icon type="user" />,
-                text: this.props.user.preferred_username,
-                children: [{
-                    key: "sign-out-link",
-                    onClick: () => window.location.href = withBasePath(SIGN_OUT_URL),
-                    icon: <Icon type="logout" />,
-                    text: <span className="nav-text">Sign Out</span>,
-                }]
-            }] : [{
-                key: "sign-in",
-                style: {float: "right"},
-                icon: <Icon type="login" />,
-                text: <span className="nav-text">{this.props.authHasAttempted ? "Sign In" : "Loading..."}</span>,
-                onClick: () => window.location.href = signInURLWithRedirect(),
-            }]),
+            ...(this.props.user
+                ? [
+                    {
+                        key: "user-menu",
+                        style: { float: "right" },
+                        icon: <Icon type="user" />,
+                        text: this.props.user.preferred_username,
+                        children: [
+                            {
+                                key: "sign-out-link",
+                                onClick: () => (window.location.href = withBasePath(SIGN_OUT_URL)),
+                                icon: <Icon type="logout" />,
+                                text: <span className="nav-text">Sign Out</span>,
+                            },
+                        ],
+                    },
+                ]
+                : [
+                    {
+                        key: "sign-in",
+                        style: { float: "right" },
+                        icon: <Icon type="login" />,
+                        text: (
+                <span className="nav-text">{this.props.authHasAttempted ? "Sign In" : "Loading..."}</span>
+                        ),
+                        onClick: () => (window.location.href = signInURLWithRedirect()),
+                    },
+                ]),
             {
                 url: withBasePath("notifications"),
-                style: {float: "right"},
+                style: { float: "right" },
                 disabled: !this.props.isOwner,
-                icon: <Badge dot count={this.props.unreadNotifications.length}>
-                    <Icon type="bell" style={{marginRight: "0"}}/>
-                </Badge>,
-                text: <span className="nav-text" style={{marginLeft: "10px"}}>
-                    Notifications
-                    {this.props.unreadNotifications.length > 0 ? (
-                        <span> ({this.props.unreadNotifications.length})</span>
-                    ) : null}
-                </span>,
+                icon: (
+          <Badge dot count={this.props.unreadNotifications.length}>
+            <Icon type="bell" style={{ marginRight: "0" }} />
+          </Badge>
+                ),
+                text: (
+          <span className="nav-text" style={{ marginLeft: "10px" }}>
+            Notifications
+            {this.props.unreadNotifications.length > 0 ? (
+              <span> ({this.props.unreadNotifications.length})</span>
+            ) : null}
+          </span>
+                ),
                 onClick: () => this.props.showNotificationDrawer(),
-            }
+                key: "notifications",
+            },
+            {
+                style: { float: "right" },
+                icon: <Icon type="setting" />,
+                text: <span className="nav-text">Settings</span>,
+                onClick: this.openModal,
+                key: "settings",
+            },
         ];
 
         return (
-          <Layout.Header>
-            <Link to={BASE_PATH}>
-              <div
-                style={{
-                    margin: "0 15px 0 0",
-                    float: "left",
-                }}
-              >
-                <img style={{ height: "35px" }} src={logo} alt="logo" />
-              </div>
-            </Link>
-            {customHeader && (
-              <h3 style={{ color: "rgba(255, 255, 255, 0.95)", float: "left", margin: "0 10px 0 -10px" }}>
-                {customHeader}
-              </h3>
-            )}
-            <Menu
-              theme="dark"
-              mode="horizontal"
-              selectedKeys={matchingMenuKeys(menuItems)}
-              style={{ lineHeight: "64px" }}
+            <>
+        <Layout.Header>
+          <Link to={BASE_PATH}>
+            <div
+              style={{
+                  margin: "0 15px 0 0",
+                  float: "left",
+              }}
             >
-              {menuItems.map((i) => renderMenuItem(i))}
-            </Menu>
-          </Layout.Header>
+              <img style={{ height: "35px" }} src={logo} alt="logo" />
+            </div>
+          </Link>
+          {customHeader && (
+            <h3 style={{ color: "rgba(255, 255, 255, 0.95)", float: "left", margin: "0 10px 0 -10px" }}>
+              {customHeader}
+            </h3>
+          )}
+          <Menu
+            theme="dark"
+            mode="horizontal"
+            selectedKeys={matchingMenuKeys(menuItems)}
+            style={{ lineHeight: "64px" }}
+          >
+            {menuItems.map((i) => renderMenuItem(i))}
+          </Menu>
+        </Layout.Header>
+        <Modal
+          visible={this.state.modalVisible}
+          closable={false}
+          destroyOnClose={true}
+          onOk={this.setValueAndCloseModal}
+          onCancel={this.cancelModal}
+        >
+          <OverviewSettingsControl
+            otherThresholdPercentage={this.state.otherThresholdPercentage}
+            setOtherThresholdPercentage={this.setOtherThresholdPercentage}
+            setValueAndCloseModal={this.setValueAndCloseModal}
+          />
+        </Modal>
+            </>
         );
     }
 }
-
 
 SiteHeader.propTypes = {
     nodeInfo: nodeInfoDataPropTypesShape,
@@ -139,16 +210,15 @@ SiteHeader.propTypes = {
     user: userPropTypesShape,
     authHasAttempted: PropTypes.bool,
     isOwner: PropTypes.bool,
-
     showNotificationDrawer: PropTypes.func,
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
     nodeInfo: state.nodeInfo.data,
-    unreadNotifications: state.notifications.items.filter(n => !n.read),
+    unreadNotifications: state.notifications.items.filter((n) => !n.read),
     user: state.auth.user,
     authHasAttempted: state.auth.hasAttempted,
-    isOwner: (state.auth.user || {}).chord_user_role === "owner"
+    isOwner: (state.auth.user || {}).chord_user_role === "owner",
 });
 
-export default withRouter(connect(mapStateToProps, {showNotificationDrawer})(SiteHeader));
+export default withRouter(connect(mapStateToProps, { showNotificationDrawer })(SiteHeader));

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -3,7 +3,6 @@ import { connect } from "react-redux";
 import { Link, withRouter } from "react-router-dom";
 import PropTypes from "prop-types";
 import { Badge, Icon, Layout, Menu } from "antd";
-
 import { showNotificationDrawer } from "../modules/notifications/actions";
 import { SIGN_OUT_URL } from "../constants";
 import { matchingMenuKeys, renderMenuItem } from "../utils/menu";
@@ -132,7 +131,7 @@ class SiteHeader extends Component {
                 style: { float: "right" },
                 icon: <Icon type="setting" />,
                 text: <span className="nav-text">Settings</span>,
-                onClick: this.toggleModalVisibility,                //xxxxxxxxx
+                onClick: this.toggleModalVisibility,
                 key: "settings",
             },
         ];

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -130,6 +130,7 @@ class DiscoveryQueryBuilder extends Component {
             <Menu onClick={this.handleAddDataTypeQueryForm}>
                 {this.props.servicesInfo
                     .filter(s => (this.props.dataTypes[s.id]?.items ?? []).length)
+                    .filter(s => s.name !== "Bento Variant Service")
                     .flatMap(s =>
                         this.props.dataTypes[s.id].items.map(dt =>
                             <Menu.Item key={`${s.id}:${dt.id}`}>{dt.id}</Menu.Item>

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -115,7 +115,7 @@ const IndividualExperiments = ({ individual }) => {
         <div className="experiment_and_results" id={e.biosample} key={e.id}>
           <div className="experiment-titles">
             <Typography.Text style={titleStyle}>
-              {`${e.experiment_type} (Biosample ${e.biosample})`}{" "}
+              {`${e.experiment_type} (Biosample ${e.biosample})`}
             </Typography.Text>
           </div>
           <div className="experiment_summary">
@@ -186,7 +186,6 @@ const IndividualExperiments = ({ individual }) => {
           </div>
           <div className="experiment-titles">
             <Typography.Text style={titleStyle} level={4}>
-              {" "}
               {`${e.experiment_type} - Results`}
             </Typography.Text>
           </div>

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -11,7 +11,7 @@ import { guessFileType } from "../../utils/guessFileType";
 
 const IndividualExperiments = ({ individual }) => {
     const titleStyle = { fontSize: "16px", fontWeight: "bold", color: BENTO_BLUE };
-    const blankExperimentOntology = [{id: EM_DASH, label: EM_DASH}];
+    const blankExperimentOntology = [{ id: EM_DASH, label: EM_DASH }];
 
     const downloadUrls = useSelector((state) => state.drs.downloadUrlsByFilename);
     const dispatch = useDispatch();
@@ -77,7 +77,7 @@ const IndividualExperiments = ({ individual }) => {
             title: "Download",
             key: "download",
             align: "center",
-            render: (_, result) => renderDownloadButton(result)
+            render: (_, result) => renderDownloadButton(result),
         },
         {
             title: "Other Details",
@@ -89,139 +89,120 @@ const IndividualExperiments = ({ individual }) => {
           title={`Experiment Results: ${result.file_format}`}
           content={
             <div className="other-details">
-          <Descriptions
-            layout="horizontal"
-            bordered={true}
-            colon={false}
-            column={1}
-            size="small"
-          >
-            <Descriptions.Item label="identifier">{result.identifier}</Descriptions.Item>
-            <Descriptions.Item label="description">{result.description}</Descriptions.Item>
-            <Descriptions.Item label="filename">{result.filename}</Descriptions.Item>
-            <Descriptions.Item label="file format">{result.file_format}</Descriptions.Item>
-            <Descriptions.Item label="data output type">{result.data_output_type}</Descriptions.Item>
-            <Descriptions.Item label="usage">{result.usage}</Descriptions.Item>
-            <Descriptions.Item label="creation date">{result.creation_date}</Descriptions.Item>
-            <Descriptions.Item label="created by">{result.created_by}</Descriptions.Item>
-            </Descriptions>
+              <Descriptions layout="horizontal" bordered={true} colon={false} column={1} size="small">
+                <Descriptions.Item label="identifier">{result.identifier}</Descriptions.Item>
+                <Descriptions.Item label="description">{result.description}</Descriptions.Item>
+                <Descriptions.Item label="filename">{result.filename}</Descriptions.Item>
+                <Descriptions.Item label="file format">{result.file_format}</Descriptions.Item>
+                <Descriptions.Item label="data output type">{result.data_output_type}</Descriptions.Item>
+                <Descriptions.Item label="usage">{result.usage}</Descriptions.Item>
+                <Descriptions.Item label="creation date">{result.creation_date}</Descriptions.Item>
+                <Descriptions.Item label="created by">{result.created_by}</Descriptions.Item>
+              </Descriptions>
             </div>
-            }
+          }
           trigger="click"
         >
-         <Button> click here </Button>
+          <Button> click here </Button>
         </Popover>
             ),
         },
     ];
 
-
     return (
         <>
-{experimentsData.map((e, i) => (
-  <div className="experiment_and_results" id={e.biosample} key={e.id}>
-    <div className="experiment-titles">
-    <Typography.Text
-      style={titleStyle}
-    >
-      {`${e.experiment_type} (Biosample ${e.biosample})`}{" "}
-    </Typography.Text>
-    </div>
-    <div className="experiment_summary">
-        <Descriptions
-          layout="vertical"
-          bordered={true}
-          colon={false}
-          column={1}
-          size="small"
-          key={e.id}
-        >
-          <Descriptions.Item>
-            {(e.molecule_ontology ?? []).map((mo) => (
-              <Descriptions
-                title="Molecule Ontology"
-                layout="horizontal"
-                bordered={true}
-                column={1}
-                size="small"
-                key={mo.id}
-              >
-                <Descriptions.Item label="id">{mo.id}</Descriptions.Item>
-                <Descriptions.Item label="label">{mo.label}</Descriptions.Item>
-              </Descriptions>
-            ))}
-          </Descriptions.Item>
-          <Descriptions.Item>
-            {(e.experiment_ontology  || blankExperimentOntology).map((eo) => (
-              <Descriptions
-                title="Experiment Ontology"
-                layout="horizontal"
-                bordered={true}
-                column={1}
-                size="small"
-                key={eo.id}
-              >
-                <Descriptions.Item label="id">{eo.id}</Descriptions.Item>
-                <Descriptions.Item label="label">{eo.label}</Descriptions.Item>
-              </Descriptions>
-            ))}
-          </Descriptions.Item>
-          <Descriptions.Item>
-            <Descriptions
-              title="Instrument"
-              layout="horizontal"
-              bordered={true}
-              column={1}
-              size="small"
-            >
-              <Descriptions.Item label="platform">{e.instrument.platform}</Descriptions.Item>
-              <Descriptions.Item label="identifier">{e.instrument.identifier}</Descriptions.Item>
-            </Descriptions>
-          </Descriptions.Item>
-        </Descriptions>
-        <Descriptions layout="vertical" bordered={true} column={1} size="small" >
-          <Descriptions.Item>
-            <Descriptions layout="horizontal" bordered={true} column={1} size="small">
-              <Descriptions.Item label="Experiment Type">{e.experiment_type}</Descriptions.Item>
-              <Descriptions.Item label="Study Type">{e.study_type}</Descriptions.Item>
-              <Descriptions.Item label="Extraction Protocol">
-                {e.extraction_protocol}
-              </Descriptions.Item>
-              <Descriptions.Item label="Library Layout">{e.library_layout}</Descriptions.Item>
-              <Descriptions.Item label="Library Selection">{e.library_selection}</Descriptions.Item>
-              <Descriptions.Item label="Library Source">{e.library_source}</Descriptions.Item>
-              <Descriptions.Item label="Library Strategy">{e.library_strategy}</Descriptions.Item>
-            </Descriptions>
-          </Descriptions.Item>
-          <Descriptions.Item>
-            <Descriptions
-              title="Extra Properties"
-              layout="horizontal"
-              bordered={true}
-              column={1}
-              size="small"
-            >
+      {experimentsData.map((e, i) => (
+        <div className="experiment_and_results" id={e.biosample} key={e.id}>
+          <div className="experiment-titles">
+            <Typography.Text style={titleStyle}>
+              {`${e.experiment_type} (Biosample ${e.biosample})`}{" "}
+            </Typography.Text>
+          </div>
+          <div className="experiment_summary">
+            <Descriptions layout="vertical" bordered={true} colon={false} column={1} size="small" key={e.id}>
               <Descriptions.Item>
-                <JsonView inputJson={e.extra_properties} />
+                {(e.molecule_ontology ?? []).map((mo) => (
+                  <Descriptions
+                    title="Molecule Ontology"
+                    layout="horizontal"
+                    bordered={true}
+                    column={1}
+                    size="small"
+                    key={mo.id}
+                  >
+                    <Descriptions.Item label="id">{mo.id}</Descriptions.Item>
+                    <Descriptions.Item label="label">{mo.label}</Descriptions.Item>
+                  </Descriptions>
+                ))}
+              </Descriptions.Item>
+              <Descriptions.Item>
+                {(e.experiment_ontology || blankExperimentOntology).map((eo) => (
+                  <Descriptions
+                    title="Experiment Ontology"
+                    layout="horizontal"
+                    bordered={true}
+                    column={1}
+                    size="small"
+                    key={eo.id}
+                  >
+                    <Descriptions.Item label="id">{eo.id}</Descriptions.Item>
+                    <Descriptions.Item label="label">{eo.label}</Descriptions.Item>
+                  </Descriptions>
+                ))}
+              </Descriptions.Item>
+              <Descriptions.Item>
+                <Descriptions title="Instrument" layout="horizontal" bordered={true} column={1} size="small">
+                  <Descriptions.Item label="platform">{e.instrument.platform}</Descriptions.Item>
+                  <Descriptions.Item label="identifier">{e.instrument.identifier}</Descriptions.Item>
+                </Descriptions>
               </Descriptions.Item>
             </Descriptions>
-          </Descriptions.Item>
-        </Descriptions>
-    </div>
-    <div className="experiment-titles">
-    <Typography.Text style={titleStyle} level={4}> { `${e.experiment_type} - Results` }</Typography.Text>
-    </div>
-    <Table
-      bordered
-      size="small"
-      pagination={false}
-      columns={EXPERIMENT_RESULTS_COLUMNS}
-      rowKey="filename"
-      dataSource={(e.experiment_results || []).sort((r1, r2) => (r1.file_format > r2.file_format ) ? 1 : -1)}
-    />
-    {i !== (experimentsData.length - 1) && <Divider/>}
-  </div>
-))}
+            <Descriptions layout="vertical" bordered={true} column={1} size="small">
+              <Descriptions.Item>
+                <Descriptions layout="horizontal" bordered={true} column={1} size="small">
+                  <Descriptions.Item label="Experiment Type">{e.experiment_type}</Descriptions.Item>
+                  <Descriptions.Item label="Study Type">{e.study_type}</Descriptions.Item>
+                  <Descriptions.Item label="Extraction Protocol">{e.extraction_protocol}</Descriptions.Item>
+                  <Descriptions.Item label="Library Layout">{e.library_layout}</Descriptions.Item>
+                  <Descriptions.Item label="Library Selection">{e.library_selection}</Descriptions.Item>
+                  <Descriptions.Item label="Library Source">{e.library_source}</Descriptions.Item>
+                  <Descriptions.Item label="Library Strategy">{e.library_strategy}</Descriptions.Item>
+                </Descriptions>
+              </Descriptions.Item>
+              <Descriptions.Item>
+                <Descriptions
+                  title="Extra Properties"
+                  layout="horizontal"
+                  bordered={true}
+                  column={1}
+                  size="small"
+                >
+                  <Descriptions.Item>
+                    <JsonView inputJson={e.extra_properties} />
+                  </Descriptions.Item>
+                </Descriptions>
+              </Descriptions.Item>
+            </Descriptions>
+          </div>
+          <div className="experiment-titles">
+            <Typography.Text style={titleStyle} level={4}>
+              {" "}
+              {`${e.experiment_type} - Results`}
+            </Typography.Text>
+          </div>
+          <Table
+            bordered
+            size="small"
+            pagination={false}
+            columns={EXPERIMENT_RESULTS_COLUMNS}
+            rowKey="filename"
+            dataSource={(e.experiment_results || []).sort((r1, r2) =>
+                r1.file_format > r2.file_format ? 1 : -1
+            )}
+          />
+          {i !== experimentsData.length - 1 && <Divider />}
+        </div>
+      ))}
         </>
     );
 };

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -217,7 +217,7 @@ const IndividualExperiments = ({ individual }) => {
       pagination={false}
       columns={EXPERIMENT_RESULTS_COLUMNS}
       rowKey="filename"
-      dataSource={e.experiment_results.sort((r1, r2) => (r1.file_format > r2.file_format ) ? 1 : -1)}
+      dataSource={(e.experiment_results || []).sort((r1, r2) => (r1.file_format > r2.file_format ) ? 1 : -1)}
     />
     {i !== (experimentsData.length - 1) && <Divider/>}
   </div>

--- a/src/components/explorer/IndividualTracks.js
+++ b/src/components/explorer/IndividualTracks.js
@@ -105,7 +105,7 @@ const IndividualTracks = ({individual}) => {
             return;
         }
 
-        if (!allTracks.length || !hasFreshUrls(allTracks, igvUrls) || igvRendered.current) {
+        if (!allFoundFiles.length || !hasFreshUrls(allTracks, igvUrls) || igvRendered.current) {
             console.log("urls not ready");
             console.log({ igvUrls: igvUrls });
             console.log({ tracksValid: hasFreshUrls(allTracks, igvUrls) });
@@ -113,11 +113,11 @@ const IndividualTracks = ({individual}) => {
             return;
         }
 
-        const indexedTracks = allTracks.filter(
+        const indexedTracks = allFoundFiles.filter(
             (t) => t.viewInIgv && igvUrls[t.filename].dataUrl && igvUrls[t.filename].indexUrl
         );
 
-        const unindexedTracks = allTracks.filter(
+        const unindexedTracks = allFoundFiles.filter(
             (t) => t.viewInIgv && igvUrls[t.filename].url
         );
 

--- a/src/components/explorer/SearchSummaryModal.js
+++ b/src/components/explorer/SearchSummaryModal.js
@@ -6,15 +6,15 @@ import Histogram from "../overview/Histogram";
 import {SEX_VALUES} from "../../dataTypes/phenopacket";
 import {explorerSearchResultsPropTypesShape} from "../../propTypes";
 import {mapNameValueFields} from "../../utils/mapNameValueFields";
-import {DEFAULT_OTHER_THRESHOLD_PERCENTAGE} from "../../constants";
+import { useSelector } from "react-redux";
 
 const CHART_HEIGHT = 300;
 const CHART_ASPECT_RATIO = 1.8;
 const MODAL_WIDTH = 1000;
 
 const SearchSummaryModal = ({searchResults, ...props}) => {
-    const otherThresholdPercentage =
-      JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE;
+
+    const otherThresholdPercentage = useSelector((state) => state.explorer.otherThresholdPercentage);
     const thresholdProportion = otherThresholdPercentage / 100;
     const searchFormattedResults = searchResults.searchFormattedResults || [];
 

--- a/src/components/overview/ClinicalSummary.js
+++ b/src/components/overview/ClinicalSummary.js
@@ -11,7 +11,8 @@ import {
 import {mapNameValueFields} from "../../utils/mapNameValueFields";
 
 const mapStateToProps = state => ({
-    overviewSummary: state.overviewSummary
+    overviewSummary: state.overviewSummary,
+    otherThresholdPercentage: state.explorer.otherThresholdPercentage
 });
 
 const actionCreators = {

--- a/src/components/overview/CustomPieChart.js
+++ b/src/components/overview/CustomPieChart.js
@@ -57,7 +57,7 @@ class CustomPieChart extends React.Component {
     onClick = (data) => {
         const { history, setAutoQueryPageTransition, autoQueryDataType } = this.props;
 
-        if (!setAutoQueryPageTransition) {
+        if (!setAutoQueryPageTransition || data.skipAutoquery) {
             return;
         }
 

--- a/src/components/overview/CustomPieChart.js
+++ b/src/components/overview/CustomPieChart.js
@@ -278,12 +278,14 @@ class CustomPieChart extends React.Component {
         const titleHeaderHeight = 31;
         const totalCount = data.reduce((sum, e) => sum + e.value, 0);
 
+        console.log({piedata: data});
+
         return (<>
         <div style={this.style}>
         <h2 style={this.titleStyle}>{title}</h2>
           <PieChart height={chartHeight - titleHeaderHeight}
                     width={(chartHeight - titleHeaderHeight) * chartAspectRatio}>
-              <Pie data={data.filter(e => e.value !== 0)}
+              <Pie data={data}
                    dataKey="value"
                    cx="50%"
                    cy="50%"

--- a/src/components/overview/CustomPieChart.js
+++ b/src/components/overview/CustomPieChart.js
@@ -278,8 +278,6 @@ class CustomPieChart extends React.Component {
         const titleHeaderHeight = 31;
         const totalCount = data.reduce((sum, e) => sum + e.value, 0);
 
-        console.log({piedata: data});
-
         return (<>
         <div style={this.style}>
         <h2 style={this.titleStyle}>{title}</h2>

--- a/src/components/overview/ExperimentsSummary.js
+++ b/src/components/overview/ExperimentsSummary.js
@@ -10,7 +10,8 @@ import {
 import {mapNameValueFields} from "../../utils/mapNameValueFields";
 
 const mapStateToProps = state => ({
-    overviewSummary: state.overviewSummary
+    overviewSummary: state.overviewSummary,
+    otherThresholdPercentage: state.explorer.otherThresholdPercentage
 });
 
 const actionCreators = {

--- a/src/components/overview/OverviewSettingsControl.js
+++ b/src/components/overview/OverviewSettingsControl.js
@@ -1,14 +1,25 @@
 import React, { useState } from "react";
-import { Col, InputNumber, Row, Slider } from "antd";
+import { useDispatch, useSelector } from "react-redux";
+import { Col, InputNumber, Row, Slider, Modal } from "antd";
 import PropTypes from "prop-types";
+import { setOtherThresholdPercentage } from "../../modules/explorer/actions";
+import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../../constants";
 
+const OverviewSettingsControl = ({ modalVisible, toggleModalVisibility }) => {
+    const otherThresholdPercentage = useSelector((state) => state.explorer.otherThresholdPercentage);
+    const [inputValue, setInputValue] = useState(
+        otherThresholdPercentage ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE
+    );
 
-const OverviewSettingsControl = ({ otherThresholdPercentage, setOtherThresholdPercentage, setValueAndCloseModal }) => {
-    const [inputValue, setInputValue] = useState(otherThresholdPercentage);
+  //preserve earlier setting in case user cancels
+    const [previousThreshold, setPreviousThreshold] = useState(
+        otherThresholdPercentage ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE
+    );
+    const dispatch = useDispatch();
 
     const handleChange = (newValue) => {
         setInputValue(newValue);
-        setOtherThresholdPercentage(newValue);
+        setOtherThresholdPercentageInStore(newValue);
     };
 
     const handleEnter = (e) => {
@@ -18,39 +29,68 @@ const OverviewSettingsControl = ({ otherThresholdPercentage, setOtherThresholdPe
 
     const toolTipFormatter = (value) => `${value}%`;
 
+    const setOtherThresholdPercentageInStore = (value) => {
+        dispatch(setOtherThresholdPercentage(value));
+    };
+
+    const setValueAndCloseModal = () => {
+        setOtherThresholdPercentageInStore(inputValue);
+        setPreviousThreshold(inputValue);
+        writeThresholdToLocalStorage(inputValue);
+        toggleModalVisibility();
+    };
+
+    const cancelModal = () => {
+        setInputValue(previousThreshold);
+        setOtherThresholdPercentageInStore(previousThreshold);
+        toggleModalVisibility();
+    };
+
+    const writeThresholdToLocalStorage = (value) => {
+        localStorage.setItem("otherThresholdPercentage", JSON.stringify(value));
+    };
+
     return (
-    <Row>
-      <Col span={6}>
-        <Slider
-          min={0}
-          max={25}
-          onChange={handleChange}
-          value={typeof inputValue === "number" ? inputValue : 0}
-          step={0.1}
-          tipFormatter={toolTipFormatter}
-        />
-      </Col>
-      <Col span={6}>
-        <InputNumber
-          min={0}
-          max={100}
-          style={{ margin: "0 16px" }}
-          step={0.1}
-          value={typeof inputValue === "number" ? inputValue : 0}
-          extra={"Threshold for grouping categories into other"}
-          onChange={handleChange}
-          onPressEnter={handleEnter}
-        />
-      </Col>
-      Percentage threshold to group categories into &quot;Other&quot;
-    </Row>
+    <Modal
+      visible={modalVisible}
+      closable={false}
+      maskClosable={false}
+      destroyOnClose={true}
+      onOk={setValueAndCloseModal}
+      onCancel={cancelModal}
+    >
+      <Row>
+        <Col span={6}>
+          <Slider
+            min={0}
+            max={25}
+            onChange={handleChange}
+            value={typeof inputValue === "number" ? inputValue : 0}
+            step={0.1}
+            tipFormatter={toolTipFormatter}
+          />
+        </Col>
+        <Col span={6}>
+          <InputNumber
+            min={0}
+            max={100}
+            style={{ margin: "0 16px" }}
+            step={0.1}
+            value={typeof inputValue === "number" ? inputValue : 0}
+            extra={"Threshold for grouping categories into other"}
+            onChange={handleChange}
+            onPressEnter={handleEnter}
+          />
+        </Col>
+        Combine categories below this percentage into an &quot;Other&quot; category
+      </Row>
+    </Modal>
     );
 };
 
 OverviewSettingsControl.propTypes = {
-    otherThresholdPercentage: PropTypes.number,
-    setOtherThresholdPercentage: PropTypes.func,
-    setValueAndCloseModal: PropTypes.func,
+    modalVisible: PropTypes.bool,
+    toggleModalVisibility: PropTypes.func,
 };
 
 export default OverviewSettingsControl;

--- a/src/components/overview/OverviewSettingsControl.js
+++ b/src/components/overview/OverviewSettingsControl.js
@@ -3,7 +3,15 @@ import { useDispatch, useSelector } from "react-redux";
 import { Col, InputNumber, Row, Slider, Modal } from "antd";
 import PropTypes from "prop-types";
 import { setOtherThresholdPercentage } from "../../modules/explorer/actions";
+import { writeToLocalStorage } from "../../utils/localStorageUtils";
 import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../../constants";
+
+// currently only sets pie chart "Other" threshold:
+// writes to redux store on all changes, writes to redux and localStorage on close
+// initial threshold value is ether:
+// - the value in the redux store
+// - the value in localStorage if nothing in store
+// - DEFAULT_OTHER_THRESHOLD_PERCENTAGE if redux and localStorage both empty
 
 const OverviewSettingsControl = ({ modalVisible, toggleModalVisibility }) => {
     const otherThresholdPercentage = useSelector((state) => state.explorer.otherThresholdPercentage);
@@ -11,7 +19,7 @@ const OverviewSettingsControl = ({ modalVisible, toggleModalVisibility }) => {
         otherThresholdPercentage ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE
     );
 
-  //preserve earlier setting in case user cancels
+    //preserve earlier setting in case user cancels
     const [previousThreshold, setPreviousThreshold] = useState(
         otherThresholdPercentage ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE
     );
@@ -33,10 +41,11 @@ const OverviewSettingsControl = ({ modalVisible, toggleModalVisibility }) => {
         dispatch(setOtherThresholdPercentage(value));
     };
 
+    // only write to localStorage on close instead of at every change
     const setValueAndCloseModal = () => {
         setOtherThresholdPercentageInStore(inputValue);
         setPreviousThreshold(inputValue);
-        writeThresholdToLocalStorage(inputValue);
+        writeToLocalStorage("otherThresholdPercentage", inputValue);
         toggleModalVisibility();
     };
 
@@ -44,10 +53,6 @@ const OverviewSettingsControl = ({ modalVisible, toggleModalVisibility }) => {
         setInputValue(previousThreshold);
         setOtherThresholdPercentageInStore(previousThreshold);
         toggleModalVisibility();
-    };
-
-    const writeThresholdToLocalStorage = (value) => {
-        localStorage.setItem("otherThresholdPercentage", JSON.stringify(value));
     };
 
     return (

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -4,17 +4,14 @@ import {extractQueriesFromDataTypeForms} from "../../utils/search";
 
 export const PERFORM_SEARCH = createNetworkActionTypes("EXPLORER.PERFORM_SEARCH");
 export const PERFORM_INDIVIDUAL_CSV_DOWNLOAD = createNetworkActionTypes("EXPLORER.PERFORM_INDIVIDUAL_CSV_DOWNLOAD");
-
 export const ADD_DATA_TYPE_QUERY_FORM = "EXPLORER.ADD_DATA_TYPE_QUERY_FORM";
 export const UPDATE_DATA_TYPE_QUERY_FORM = "EXPLORER.UPDATE_DATA_TYPE_QUERY_FORM";
 export const REMOVE_DATA_TYPE_QUERY_FORM = "EXPLORER.REMOVE_DATA_TYPE_QUERY_FORM";
-
 export const SET_SELECTED_ROWS = "EXPLORER.SET_SELECTED_ROWS";
-
 export const SET_AUTO_QUERY_PAGE_TRANSITION = "EXPLORER.SET_AUTO_QUERY_PAGE_TRANSITION";
-
 export const NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION = "EXPLORER.NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION";
 export const FREE_TEXT_SEARCH = createNetworkActionTypes("FREE_TEXT_SEARCH");
+export const SET_OTHER_THRESHOLD_PERCENTAGE = "EXPLORER.SET_OTHER_THRESHOLD_PERCENTAGE";
 
 const performSearch = networkAction((datasetID, dataTypeQueries, excludeFromAutoJoin = []) =>
     (dispatch, getState) => ({
@@ -134,3 +131,8 @@ const performFreeTextSearch = networkAction((datasetID, term) => (dispatch, getS
 export const performFreeTextSearchIfPossible = (datasetID, term) => (dispatch, _getState) => {
     return dispatch(performFreeTextSearch(datasetID, term));
 };
+
+export const setOtherThresholdPercentage = (threshold) => ({
+    type: SET_OTHER_THRESHOLD_PERCENTAGE,
+    otherThresholdPercentage: threshold
+});

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -1,12 +1,15 @@
 import "file-saver"; // https://github.com/eligrey/FileSaver.js/
 import FileSaver from "file-saver";
+
 import {
     addDataTypeFormIfPossible,
     removeDataTypeFormIfPossible,
     updateDataTypeFormIfPossible
 } from "../../utils/search";
 
-import DEFAULT_OTHER_THRESHOLD_PERCENTAGE from "../../constants";
+import { readFromLocalStorage } from "../../utils/localStorageUtils";
+
+import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../../constants";
 
 import {
     PERFORM_SEARCH,
@@ -33,8 +36,7 @@ export const explorer = (
         autoQuery: {
             isAutoQuery: false,
         },
-        otherThresholdPercentage:
-      JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE,
+        otherThresholdPercentage: readFromLocalStorage("otherThresholdPercentage") ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE
     },
     action
 ) => {

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -1,4 +1,4 @@
-import "file-saver"; // https://github.com/eligrey/FileSaver.js/
+// https://github.com/eligrey/FileSaver.js/
 import FileSaver from "file-saver";
 
 import {

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -6,6 +6,8 @@ import {
     updateDataTypeFormIfPossible
 } from "../../utils/search";
 
+import DEFAULT_OTHER_THRESHOLD_PERCENTAGE from "../../constants";
+
 import {
     PERFORM_SEARCH,
     PERFORM_INDIVIDUAL_CSV_DOWNLOAD,
@@ -16,6 +18,7 @@ import {
     SET_AUTO_QUERY_PAGE_TRANSITION,
     NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION,
     FREE_TEXT_SEARCH,
+    SET_OTHER_THRESHOLD_PERCENTAGE
 } from "./actions";
 
 // TODO: Could this somehow be combined with discovery?
@@ -28,8 +31,10 @@ export const explorer = (
         isFetchingDownload: false,
 
         autoQuery: {
-            isAutoQuery: false
-        }
+            isAutoQuery: false,
+        },
+        otherThresholdPercentage:
+      JSON.parse(localStorage.getItem("otherThresholdPercentage")) ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE,
     },
     action
 ) => {
@@ -83,7 +88,7 @@ export const explorer = (
                 ...state,
                 isFetchingDownload: false,
             };
-        // ---
+    // ---
 
         case ADD_DATA_TYPE_QUERY_FORM:
             return {
@@ -92,7 +97,7 @@ export const explorer = (
                     ...state.dataTypeFormsByDatasetID,
                     [action.datasetID]: addDataTypeFormIfPossible(
                         state.dataTypeFormsByDatasetID[action.datasetID] || [],
-                        action.dataType,
+                        action.dataType
                     ),
                 },
             };
@@ -104,7 +109,7 @@ export const explorer = (
                     [action.datasetID]: updateDataTypeFormIfPossible(
                         state.dataTypeFormsByDatasetID[action.datasetID] || [],
                         action.dataType,
-                        action.fields,
+                        action.fields
                     ),
                 },
             };
@@ -115,7 +120,7 @@ export const explorer = (
                     ...state.dataTypeFormsByDatasetID,
                     [action.datasetID]: removeDataTypeFormIfPossible(
                         state.dataTypeFormsByDatasetID[action.datasetID] || [],
-                        action.dataType,
+                        action.dataType
                     ),
                 },
             };
@@ -129,7 +134,7 @@ export const explorer = (
                 },
             };
 
-        // Auto-Queries start here ----
+    // Auto-Queries start here ----
         case SET_AUTO_QUERY_PAGE_TRANSITION:
             return {
                 ...state,
@@ -139,7 +144,7 @@ export const explorer = (
                     autoQueryType: action.autoQueryType,
                     autoQueryField: action.autoQueryField,
                     autoQueryValue: action.autoQueryValue,
-                }
+                },
             };
 
         case NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION:
@@ -151,11 +156,11 @@ export const explorer = (
                     autoQueryType: undefined,
                     autoQueryField: undefined,
                     autoQueryValue: undefined,
-                }
+                },
             };
-        //.. and end here.. ----
+    //.. and end here.. ----
 
-        // free-text search
+    // free-text search
         case FREE_TEXT_SEARCH.REQUEST:
             return {
                 ...state,
@@ -182,6 +187,11 @@ export const explorer = (
                     ...state.fetchingSearchByDatasetID,
                     [action.datasetID]: false,
                 },
+            };
+        case SET_OTHER_THRESHOLD_PERCENTAGE:
+            return {
+                ...state,
+                otherThresholdPercentage: action.otherThresholdPercentage,
             };
 
         default:

--- a/src/utils/localStorageUtils.js
+++ b/src/utils/localStorageUtils.js
@@ -1,0 +1,14 @@
+export const writeToLocalStorage = (item, value) => {
+    localStorage.setItem(item, JSON.stringify(value));
+};
+
+export const readFromLocalStorage = (item) => {
+    let value;
+    try {
+        value = JSON.parse(localStorage.getItem(item));
+    } catch (e) {
+        console.error(e);
+        return null;
+    }
+    return value;
+};

--- a/src/utils/mapNameValueFields.js
+++ b/src/utils/mapNameValueFields.js
@@ -1,4 +1,6 @@
-export const mapNameValueFields = (data, otherThreshold = 0.04) => {
+import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../constants";
+
+export const mapNameValueFields = (data, otherThreshold = DEFAULT_OTHER_THRESHOLD_PERCENTAGE) => {
     if (!data)
         return [];
 

--- a/src/utils/mapNameValueFields.js
+++ b/src/utils/mapNameValueFields.js
@@ -13,14 +13,14 @@ export const mapNameValueFields = (data, otherThreshold) => {
     const other = { name: "Other", value: 0, skipAutoquery: true };
 
     Object.entries(data).forEach(([key, val]) => {
-        const categoryNotEmpty = val > 0;
+        if (val === 0) {
+            return;   //continue
+        }
         const categoryBelowThreshold = val / sumOfAllValues < otherThreshold;
-        if (multipleCategoriesBelowThreshold && categoryNotEmpty && categoryBelowThreshold) {
+        if (multipleCategoriesBelowThreshold && categoryBelowThreshold) {
             other.value += val;
         } else {
-            if (categoryNotEmpty) {
-                results.push({ name: key, value: val });
-            }
+            results.push({ name: key, value: val });
         }
     });
 

--- a/src/utils/mapNameValueFields.js
+++ b/src/utils/mapNameValueFields.js
@@ -6,14 +6,16 @@ export const mapNameValueFields = (data, otherThreshold = DEFAULT_OTHER_THRESHOL
 
     // Accumulate all values to compute on them later
     const sumOfAllValues = Object.values(data).reduce((acc, v) => acc + v, 0);
-    const numCategories = Object.keys(data).length;
+    const numCategoriesBelowThreshold = Object.values(data).filter(
+        (val) => val / sumOfAllValues < otherThreshold
+    ).length;
 
     // Group the items in the array of objects denoted by
     // a "name" and "value" parameter
     const results = [];
     Object.entries(data).forEach(([key, val]) => {
-        // Group all elements with a small enough value together under an "Other"
-        if (numCategories > 2 && val > 0 && (val / sumOfAllValues) < otherThreshold) {
+        // Group all elements with a small enough value together under an "Other", as long as there's more than one
+        if (numCategoriesBelowThreshold > 1 && val > 0 && (val / sumOfAllValues) < otherThreshold) {
             const otherIndex = results.findIndex(ob => ob.name === "Other");
             if (otherIndex > -1) {
                 results[otherIndex].value += val; // Accumulate

--- a/src/utils/mapNameValueFields.js
+++ b/src/utils/mapNameValueFields.js
@@ -4,13 +4,14 @@ export const mapNameValueFields = (data, otherThreshold = 0.04) => {
 
     // Accumulate all values to compute on them later
     const sumOfAllValues = Object.values(data).reduce((acc, v) => acc + v, 0);
+    const numCategories = Object.keys(data).length;
 
     // Group the items in the array of objects denoted by
     // a "name" and "value" parameter
     const results = [];
     Object.entries(data).forEach(([key, val]) => {
         // Group all elements with a small enough value together under an "Other"
-        if (val > 0 && (val / sumOfAllValues) < otherThreshold) {
+        if (numCategories > 2 && val > 0 && (val / sumOfAllValues) < otherThreshold) {
             const otherIndex = results.findIndex(ob => ob.name === "Other");
             if (otherIndex > -1) {
                 results[otherIndex].value += val; // Accumulate

--- a/src/utils/mapNameValueFields.js
+++ b/src/utils/mapNameValueFields.js
@@ -15,7 +15,7 @@ export const mapNameValueFields = (data, otherThreshold = 0.04) => {
             if (otherIndex > -1) {
                 results[otherIndex].value += val; // Accumulate
             } else {
-                results.push({name: "Other", value: val}); // Create a new  element in the array
+                results.push({name: "Other", value: val, skipAutoquery: true}); // Create a new  element in the array
             }
         } else { // Treat items
             results.push({name: key, value: val});

--- a/src/utils/mapNameValueFields.js
+++ b/src/utils/mapNameValueFields.js
@@ -1,32 +1,32 @@
-import { DEFAULT_OTHER_THRESHOLD_PERCENTAGE } from "../constants";
-
-export const mapNameValueFields = (data, otherThreshold = DEFAULT_OTHER_THRESHOLD_PERCENTAGE) => {
-    if (!data)
+export const mapNameValueFields = (data, otherThreshold) => {
+    if (!data) {
         return [];
+    }
 
-    // Accumulate all values to compute on them later
     const sumOfAllValues = Object.values(data).reduce((acc, v) => acc + v, 0);
-    const numCategoriesBelowThreshold = Object.values(data).filter(
-        (val) => val / sumOfAllValues < otherThreshold
-    ).length;
 
-    // Group the items in the array of objects denoted by
-    // a "name" and "value" parameter
+  // no point using an "other" category if only one category below threshold
+    const multipleCategoriesBelowThreshold =
+    Object.values(data).filter((val) => (val > 0) && (val / sumOfAllValues < otherThreshold)).length > 1;
+
     const results = [];
+    const other = { name: "Other", value: 0, skipAutoquery: true };
+
     Object.entries(data).forEach(([key, val]) => {
-        // Group all categories with value below the threshold into "Other", as long as there's more than one
-        if (numCategoriesBelowThreshold > 1 && val > 0 && (val / sumOfAllValues) < otherThreshold) {
-            const otherIndex = results.findIndex(ob => ob.name === "Other");
-            if (otherIndex > -1) {
-                results[otherIndex].value += val; // Accumulate
-            } else {
-                results.push({name: "Other", value: val, skipAutoquery: true}); // Create a new  element in the array
+        const categoryNotEmpty = val > 0;
+        const categoryBelowThreshold = val / sumOfAllValues < otherThreshold;
+        if (multipleCategoriesBelowThreshold && categoryNotEmpty && categoryBelowThreshold) {
+            other.value += val;
+        } else {
+            if (categoryNotEmpty) {
+                results.push({ name: key, value: val });
             }
-        } else { // Treat items
-            results.push({name: key, value: val});
         }
     });
 
-    // Sort by value
+    if (other["value"] > 0) {
+        results.push(other);
+    }
+
     return results.sort((a, b) => a.value - b.value);
 };

--- a/src/utils/mapNameValueFields.js
+++ b/src/utils/mapNameValueFields.js
@@ -14,7 +14,7 @@ export const mapNameValueFields = (data, otherThreshold = DEFAULT_OTHER_THRESHOL
     // a "name" and "value" parameter
     const results = [];
     Object.entries(data).forEach(([key, val]) => {
-        // Group all elements with a small enough value together under an "Other", as long as there's more than one
+        // Group all categories with value below the threshold into "Other", as long as there's more than one
         if (numCategoriesBelowThreshold > 1 && val > 0 && (val / sumOfAllValues) < otherThreshold) {
             const otherIndex = results.findIndex(ob => ob.name === "Other");
             if (otherIndex > -1) {


### PR DESCRIPTION
Fixes for pie chart "Other" category:
- move "other" threshold control to header (Redmine #987)
- skip autoquery for the grouped "other" category (search does not work here, so no point offering search)
- don't use "Other" if there is only a single category below the threshold for grouping into "Other"

unrelated bugfixes:
- Remove double "variant" option from search 
- fix for crash where unindexed igv files were expected but missing
- fix for crash where experiments have no experiment results
