### PR TITLE
displayed N/A when no url

### DIFF
--- a/src/components/ServiceList.js
+++ b/src/components/ServiceList.js
@@ -42,7 +42,7 @@ const serviceColumns = (isOwner) => [
     {
         title: "URL",
         dataIndex: "serviceInfo.url",
-        render: (url) => <a href={`${url}/service-info`}>{`${url}/service-info`}</a>,
+        render: (url) => url ? <a href={`${url}/service-info`}>{`${url}/service-info`}</a> : "N/A",
     },
     {
         title: "Status",

--- a/src/components/ServiceList.js
+++ b/src/components/ServiceList.js
@@ -42,6 +42,8 @@ const serviceColumns = (isOwner) => [
     {
         title: "URL",
         dataIndex: "serviceInfo.url",
+        // url is undefined when service-registry does not receive replies from
+        // the container.
         render: (url) => url ? <a href={`${url}/service-info`}>{`${url}/service-info`}</a> : "N/A",
     },
     {


### PR DESCRIPTION
It resolves the issue below by displaying N/A in url when a service is down


![image](https://user-images.githubusercontent.com/52885662/186488063-4105742b-fda9-49d1-bad7-d02bfd783358.png)
