### PR TITLE
Experiments UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/workspace.xml
 dist
 node_modules/
+.idea

--- a/package.json
+++ b/package.json
@@ -62,5 +62,11 @@
   "bugs": {
     "url": "https://github.com/c3g/chord_web/issues"
   },
-  "homepage": "https://github.com/c3g/chord_web#readme"
+  "homepage": "https://github.com/c3g/chord_web#readme",
+  "prettier": {
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": false
+  }
 }

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -25,80 +25,72 @@ class IndividualBiosamples extends Component {
         const biosamplesData = (
             this.props.individual?.phenopackets ?? []
         ).flatMap((p) => p.biosamples);
-
         return (
             <div
                 className="biosamples-descriptions"
                 style={{ display: "inline-block" }}
             >
-                {biosamplesData.map((b, i) => (
+                {biosamplesData.map((biosample, i) => (
                     <>
                         <Descriptions
-                            title={`Biosample ${b.id}`}
+                            title={`Biosample ${biosample.id}`}
                             layout="horizontal"
                             bordered={true}
                             column={1}
                             size="small"
-                            key={b.id}
+                            key={biosample.id}
                         >
                             <Descriptions.Item label="ID">
-                                {b.id}
+                                {biosample.id}
                             </Descriptions.Item>
                             <Descriptions.Item label="Sampled Tissue">
-                                {renderOntologyTerm(b.sampled_tissue)}
+                                {renderOntologyTerm(biosample.sampled_tissue)}
                             </Descriptions.Item>
                             <Descriptions.Item label="Procedure">
                                 <div>
                                     <strong>Code:</strong>{" "}
-                                    {renderOntologyTerm(b.procedure.code)}
-                                    {b.procedure.body_site ? (
+                                    {renderOntologyTerm(biosample.procedure.code)}
+                                    {biosample.procedure.body_site ? (
                                         <div>
                                             <strong>Body Site:</strong>{" "}
                                             {renderOntologyTerm(
-                                                b.procedure.body_site
+                                                biosample.procedure.body_site
                                             )}
                                         </div>
                                     ) : null}
                                 </div>
                             </Descriptions.Item>
                             <Descriptions.Item label="Histological Diagnosis">
-                                {renderOntologyTerm(b.histological_diagnosis)}
+                                {renderOntologyTerm(biosample.histological_diagnosis)}
                             </Descriptions.Item>
                             <Descriptions.Item label="Ind. Age At Collection">
-                                {b.individual_age_at_collection
-                                    ? b.individual_age_at_collection.hasOwnProperty(
-                                        "age"
-                                    )
-                                        ? b.individual_age_at_collection.age
-                                        : `Between ${b.individual_age_at_collection.start.age}` +
-                                          `and ${b.individual_age_at_collection.end.age}`
+                                {biosample.individual_age_at_collection
+                                    ? biosample.individual_age_at_collection.hasOwnProperty(
+                                          "age"
+                                      )
+                                        ? biosample.individual_age_at_collection.age
+                                        : `Between ${biosample.individual_age_at_collection.start.age}` +
+                                          `and ${biosample.individual_age_at_collection.end.age}`
                                     : EM_DASH}
                             </Descriptions.Item>
                             <Descriptions.Item label="Extra Properties">
-                                {b.hasOwnProperty("extra_properties") &&
-                                Object.keys(b.extra_properties).length ? (
-                                    <JsonView inputJson={b.extra_properties} />
-                                    ) : (
-                                        EM_DASH
-                                    )}
+                                {biosample.hasOwnProperty("extra_properties") &&
+                                Object.keys(biosample.extra_properties).length ? (
+                                    <JsonView inputJson={biosample.extra_properties} />
+                                ) : (
+                                    EM_DASH
+                                )}
                             </Descriptions.Item>
                             <Descriptions.Item label="Available Experiments">
-                                {(b.experiments ?? [])
-                                    .flatMap((b) => b?.experiment_type ?? [])
-                                    .map((t, i) => (
+                                {(biosample.experiments ?? [])
+                                    .map((e, i) => (
                                         <Button
                                             key={i}
                                             onClick={() =>
-                                                this.handleClick(
-                                                    b.experiments.find(
-                                                        (e) =>
-                                                            e.experiment_type ===
-                                                            t
-                                                    ).id
-                                                )
+                                                this.handleClick(e.id)
                                             }
                                         >
-                                            {t}
+                                            {e.experiment_type}
                                         </Button>
                                     ))}
                             </Descriptions.Item>

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -7,88 +7,113 @@ import JsonView from "./JsonView";
 import { withRouter } from "react-router-dom";
 import PropTypes from "prop-types";
 
-
 // TODO: Only show biosamples from the relevant dataset, if specified;
 //  highlight those found in search results, if specified
 
 class IndividualBiosamples extends Component {
-
     constructor(props) {
         super(props);
         this.state = {};
     }
 
-    handleClick = (b) => {
-        const hashLink = this.props.experimentsUrl + "#" + b.id;
+    handleClick = (eid) => {
+        const hashLink = this.props.experimentsUrl + "#" + eid;
         this.props.history.push(hashLink);
-    }
+    };
 
     render() {
-        const biosamplesData = (this.props.individual?.phenopackets ?? []).flatMap((p) => p.biosamples);
+        const biosamplesData = (
+            this.props.individual?.phenopackets ?? []
+        ).flatMap((p) => p.biosamples);
 
         return (
-      <div className="biosamples-descriptions" style={{ display: "inline-block" }}>
-        {biosamplesData.map((b, i) => (
-            <>
-          <Descriptions
-            title={`Biosample ${b.id}`}
-            layout="horizontal"
-            bordered={true}
-            column={1}
-            size="small"
-            key={b.id}
-          >
-            <Descriptions.Item label="ID">{b.id}</Descriptions.Item>
-            <Descriptions.Item label="Sampled Tissue">
-              {renderOntologyTerm(b.sampled_tissue)}
-            </Descriptions.Item>
-            <Descriptions.Item label="Procedure">
-              <div>
-                <strong>Code:</strong> {renderOntologyTerm(b.procedure.code)}
-                {b.procedure.body_site ? (
-                  <div>
-                    <strong>Body Site:</strong> {renderOntologyTerm(b.procedure.body_site)}
-                  </div>
-                ) : null}
-              </div>
-            </Descriptions.Item>
-            <Descriptions.Item label="Histological Diagnosis">
-              {renderOntologyTerm(b.histological_diagnosis)}
-            </Descriptions.Item>
-            <Descriptions.Item label="Ind. Age At Collection">
-              {b.individual_age_at_collection
-                  ? b.individual_age_at_collection.hasOwnProperty("age")
-                      ? b.individual_age_at_collection.age
-                      : `Between ${b.individual_age_at_collection.start.age}` +
-                    `and ${b.individual_age_at_collection.end.age}`
-                  : EM_DASH}
-            </Descriptions.Item>
-            <Descriptions.Item label="Extra Properties">
-              {b.hasOwnProperty("extra_properties") && Object.keys(b.extra_properties).length ? (
-                <JsonView inputJson={b.extra_properties} />
-              ) : (
-                  EM_DASH
-              )}
-            </Descriptions.Item>
-            <Descriptions.Item label="Available Experiments">
-              {(b.experiments ?? []).flatMap((b) => b?.experiment_type ?? []).map((t, i) => (
-                <Button key={i} onClick={() => this.handleClick(b)}>
-                  {t}
-                </Button>
-              ))}
-            </Descriptions.Item>
-          </Descriptions>
-          {i !== (biosamplesData.length - 1) && <Divider/>}
-            </>
-        ))}
-      </div>
+            <div
+                className="biosamples-descriptions"
+                style={{ display: "inline-block" }}
+            >
+                {biosamplesData.map((b, i) => (
+                    <>
+                        <Descriptions
+                            title={`Biosample ${b.id}`}
+                            layout="horizontal"
+                            bordered={true}
+                            column={1}
+                            size="small"
+                            key={b.id}
+                        >
+                            <Descriptions.Item label="ID">
+                                {b.id}
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Sampled Tissue">
+                                {renderOntologyTerm(b.sampled_tissue)}
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Procedure">
+                                <div>
+                                    <strong>Code:</strong>{" "}
+                                    {renderOntologyTerm(b.procedure.code)}
+                                    {b.procedure.body_site ? (
+                                        <div>
+                                            <strong>Body Site:</strong>{" "}
+                                            {renderOntologyTerm(
+                                                b.procedure.body_site
+                                            )}
+                                        </div>
+                                    ) : null}
+                                </div>
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Histological Diagnosis">
+                                {renderOntologyTerm(b.histological_diagnosis)}
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Ind. Age At Collection">
+                                {b.individual_age_at_collection
+                                    ? b.individual_age_at_collection.hasOwnProperty(
+                                          "age"
+                                      )
+                                        ? b.individual_age_at_collection.age
+                                        : `Between ${b.individual_age_at_collection.start.age}` +
+                                          `and ${b.individual_age_at_collection.end.age}`
+                                    : EM_DASH}
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Extra Properties">
+                                {b.hasOwnProperty("extra_properties") &&
+                                Object.keys(b.extra_properties).length ? (
+                                    <JsonView inputJson={b.extra_properties} />
+                                ) : (
+                                    EM_DASH
+                                )}
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Available Experiments">
+                                {(b.experiments ?? [])
+                                    .flatMap((b) => b?.experiment_type ?? [])
+                                    .map((t, i) => (
+                                        <Button
+                                            key={i}
+                                            onClick={() =>
+                                                this.handleClick(
+                                                    b.experiments.find(
+                                                        (e) =>
+                                                            e.experiment_type ===
+                                                            t
+                                                    ).id
+                                                )
+                                            }
+                                        >
+                                            {t}
+                                        </Button>
+                                    ))}
+                            </Descriptions.Item>
+                        </Descriptions>
+                        {i !== biosamplesData.length - 1 && <Divider />}
+                    </>
+                ))}
+            </div>
         );
     }
 }
 
 IndividualBiosamples.propTypes = {
     individual: individualPropTypesShape,
-    experimentsUrl: PropTypes.string
+    experimentsUrl: PropTypes.string,
 };
 
 export default withRouter(IndividualBiosamples);

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -67,8 +67,8 @@ class IndividualBiosamples extends Component {
                             <Descriptions.Item label="Ind. Age At Collection">
                                 {b.individual_age_at_collection
                                     ? b.individual_age_at_collection.hasOwnProperty(
-                                          "age"
-                                      )
+                                        "age"
+                                    )
                                         ? b.individual_age_at_collection.age
                                         : `Between ${b.individual_age_at_collection.start.age}` +
                                           `and ${b.individual_age_at_collection.end.age}`
@@ -78,9 +78,9 @@ class IndividualBiosamples extends Component {
                                 {b.hasOwnProperty("extra_properties") &&
                                 Object.keys(b.extra_properties).length ? (
                                     <JsonView inputJson={b.extra_properties} />
-                                ) : (
-                                    EM_DASH
-                                )}
+                                    ) : (
+                                        EM_DASH
+                                    )}
                             </Descriptions.Item>
                             <Descriptions.Item label="Available Experiments">
                                 {(b.experiments ?? [])

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -65,30 +65,25 @@ class IndividualBiosamples extends Component {
                             </Descriptions.Item>
                             <Descriptions.Item label="Ind. Age At Collection">
                                 {biosample.individual_age_at_collection
-                                    ? biosample.individual_age_at_collection.hasOwnProperty(
-                                          "age"
-                                      )
-                                        ? biosample.individual_age_at_collection.age
-                                        : `Between ${biosample.individual_age_at_collection.start.age}` +
-                                          `and ${biosample.individual_age_at_collection.end.age}`
+                                    ? biosample.individual_age_at_collection.age ??
+                                        `Between ${biosample.individual_age_at_collection.start.age}` +
+                                            `and ${biosample.individual_age_at_collection.end.age}`
                                     : EM_DASH}
                             </Descriptions.Item>
                             <Descriptions.Item label="Extra Properties">
                                 {biosample.hasOwnProperty("extra_properties") &&
                                 Object.keys(biosample.extra_properties).length ? (
                                     <JsonView inputJson={biosample.extra_properties} />
-                                ) : (
-                                    EM_DASH
-                                )}
+                                    ) : (
+                                        EM_DASH
+                                    )}
                             </Descriptions.Item>
                             <Descriptions.Item label="Available Experiments">
                                 {(biosample.experiments ?? [])
                                     .map((e, i) => (
                                         <Button
                                             key={i}
-                                            onClick={() =>
-                                                this.handleClick(e.id)
-                                            }
+                                            onClick={() => this.handleClick(e.id)}
                                         >
                                             {e.experiment_type}
                                         </Button>

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -12,7 +12,6 @@ import { guessFileType } from "../../utils/guessFileType";
 const { Panel } = Collapse;
 
 const IndividualExperiments = ({ individual }) => {
-    const titleStyle = { fontSize: "16px", fontWeight: "bold", color: BENTO_BLUE };
     const blankExperimentOntology = [{ id: EM_DASH, label: EM_DASH }];
 
     const downloadUrls = useSelector(
@@ -40,14 +39,11 @@ const IndividualExperiments = ({ individual }) => {
     useEffect(() => {
         // retrieve any download urls on mount
         dispatch(getFileDownloadUrlsFromDrs(downloadableFiles));
-
-    // React Router can't handle hashlinks so force scroll if there is one
-        const selected = history.location.hash;
-        if (selected && selected.length > 0) {
-            const elem = document.querySelector(selected);
-            elem && elem.scrollIntoView();
-        }
     }, []);
+
+    const selected = history.location.hash.slice(1);
+    const opened = [];
+    if (selected && selected.length > 1) opened.push(selected);
 
     const renderDownloadButton = (resultFile) => {
         return downloadUrls[resultFile.filename]?.url ? (

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -1,35 +1,44 @@
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
-import { Button, Descriptions, Divider, Icon, Popover, Table, Typography } from "antd";
+import { Button, Collapse, Descriptions, Icon, Popover, Table } from "antd";
 import JsonView from "./JsonView";
 import FileSaver from "file-saver";
-import { BENTO_BLUE, EM_DASH } from "../../constants";
+import { EM_DASH } from "../../constants";
 import { individualPropTypesShape } from "../../propTypes";
 import { getFileDownloadUrlsFromDrs } from "../../modules/drs/actions";
 import { guessFileType } from "../../utils/guessFileType";
+
+const { Panel } = Collapse;
 
 const IndividualExperiments = ({ individual }) => {
     const titleStyle = { fontSize: "16px", fontWeight: "bold", color: BENTO_BLUE };
     const blankExperimentOntology = [{ id: EM_DASH, label: EM_DASH }];
 
-    const downloadUrls = useSelector((state) => state.drs.downloadUrlsByFilename);
+    const downloadUrls = useSelector(
+        (state) => state.drs.downloadUrlsByFilename
+    );
     const dispatch = useDispatch();
     const history = useHistory();
 
-    const biosamplesData = (individual?.phenopackets ?? []).flatMap((p) => p.biosamples);
+    const biosamplesData = (individual?.phenopackets ?? []).flatMap(
+        (p) => p.biosamples
+    );
     const experimentsData = biosamplesData.flatMap((b) => b?.experiments ?? []);
     let results = experimentsData.flatMap((e) => e?.experiment_results ?? []);
 
-  // enforce file_format property
+    // enforce file_format property
     results = results.map((r) => {
-        return { ...r, file_format: r.file_format ?? guessFileType(r.filename) };
+        return {
+            ...r,
+            file_format: r.file_format ?? guessFileType(r.filename),
+        };
     });
 
     const downloadableFiles = results.filter(isDownloadable);
 
     useEffect(() => {
-    // retrieve any download urls on mount
+        // retrieve any download urls on mount
         dispatch(getFileDownloadUrlsFromDrs(downloadableFiles));
 
     // React Router can't handle hashlinks so force scroll if there is one
@@ -42,11 +51,18 @@ const IndividualExperiments = ({ individual }) => {
 
     const renderDownloadButton = (resultFile) => {
         return downloadUrls[resultFile.filename]?.url ? (
-      <div>
-        <a onClick={async () => FileSaver.saveAs(downloadUrls[resultFile.filename].url, resultFile.filename)}>
-          <Icon type={"cloud-download"} />
-        </a>
-      </div>
+            <div>
+                <a
+                    onClick={async () =>
+                        FileSaver.saveAs(
+                            downloadUrls[resultFile.filename].url,
+                            resultFile.filename
+                        )
+                    }
+                >
+                    <Icon type={"cloud-download"} />
+                </a>
+            </div>
         ) : (
             EM_DASH
         );
@@ -84,132 +100,217 @@ const IndividualExperiments = ({ individual }) => {
             key: "other_details",
             align: "center",
             render: (_, result) => (
-        <Popover
-          placement="leftTop"
-          title={`Experiment Results: ${result.file_format}`}
-          content={
-            <div className="other-details">
-              <Descriptions layout="horizontal" bordered={true} colon={false} column={1} size="small">
-                <Descriptions.Item label="identifier">{result.identifier}</Descriptions.Item>
-                <Descriptions.Item label="description">{result.description}</Descriptions.Item>
-                <Descriptions.Item label="filename">{result.filename}</Descriptions.Item>
-                <Descriptions.Item label="file format">{result.file_format}</Descriptions.Item>
-                <Descriptions.Item label="data output type">{result.data_output_type}</Descriptions.Item>
-                <Descriptions.Item label="usage">{result.usage}</Descriptions.Item>
-                <Descriptions.Item label="creation date">{result.creation_date}</Descriptions.Item>
-                <Descriptions.Item label="created by">{result.created_by}</Descriptions.Item>
-              </Descriptions>
-            </div>
-          }
-          trigger="click"
-        >
-          <Button> click here </Button>
-        </Popover>
+                <Popover
+                    placement="leftTop"
+                    title={`Experiment Results: ${result.file_format}`}
+                    content={
+                        <div className="other-details">
+                            <Descriptions
+                                layout="horizontal"
+                                bordered={true}
+                                colon={false}
+                                column={1}
+                                size="small"
+                            >
+                                <Descriptions.Item label="identifier">
+                                    {result.identifier}
+                                </Descriptions.Item>
+                                <Descriptions.Item label="description">
+                                    {result.description}
+                                </Descriptions.Item>
+                                <Descriptions.Item label="filename">
+                                    {result.filename}
+                                </Descriptions.Item>
+                                <Descriptions.Item label="file format">
+                                    {result.file_format}
+                                </Descriptions.Item>
+                                <Descriptions.Item label="data output type">
+                                    {result.data_output_type}
+                                </Descriptions.Item>
+                                <Descriptions.Item label="usage">
+                                    {result.usage}
+                                </Descriptions.Item>
+                                <Descriptions.Item label="creation date">
+                                    {result.creation_date}
+                                </Descriptions.Item>
+                                <Descriptions.Item label="created by">
+                                    {result.created_by}
+                                </Descriptions.Item>
+                            </Descriptions>
+                        </div>
+                    }
+                    trigger="click"
+                >
+                    <Button> click here </Button>
+                </Popover>
             ),
         },
     ];
 
     return (
         <>
-      {experimentsData.map((e, i) => (
-        <div className="experiment_and_results" id={e.biosample} key={e.id}>
-          <div className="experiment-titles">
-            <Typography.Text style={titleStyle}>
-              {`${e.experiment_type} (Biosample ${e.biosample})`}
-            </Typography.Text>
-          </div>
-          <div className="experiment_summary">
-            <Descriptions layout="vertical" bordered={true} colon={false} column={1} size="small" key={e.id}>
-              <Descriptions.Item>
-                {(e.molecule_ontology ?? []).map((mo) => (
-                  <Descriptions
-                    title="Molecule Ontology"
-                    layout="horizontal"
-                    bordered={true}
-                    column={1}
-                    size="small"
-                    key={mo.id}
-                  >
-                    <Descriptions.Item label="id">{mo.id}</Descriptions.Item>
-                    <Descriptions.Item label="label">{mo.label}</Descriptions.Item>
-                  </Descriptions>
+            <Collapse defaultActiveKey={opened}>
+                {experimentsData.map((e) => (
+                    <Panel
+                        key={e.id}
+                        header={`${e.experiment_type} (Biosample ${e.biosample})`}
+                    >
+                        <div
+                            className="experiment_and_results"
+                            id={e.biosample}
+                            key={e.id}
+                        >
+                            <div className="experiment_summary">
+                                <Descriptions
+                                    layout="vertical"
+                                    bordered={true}
+                                    colon={false}
+                                    column={1}
+                                    size="small"
+                                    key={e.id}
+                                >
+                                    <Descriptions.Item>
+                                        {(e.molecule_ontology ?? []).map(
+                                            (mo) => (
+                                                <Descriptions
+                                                    title="Molecule Ontology"
+                                                    layout="horizontal"
+                                                    bordered={true}
+                                                    column={1}
+                                                    size="small"
+                                                    key={mo.id}
+                                                >
+                                                    <Descriptions.Item label="id">
+                                                        {mo.id}
+                                                    </Descriptions.Item>
+                                                    <Descriptions.Item label="label">
+                                                        {mo.label}
+                                                    </Descriptions.Item>
+                                                </Descriptions>
+                                            )
+                                        )}
+                                    </Descriptions.Item>
+                                    <Descriptions.Item>
+                                        {(
+                                            e.experiment_ontology ||
+                                            blankExperimentOntology
+                                        ).map((eo) => (
+                                            <Descriptions
+                                                title="Experiment Ontology"
+                                                layout="horizontal"
+                                                bordered={true}
+                                                column={1}
+                                                size="small"
+                                                key={eo.id}
+                                            >
+                                                <Descriptions.Item label="id">
+                                                    {eo.id}
+                                                </Descriptions.Item>
+                                                <Descriptions.Item label="label">
+                                                    {eo.label}
+                                                </Descriptions.Item>
+                                            </Descriptions>
+                                        ))}
+                                    </Descriptions.Item>
+                                    <Descriptions.Item>
+                                        <Descriptions
+                                            title="Instrument"
+                                            layout="horizontal"
+                                            bordered={true}
+                                            column={1}
+                                            size="small"
+                                        >
+                                            <Descriptions.Item label="platform">
+                                                {e.instrument.platform}
+                                            </Descriptions.Item>
+                                            <Descriptions.Item label="identifier">
+                                                {e.instrument.identifier}
+                                            </Descriptions.Item>
+                                        </Descriptions>
+                                    </Descriptions.Item>
+                                </Descriptions>
+                                <Descriptions
+                                    layout="vertical"
+                                    bordered={true}
+                                    column={1}
+                                    size="small"
+                                >
+                                    <Descriptions.Item>
+                                        <Descriptions
+                                            layout="horizontal"
+                                            bordered={true}
+                                            column={1}
+                                            size="small"
+                                        >
+                                            <Descriptions.Item label="Experiment Type">
+                                                {e.experiment_type}
+                                            </Descriptions.Item>
+                                            <Descriptions.Item label="Study Type">
+                                                {e.study_type}
+                                            </Descriptions.Item>
+                                            <Descriptions.Item label="Extraction Protocol">
+                                                {e.extraction_protocol}
+                                            </Descriptions.Item>
+                                            <Descriptions.Item label="Library Layout">
+                                                {e.library_layout}
+                                            </Descriptions.Item>
+                                            <Descriptions.Item label="Library Selection">
+                                                {e.library_selection}
+                                            </Descriptions.Item>
+                                            <Descriptions.Item label="Library Source">
+                                                {e.library_source}
+                                            </Descriptions.Item>
+                                            <Descriptions.Item label="Library Strategy">
+                                                {e.library_strategy}
+                                            </Descriptions.Item>
+                                        </Descriptions>
+                                    </Descriptions.Item>
+                                    <Descriptions.Item>
+                                        <Descriptions
+                                            title="Extra Properties"
+                                            layout="horizontal"
+                                            bordered={true}
+                                            column={1}
+                                            size="small"
+                                        >
+                                            <Descriptions.Item>
+                                                <JsonView
+                                                    inputJson={
+                                                        e.extra_properties
+                                                    }
+                                                />
+                                            </Descriptions.Item>
+                                        </Descriptions>
+                                    </Descriptions.Item>
+                                </Descriptions>
+                            </div>
+                            <Descriptions
+                                title={`${e.experiment_type} - Results`}
+                                bordered
+                            />
+                            <Table
+                                // bordered
+                                size="small"
+                                pagination={false}
+                                columns={EXPERIMENT_RESULTS_COLUMNS}
+                                rowKey="filename"
+                                dataSource={(e.experiment_results || []).sort(
+                                    (r1, r2) =>
+                                        r1.file_format > r2.file_format ? 1 : -1
+                                )}
+                            />
+                        </div>
+                    </Panel>
                 ))}
-              </Descriptions.Item>
-              <Descriptions.Item>
-                {(e.experiment_ontology || blankExperimentOntology).map((eo) => (
-                  <Descriptions
-                    title="Experiment Ontology"
-                    layout="horizontal"
-                    bordered={true}
-                    column={1}
-                    size="small"
-                    key={eo.id}
-                  >
-                    <Descriptions.Item label="id">{eo.id}</Descriptions.Item>
-                    <Descriptions.Item label="label">{eo.label}</Descriptions.Item>
-                  </Descriptions>
-                ))}
-              </Descriptions.Item>
-              <Descriptions.Item>
-                <Descriptions title="Instrument" layout="horizontal" bordered={true} column={1} size="small">
-                  <Descriptions.Item label="platform">{e.instrument.platform}</Descriptions.Item>
-                  <Descriptions.Item label="identifier">{e.instrument.identifier}</Descriptions.Item>
-                </Descriptions>
-              </Descriptions.Item>
-            </Descriptions>
-            <Descriptions layout="vertical" bordered={true} column={1} size="small">
-              <Descriptions.Item>
-                <Descriptions layout="horizontal" bordered={true} column={1} size="small">
-                  <Descriptions.Item label="Experiment Type">{e.experiment_type}</Descriptions.Item>
-                  <Descriptions.Item label="Study Type">{e.study_type}</Descriptions.Item>
-                  <Descriptions.Item label="Extraction Protocol">{e.extraction_protocol}</Descriptions.Item>
-                  <Descriptions.Item label="Library Layout">{e.library_layout}</Descriptions.Item>
-                  <Descriptions.Item label="Library Selection">{e.library_selection}</Descriptions.Item>
-                  <Descriptions.Item label="Library Source">{e.library_source}</Descriptions.Item>
-                  <Descriptions.Item label="Library Strategy">{e.library_strategy}</Descriptions.Item>
-                </Descriptions>
-              </Descriptions.Item>
-              <Descriptions.Item>
-                <Descriptions
-                  title="Extra Properties"
-                  layout="horizontal"
-                  bordered={true}
-                  column={1}
-                  size="small"
-                >
-                  <Descriptions.Item>
-                    <JsonView inputJson={e.extra_properties} />
-                  </Descriptions.Item>
-                </Descriptions>
-              </Descriptions.Item>
-            </Descriptions>
-          </div>
-          <div className="experiment-titles">
-            <Typography.Text style={titleStyle} level={4}>
-              {`${e.experiment_type} - Results`}
-            </Typography.Text>
-          </div>
-          <Table
-            bordered
-            size="small"
-            pagination={false}
-            columns={EXPERIMENT_RESULTS_COLUMNS}
-            rowKey="filename"
-            dataSource={(e.experiment_results || []).sort((r1, r2) =>
-                r1.file_format > r2.file_format ? 1 : -1
-            )}
-          />
-          {i !== experimentsData.length - 1 && <Divider />}
-        </div>
-      ))}
+            </Collapse>
         </>
     );
 };
 
 // expand here accordingly
-function isDownloadable(result) {
-    return result.file_format?.toLowerCase() === "vcf" || result.file_format?.toLowerCase() === "cram";
-}
+const isDownloadable = (result) =>
+    result.file_format?.toLowerCase() === "vcf" ||
+    result.file_format?.toLowerCase() === "cram";
 
 IndividualExperiments.propTypes = {
     individual: individualPropTypesShape,

--- a/src/components/overview/ClinicalSummary.js
+++ b/src/components/overview/ClinicalSummary.js
@@ -1,84 +1,74 @@
-import React, {Component} from "react";
-import {connect} from "react-redux";
+import React from "react";
+import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import {Col, Row, Spin, Statistic, Typography} from "antd";
+import { Col, Row, Spin, Statistic, Typography } from "antd";
 import CustomPieChart from "./CustomPieChart";
 import Histogram from "./Histogram";
 import { setAutoQueryPageTransition } from "../../modules/explorer/actions";
-import {
-    overviewSummaryPropTypesShape,
-} from "../../propTypes";
-import {mapNameValueFields} from "../../utils/mapNameValueFields";
+import { overviewSummaryPropTypesShape } from "../../propTypes";
+import { mapNameValueFields } from "../../utils/mapNameValueFields";
 
-const mapStateToProps = state => ({
-    overviewSummary: state.overviewSummary,
-    otherThresholdPercentage: state.explorer.otherThresholdPercentage
-});
+const ClinicalSummary = ({
+                             overviewSummary,
+                             setAutoQueryPageTransition,
+                             otherThresholdPercentage,
+                         }) => {
+    const chartHeight = 300;
+    const chartAspectRatio = 1.8;
 
-const actionCreators = {
-    setAutoQueryPageTransition
-};
+    const { data, isFetching } = overviewSummary;
 
-class ClinicalSummary extends Component {
+    const numParticipants = data.data_type_specific?.individuals?.count;
+    const numDiseases = data.data_type_specific?.diseases?.count;
+    const numPhenotypicFeatures =
+        overviewSummary.data?.data_type_specific?.phenotypic_features?.count;
+    const numExperiments =
+        overviewSummary.data?.data_type_specific?.experiments?.count;
 
-    static propTypes = {
-        overviewSummary: PropTypes.shape({
-            isFetching: PropTypes.bool,
-            data: overviewSummaryPropTypesShape
-        }).isRequired,
-        setAutoQueryPageTransition: PropTypes.func, // temp
-        otherThresholdPercentage: PropTypes.number
-    };
+    const biosampleLabels = mapNameValueFields(
+        data.data_type_specific?.biosamples?.sampled_tissue,
+        otherThresholdPercentage / 100
+    );
+    const numBiosamples = data.data_type_specific?.biosamples?.count;
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            chartPadding:  "1rem",
-            chartHeight: 300,
-            chartAspectRatio: 1.8,
-        };
-    }
+    const sexLabels = mapNameValueFields(
+        data.data_type_specific?.individuals?.sex,
+        -1
+    );
+    const binnedParticipantAges = binAges(
+        data.data_type_specific?.individuals?.age
+    );
+    const diseaseLabels = mapNameValueFields(
+        data.data_type_specific?.diseases?.term,
+        otherThresholdPercentage / 100
+    );
+    const phenotypicFeatureLabels = mapNameValueFields(
+        data.data_type_specific?.phenotypic_features?.type,
+        otherThresholdPercentage / 100
+    );
+    const autoQueryDataType = "phenopacket";
 
-    render() {
-        const {overviewSummary, otherThresholdPercentage} = this.props;
-        const {data, isFetching} = overviewSummary;
-
-        const numParticipants = data.data_type_specific?.individuals?.count;
-        const numDiseases = data.data_type_specific?.diseases?.count;
-        const numPhenotypicFeatures = overviewSummary.data?.data_type_specific?.phenotypic_features?.count;
-        const numExperiments = overviewSummary.data?.data_type_specific?.experiments?.count;
-
-        const biosampleLabels = mapNameValueFields(
-            data.data_type_specific?.biosamples?.sampled_tissue,
-            otherThresholdPercentage / 100
-        );
-        const numBiosamples = data.data_type_specific?.biosamples?.count;
-
-        const sexLabels = mapNameValueFields(data.data_type_specific?.individuals?.sex, -1);
-        const binnedParticipantAges = binAges(data.data_type_specific?.individuals?.age);
-        const diseaseLabels = mapNameValueFields(
-            data.data_type_specific?.diseases?.term,
-            otherThresholdPercentage / 100
-        );
-        const phenotypicFeatureLabels = mapNameValueFields(
-            data.data_type_specific?.phenotypic_features?.type,
-            otherThresholdPercentage / 100);
-        const autoQueryDataType = "phenopacket";
-
-        return <>
+    return (
+        <>
             <Row>
                 <Typography.Title level={4}>
                     Clinical/Phenotypical Data
                 </Typography.Title>
-                <Row style={{marginBottom: "24px"}} gutter={[0, 16]}>
+                <Row style={{ marginBottom: "24px" }} gutter={[0, 16]}>
                     <Col xl={2} lg={3} md={5} sm={6} xs={10}>
                         <Spin spinning={isFetching}>
-                            <Statistic title="Participants" value={numParticipants} />
+                            <Statistic
+                                title="Participants"
+                                value={numParticipants}
+                            />
                         </Spin>
                     </Col>
                     <Col xl={2} lg={3} md={5} sm={6} xs={10}>
                         <Spin spinning={isFetching}>
-                            <Statistic title="Biosamples" value={numBiosamples} />
+                            <Statistic
+                                title="Biosamples"
+                                value={numBiosamples}
+                            />
                         </Spin>
                     </Col>
                     <Col xl={2} lg={3} md={5} sm={6} xs={10}>
@@ -88,91 +78,130 @@ class ClinicalSummary extends Component {
                     </Col>
                     <Col xl={2} lg={3} md={5} sm={6} xs={10}>
                         <Spin spinning={isFetching}>
-                            <Statistic title="Phenotypic Features" value={numPhenotypicFeatures} />
+                            <Statistic
+                                title="Phenotypic Features"
+                                value={numPhenotypicFeatures}
+                            />
                         </Spin>
                     </Col>
                     <Col xl={2} lg={3} md={5} sm={6} xs={10}>
                         <Spin spinning={isFetching}>
-                            <Statistic title="Experiments" value={numExperiments} />
+                            <Statistic
+                                title="Experiments"
+                                value={numExperiments}
+                            />
                         </Spin>
                     </Col>
                 </Row>
-                <Row style={{display: "flex", flexWrap: "wrap"}} >
-            <Col style={{ textAlign: "center" }}>
-              <Spin spinning={isFetching}>
-                <CustomPieChart
-                  title="Individuals"
-                  data={sexLabels}
-                  chartHeight={this.state.chartHeight}
-                  chartAspectRatio={this.state.chartAspectRatio}
-                  fieldLabel={"[dataset item].subject.sex"}
-                  setAutoQueryPageTransition={this.props.setAutoQueryPageTransition}
-                  autoQueryDataType={autoQueryDataType}
-                />
-              </Spin>
-            </Col>
-            <Col  style={{ textAlign: "center" }}>
-              <Spin spinning={isFetching}>
-                <CustomPieChart
-                  title="Diseases"
-                  data={diseaseLabels}
-                  chartHeight={this.state.chartHeight}
-                  chartAspectRatio={this.state.chartAspectRatio}
-                  fieldLabel={"[dataset item].diseases.[item].term.label"}
-                  setAutoQueryPageTransition={this.props.setAutoQueryPageTransition}
-                  autoQueryDataType={autoQueryDataType}
-                />
-              </Spin>
-            </Col>
-            <Col  style={{ textAlign: "center" }}>
-              <Spin spinning={isFetching}>
-                <Histogram
-                  title="Ages"
-                  data={binnedParticipantAges}
-                  chartAspectRatio={this.state.chartAspectRatio}
-                  chartHeight={this.state.chartHeight}
-                />
-              </Spin>
-            </Col>
-            <Col style={{ textAlign: "center" }}>
-              <Spin spinning={isFetching}>
-                <CustomPieChart
-                  title="Biosamples"
-                  data={biosampleLabels}
-                  chartHeight={this.state.chartHeight}
-                  chartAspectRatio={this.state.chartAspectRatio}
-                  fieldLabel={"[dataset item].biosamples.[item].sampled_tissue.label"}
-                  setAutoQueryPageTransition={this.props.setAutoQueryPageTransition}
-                  autoQueryDataType={autoQueryDataType}
-                />
-              </Spin>
-            </Col>
-            {Boolean(phenotypicFeatureLabels.length) && <Col  style={{ textAlign: "center" }}>
-              <Spin spinning={isFetching}>
-                <CustomPieChart
-                  title="Phenotypic Features"
-                  data={phenotypicFeatureLabels}
-                  chartHeight={this.state.chartHeight}
-                  chartAspectRatio={this.state.chartAspectRatio}
-                  fieldLabel={"[dataset item].phenotypic_features.[item].type.label"}
-                  setAutoQueryPageTransition={this.props.setAutoQueryPageTransition}
-                  autoQueryDataType={autoQueryDataType}
-                />
-              </Spin>
-            </Col>}
-          </Row>
-
+                <Row style={{ display: "flex", flexWrap: "wrap" }}>
+                    <Col style={{ textAlign: "center" }}>
+                        <Spin spinning={isFetching}>
+                            <CustomPieChart
+                                title="Individuals"
+                                data={sexLabels}
+                                chartHeight={chartHeight}
+                                chartAspectRatio={chartAspectRatio}
+                                fieldLabel={"[dataset item].subject.sex"}
+                                setAutoQueryPageTransition={
+                                    setAutoQueryPageTransition
+                                }
+                                autoQueryDataType={autoQueryDataType}
+                            />
+                        </Spin>
+                    </Col>
+                    <Col style={{ textAlign: "center" }}>
+                        <Spin spinning={isFetching}>
+                            <CustomPieChart
+                                title="Diseases"
+                                data={diseaseLabels}
+                                chartHeight={chartHeight}
+                                chartAspectRatio={chartAspectRatio}
+                                fieldLabel={
+                                    "[dataset item].diseases.[item].term.label"
+                                }
+                                setAutoQueryPageTransition={
+                                    setAutoQueryPageTransition
+                                }
+                                autoQueryDataType={autoQueryDataType}
+                            />
+                        </Spin>
+                    </Col>
+                    <Col style={{ textAlign: "center" }}>
+                        <Spin spinning={isFetching}>
+                            <Histogram
+                                title="Ages"
+                                data={binnedParticipantAges}
+                                chartAspectRatio={chartAspectRatio}
+                                chartHeight={chartHeight}
+                            />
+                        </Spin>
+                    </Col>
+                    <Col style={{ textAlign: "center" }}>
+                        <Spin spinning={isFetching}>
+                            <CustomPieChart
+                                title="Biosamples"
+                                data={biosampleLabels}
+                                chartHeight={chartHeight}
+                                chartAspectRatio={chartAspectRatio}
+                                fieldLabel={
+                                    "[dataset item].biosamples.[item].sampled_tissue.label"
+                                }
+                                setAutoQueryPageTransition={
+                                    setAutoQueryPageTransition
+                                }
+                                autoQueryDataType={autoQueryDataType}
+                            />
+                        </Spin>
+                    </Col>
+                    {Boolean(phenotypicFeatureLabels.length) && (
+                        <Col style={{ textAlign: "center" }}>
+                            <Spin spinning={isFetching}>
+                                <CustomPieChart
+                                    title="Phenotypic Features"
+                                    data={phenotypicFeatureLabels}
+                                    chartHeight={chartHeight}
+                                    chartAspectRatio={chartAspectRatio}
+                                    fieldLabel={
+                                        "[dataset item].phenotypic_features.[item].type.label"
+                                    }
+                                    setAutoQueryPageTransition={
+                                        setAutoQueryPageTransition
+                                    }
+                                    autoQueryDataType={autoQueryDataType}
+                                />
+                            </Spin>
+                        </Col>
+                    )}
+                </Row>
             </Row>
-        </>;
-    }
-}
+        </>
+    );
+};
+
+ClinicalSummary.propTypes = {
+    overviewSummary: PropTypes.shape({
+        isFetching: PropTypes.bool,
+        data: overviewSummaryPropTypesShape,
+    }).isRequired,
+    setAutoQueryPageTransition: PropTypes.func, // temp
+    otherThresholdPercentage: PropTypes.number,
+};
+
+const mapStateToProps = (state) => ({
+    overviewSummary: state.overviewSummary,
+    otherThresholdPercentage: state.explorer.otherThresholdPercentage,
+});
+
+const actionCreators = {
+    setAutoQueryPageTransition,
+};
 
 export default connect(mapStateToProps, actionCreators)(ClinicalSummary);
 
 // custom binning function
 // input is object: {age1: count1, age2: count2....}
 // outputs an array [{bin1: bin1count}, {bin2: bin2count}...]
-function binAges (ages) {
+const binAges = (ages) => {
     if (!ages) {
         return null;
     }
@@ -202,7 +231,7 @@ function binAges (ages) {
     }
 
     // return histogram-friendly array
-    return Object.keys(ageBinCounts).map(age => {
-        return {ageBin: age, count: ageBinCounts[age]};
+    return Object.keys(ageBinCounts).map((age) => {
+        return { ageBin: age, count: ageBinCounts[age] };
     });
-}
+};


### PR DESCRIPTION
## Frontend Changes
- Experiments are now displayed in collapse
- When redirected to a specific experiment the experiment automatically opens up uncollapse
## Backend Changes
- added .idea to .gitignore
- added prettier config for jetbrain based environments
- converted clinical summary to a more dynamic, organised and smaller code
- changed how the redirection works from biosample to use experiment id as the key instead of biosample id (for cases of multiple experiments on a single biosample)