### PR TITLE
adapt tableSearchResults to latest API

### DIFF
--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -117,7 +117,7 @@ class ExplorerDatasetSearch extends Component {
             ? (this.state.currentPage * this.state.pageSize) - this.state.pageSize + 1
             : 0;
 
-        console.log("search results: " + this.props.searchResults);
+        console.log("search results: ", this.props.searchResults);
 
         return <>
             <Typography.Title level={4}>Explore Dataset {selectedDataset.title}</Typography.Title>

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -46,7 +46,7 @@ const SEARCH_RESULT_COLUMNS = [
         dataIndex: "biosamples",
         render: samples => <>
             {samples.length} Sample{samples.length === 1 ? "" : "s"}{samples.length ? ": " : ""}
-            {samples.map(b => b.id).join(", ")}
+            {samples.join(", ")}
         </>,
         sorter: (a, b) => a.biosamples.length - b.biosamples.length,
         sortDirections: ["descend", "ascend", "descend"],
@@ -54,8 +54,8 @@ const SEARCH_RESULT_COLUMNS = [
     {
         title: "Experiments",
         dataIndex: "experiments",
-        render: experiments => <>{experiments.length} Experiment{experiments.length === 1 ? "" : "s"}</>,
-        sorter: (a, b) => a.experiments.length - b.experiments.length,
+        render: experiments => <>{experiments} Experiment{experiments === 1 ? "" : "s"}</>,
+        sorter: (a, b) => a.experiments - b.experiments,
         sortDirections: ["descend", "ascend", "descend"],
     },
 ];

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -142,9 +142,9 @@ class ExplorerDatasetSearch extends Component {
                                 onClick={() => this.setState({tracksModalVisible: true})}
                                 disabled={true}>
                             Visualize Tracks</Button> */}
-                        <Button icon="bar-chart"
+                        {/* <Button icon="bar-chart"
                                 style={{marginRight: "8px"}}
-                                onClick={() => this.setState({summaryModalVisible: true})}>View Summary</Button>
+                        onClick={() => this.setState({summaryModalVisible: true})}>View Summary</Button> */}
                         <Spin spinning={this.props.isFetchingDownload} style={{display: "inline-block !important"}}>
                             <Button icon="export" style={{marginRight: "8px"}}
                                     disabled={this.props.isFetchingDownload}

--- a/src/components/explorer/SearchTracksModal.js
+++ b/src/components/explorer/SearchTracksModal.js
@@ -6,8 +6,6 @@ import {explorerSearchResultsPropTypesShape} from "../../propTypes";
 import GenomeBrowser from "./GenomeBrowser";
 
 const SearchTracksModal = ({searchResults, ...props}) => {
-    console.log("searchResults", searchResults);
-
     const variants = searchResults.results.results.variant || [];
 
     // TODO: Display some basic statistics about n. of variants/tracks/etc.

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -128,7 +128,8 @@ export const neutralizeAutoQueryPageTransition = () => ({
 const performFreeTextSearch = networkAction((datasetID, term) => (dispatch, getState) => ({
     types: FREE_TEXT_SEARCH,
     params: {datasetID},
-    url: `${getState().services.metadataService.url}/api/individuals?search=${term}&page_size=10000`,
+    url: `${getState().services.metadataService.url}/api/individuals?search=${term}&page_size=10000` +
+        "&format=bento_search_result",
     err: `Error searching in all records with term ${term}`,
 }));
 

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -246,21 +246,12 @@ function freeTextSearchFormattedResults(searchResults) {
     return searchResults.map(r => {
         return {
             key: r.id,
-            biosamples: (r.phenopackets || []).flatMap((p) => p.biosamples),
-            diseases: r.phenopackets[0].diseases, //TO FIX, multiple phenopackets possible
-            experiments: (r.phenopackets || []).flatMap((p) =>
-                (p.biosamples || []).flatMap((b) => b?.experiments ? [b.experiments] : [])
-            ),
-            phenotypic_features: r.phenopackets[0].phenotypic_features || [], //TO FIX, as above
             individual: {
-                age: r.age,
-                created: r.created,
-                date_of_birth: r.date_of_birth,
                 id: r.id,
-                karyotypic_sex: r.karyotypic_sex,
-                taxonomy: r.taxonomy,
-                updated: r.updated,
+                alternate_ids: r.alternate_ids
             },
+            biosamples: r.biosamples,
+            experiments: r.num_experiments
         };
     });
 }

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -178,7 +178,7 @@ export const explorer = (
                     ...state.searchResultsByDatasetID,
                     [action.datasetID]: {
                         results: freeTextResults(action.data),
-                        searchFormattedResults: freeTextSearchFormattedResults(action.data.results),
+                        searchFormattedResults: tableSearchResults(action.data),
                     },
                 },
             };
@@ -238,20 +238,4 @@ function freeTextResults(_searchResults) {
             variant: []   //TODO
         }
     };
-}
-
-// produces searchFormattedResults (input for results table and other components)
-// free-text equivalent to tableSearchResults() above
-function freeTextSearchFormattedResults(searchResults) {
-    return searchResults.map(r => {
-        return {
-            key: r.id,
-            individual: {
-                id: r.id,
-                alternate_ids: r.alternate_ids
-            },
-            biosamples: r.biosamples,
-            experiments: r.num_experiments
-        };
-    });
 }

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -204,64 +204,19 @@ export const explorer = (
 // helpers
 
 const tableSearchResults = (searchResults) => {
-    const results = (searchResults || {}).results || {};
-    const tableResultSet = {};
+    const results = (searchResults || {}).results || [];
 
-    // Collect all experiments (which have a biosample, not necessarily unique
-    // - one can perform multiple experiments on the same biosample) in arrays
-    // by their biosample ID.
-    const experimentsByBiosample = {};
-    (results.experiment ?? []).forEach(experiment => {
-        const biosampleID = experiment.biosample;
-        if (!experimentsByBiosample.hasOwnProperty(biosampleID)) {
-            experimentsByBiosample[biosampleID] = [];
-        }
-        experimentsByBiosample[biosampleID].push(experiment);
+    return results.map((p) => {
+        return {
+            key: p.subject_id,
+            individual: {
+                id: p.subject_id,
+                alternate_ids: p.alternate_ids ?? []
+            },
+            biosamples: p.biosamples,
+            experiments: p.num_experiments
+        };
     });
-
-    // First, collect different data from phenopackets and sort them into an object for an individual
-    (results.phenopacket || []).forEach(p => {
-        const individualID = p.subject.id;
-        if (!tableResultSet.hasOwnProperty(individualID)) {
-            // We DO NOT initialize diseases, PFs, experiments etc. here because we may have
-            // multiple phenopackets on the same individual, and we want to combine this
-            // into one record for the individual. It gets populated separately below.
-            tableResultSet[individualID] = {
-                key: individualID,
-                individual: p.subject,
-                biosamples: {},  // Only includes biosamples from the phenopackets that matched the search query.
-                diseases: {},  // Only includes diseases from "
-                phenotypic_features: {},
-                experiments: {},  // Filled from all the experiments conducted on the biosamples
-            };
-        }
-
-        // Accumulate biosamples based on individual ID and experiments by that biosample
-        // ID, de-duplicating in the process to event overlap if multiple phenopackets
-        // have the same biosample(s) or something weird.
-        (p.biosamples ?? []).forEach(b => {
-            tableResultSet[individualID].biosamples[b.id] = b;
-            (experimentsByBiosample[b.id] ?? []).forEach(e => tableResultSet[individualID].experiments[e.id] = e);
-        });
-
-        // Accumulate diseases and phenotypic features in the same manner.
-        (p.diseases ?? []).forEach(d => tableResultSet[individualID].diseases[d.id] = d);
-        (p.phenotypic_features ?? []).forEach(pf => tableResultSet[individualID].phenotypic_features[pf.type.id] = pf);
-    });
-
-    // Now that the biosamples/diseases/PFs/experiments are de-duplicated, turn
-    // them into arrays and sort them in a consistent manner. Also flatten the
-    // stuff-by-individual object into a sorted array.
-    return Object.values(tableResultSet).map(i => ({
-        ...i,
-        biosamples: Object.values(i.biosamples).sort((b1, b2) => b1.id.localeCompare(b2.id)),
-        diseases: Object.values(i.diseases).sort(
-            (d1, d2) => d1.id.toString().localeCompare(d2.id.toString())),
-        phenotypic_features: Object.values(i.phenotypic_features).sort(
-            (pf1, pf2) => pf1.type.id.localeCompare(pf2.type.id)),
-        experiments: Object.values(i.experiments).sort(
-            (e1, e2) => e1.id.toString().localeCompare(e2.id.toString())),
-    })).sort((i1, i2) => i1.key.localeCompare(i2.key));
 };
 
 

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -361,10 +361,12 @@ export const explorerSearchResultsPropTypesShape = PropTypes.shape({
     }),
     searchFormattedResults: PropTypes.arrayOf(PropTypes.shape({
         key: PropTypes.string.isRequired,
-        individual: individualPropTypesShape,
-        biosamples: PropTypes.arrayOf(biosamplePropTypesShape),
-        diseases: PropTypes.arrayOf(diseasePropTypesShape),
-        experiments: PropTypes.arrayOf(experimentPropTypesShape),  // TODO
+        individual: PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            alternate_ids: PropTypes.arrayOf(PropTypes.string)
+        }),
+        biosamples: PropTypes.arrayOf(PropTypes.string),
+        experiments: PropTypes.number
     })),
 });
 


### PR DESCRIPTION
This PR makes the frontend compatible with the shape of the response from the federation service. There are no changes in functionality, so searches should work as before only faster.

To test: searches, the table of results should keep its features unchanged (clicking on a result, sorting results by clicking on columns)