### PR TITLE
quick fix for cropped track controls

### DIFF
--- a/src/components/explorer/IndividualTracks.js
+++ b/src/components/explorer/IndividualTracks.js
@@ -206,6 +206,7 @@ const IndividualTracks = ({individual}) => {
           onOk={() => setModalVisible(false)}
           onCancel={() => setModalVisible(false)}
           zIndex={MODAL_Z_INDEX}
+          width={600}
         >
           <TrackControlTable />
         </Modal>


### PR DESCRIPTION
- Tracks tab fix: default modal width not enough when long track names present