### PR TITLE
Features/search sort order

### DIFF
--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -76,7 +76,7 @@ class ExplorerDatasetSearch extends Component {
 
         const {sortColumnKey, sortOrder} = this.props.tableSortOrder;
 
-        const SEARCH_RESULT_COLUMNS = [
+        const searchResultColumns = [
             {
                 title: "Individual",
                 dataIndex: "individual",
@@ -174,7 +174,7 @@ class ExplorerDatasetSearch extends Component {
                         <Table bordered
                                disabled={isFetchingSearchResults}
                                size="middle"
-                               columns={SEARCH_RESULT_COLUMNS}
+                               columns={searchResultColumns}
                                dataSource={this.props.searchResults.searchFormattedResults || []}
                                pagination={{
                                    pageSize: this.state.pageSize,

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -14,6 +14,7 @@ export const SET_AUTO_QUERY_PAGE_TRANSITION = "EXPLORER.SET_AUTO_QUERY_PAGE_TRAN
 export const NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION = "EXPLORER.NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION";
 export const FREE_TEXT_SEARCH = createNetworkActionTypes("FREE_TEXT_SEARCH");
 export const SET_OTHER_THRESHOLD_PERCENTAGE = "EXPLORER.SET_OTHER_THRESHOLD_PERCENTAGE";
+export const SET_TABLE_SORT_ORDER = "EXPLORER.SET_TABLE_SORT_ORDER";
 
 const performSearch = networkAction((datasetID, dataTypeQueries, excludeFromAutoJoin = []) =>
     (dispatch, getState) => ({
@@ -103,6 +104,13 @@ export const setSelectedRows = (datasetID, selectedRows) => ({
     type: SET_SELECTED_ROWS,
     datasetID,
     selectedRows,
+});
+
+export const setTableSortOrder = (datasetID, sortColumnKey, sortOrder) => ({
+    type: SET_TABLE_SORT_ORDER,
+    datasetID,
+    sortColumnKey,
+    sortOrder,
 });
 
 export const setAutoQueryPageTransition = (priorPageUrl, type, field, value) => ({

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -18,6 +18,7 @@ import {
     REMOVE_DATA_TYPE_QUERY_FORM,
     UPDATE_DATA_TYPE_QUERY_FORM,
     SET_SELECTED_ROWS,
+    SET_TABLE_SORT_ORDER,
     SET_AUTO_QUERY_PAGE_TRANSITION,
     NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION,
     FREE_TEXT_SEARCH,
@@ -31,6 +32,7 @@ export const explorer = (
         fetchingSearchByDatasetID: {},
         searchResultsByDatasetID: {},
         selectedRowsByDatasetID: {},
+        tableSortOrderByDatasetID: {},
         isFetchingDownload: false,
         fetchingTextSearch: false,
 
@@ -135,6 +137,18 @@ export const explorer = (
                     ...state.selectedRowsByDatasetID,
                     [action.datasetID]: action.selectedRows,
                 },
+            };
+
+        case SET_TABLE_SORT_ORDER:
+            return {
+                ...state,
+                tableSortOrderByDatasetID: {
+                    ...state.tableSortOrderByDatasetID,
+                    [action.datasetID]: {
+                        sortColumnKey: action.sortColumnKey,
+                        sortOrder: action.sortOrder,
+                    },
+                }
             };
 
     // Auto-Queries start here ----


### PR DESCRIPTION
- Bugfix for disappearing sort order for search results table ([Redmine #921](https://206.12.92.46/issues/921))

Previously when navigating away from the results page, any custom table sorting would be lost (table would default to sorting by ascending patient ids). This pr saves sorting preferences in redux. 

