### PR TITLE
Fixed csv export failing for individual search results

### DIFF
--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -52,12 +52,8 @@ export const performSearchIfPossible = (datasetID) => (dispatch, getState) => {
 
 export const performIndividualsDownloadCSVIfPossible = (datasetId, individualIds, allSearchResults) =>
     (dispatch, getState) => {
-        let ids;
-        if (individualIds.length > 0) { // Get only selected results
-            ids = individualIds;
-        } else { // Get all search results
-            ids = allSearchResults.map(sr => sr.key);
-        }
+
+        const ids = individualIds.length ? individualIds : allSearchResults.map(sr => sr.key);
 
         const myHeaders = new Headers();
         myHeaders.append("Content-Type", "application/json");
@@ -73,7 +69,7 @@ export const performIndividualsDownloadCSVIfPossible = (datasetId, individualIds
             redirect: "follow"
         };
 
-        fetch(`${getState().services.itemsByArtifact.metadata.url}/api/individualsgetcsv`, requestOptions)
+        fetch(`${getState().services.itemsByArtifact.metadata.url}/api/batch/individuals`, requestOptions)
             .then(response => response.blob())
             .then(result => {
                 FileSaver.saveAs(result, "data.csv");

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -67,10 +67,10 @@ export const performIndividualsDownloadCSVIfPossible = (datasetId, individualIds
         });
 
         const requestOptions = {
-            method: 'POST',
+            method: "POST",
             headers: myHeaders,
             body: raw,
-            redirect: 'follow'
+            redirect: "follow"
         };
 
         fetch(`${getState().services.itemsByArtifact.metadata.url}/api/individualsgetcsv`, requestOptions)
@@ -78,7 +78,7 @@ export const performIndividualsDownloadCSVIfPossible = (datasetId, individualIds
             .then(result => {
                 FileSaver.saveAs(result, "data.csv");
             })
-            .catch(error => console.log('error', error));
+            .catch(error => console.log("error", error));
     };
 
 

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -59,7 +59,7 @@ export const performIndividualsDownloadCSVIfPossible = (datasetId, individualIds
         myHeaders.append("Content-Type", "application/json");
 
         const raw = JSON.stringify({
-            "ids": ids
+            "id": ids
         });
 
         const requestOptions = {

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -59,7 +59,8 @@ export const performIndividualsDownloadCSVIfPossible = (datasetId, individualIds
         myHeaders.append("Content-Type", "application/json");
 
         const raw = JSON.stringify({
-            "id": ids
+            "id": ids,
+            "format": "csv"
         });
 
         const requestOptions = {


### PR DESCRIPTION
- The export failed as it made get request with all the requested ids in it, which exceeded the limit
- The changes were made to katsu to provide a post request endpoint for such a request
- This commit utilizes that change to make a post request to that end point and download csv