### PR TITLE
Features/igv save position

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "file-saver": "^2.0.5",
     "igv": "^2.13.6",
     "iso8601-duration": "^1.2.0",
+    "lodash.debounce": "^4.0.8",
     "prop-types": "^15.7.2",
     "query-string": "^6.13.7",
     "react": "^16.14.0",

--- a/src/components/explorer/IndividualGenes.js
+++ b/src/components/explorer/IndividualGenes.js
@@ -1,6 +1,8 @@
 import React from "react";
 import {Link} from "react-router-dom";
+import { useDispatch } from "react-redux";
 import {Button, Table} from "antd";
+import { setIgvPosition } from "../../modules/explorer/actions";
 import {individualPropTypesShape} from "../../propTypes";
 import PropTypes from "prop-types";
 
@@ -10,16 +12,15 @@ import PropTypes from "prop-types";
 const IndividualGenes = ({individual, tracksUrl}) => {
     const genes = (individual || {}).phenopackets.flatMap(p => p.genes);
     const genesFlat = genes.flatMap(g => ({symbol: g.symbol}));
-
+    const dispatch = useDispatch();
 
     console.log({genesFlat: genesFlat});
 
     const igvLink = (symbol) => (
-      <Link
-        to={{
-            pathname: tracksUrl,
-            state: { locus: symbol },
-        }}
+      <Link onClick={() => dispatch(setIgvPosition(symbol))}
+            to={{
+                pathname: tracksUrl,
+            }}
       >
         <Button>{symbol}</Button>
       </Link>

--- a/src/components/explorer/IndividualTracks.js
+++ b/src/components/explorer/IndividualTracks.js
@@ -173,7 +173,7 @@ const IndividualTracks = ({individual}) => {
         });
     }, [igvUrls]);
 
-    const TRACK_TABLE_COLUMNS = [
+    const trackTableColumns = [
         {
             title: "File",
             key: "filename",
@@ -197,7 +197,7 @@ const IndividualTracks = ({individual}) => {
         bordered
         size="small"
         pagination={false}
-        columns={TRACK_TABLE_COLUMNS}
+        columns={trackTableColumns}
         rowKey="filename"
         dataSource={allFoundFiles}
         style={{ display: "inline-block" }}

--- a/src/components/explorer/IndividualVariants.js
+++ b/src/components/explorer/IndividualVariants.js
@@ -1,8 +1,10 @@
 import React from "react";
 import {Link} from "react-router-dom";
+import { useDispatch } from "react-redux";
 import {Button, Descriptions, Empty} from "antd";
 import PropTypes from "prop-types";
 import {individualPropTypesShape} from "../../propTypes";
+import { setIgvPosition } from "../../modules/explorer/actions";
 import "./explorer.css";
 
 // TODO: Only show variants from the relevant dataset, if specified;
@@ -13,8 +15,8 @@ const variantStyle = {margin: "5px"};
 
 const IndividualVariants = ({individual, tracksUrl}) => {
     const biosamples = (individual || {}).phenopackets.flatMap(p => p.biosamples);
-
     const variantsMapped = {};
+    const dispatch = useDispatch();
 
     biosamples.forEach((bs) => {
         const allvariants = (bs || {}).variants;
@@ -42,14 +44,15 @@ const IndividualVariants = ({individual, tracksUrl}) => {
         return  <div style={variantStyle}>
       <span style={{display: "inline", marginRight: "15px"} }>{`id: ${variant.id} hgvs: ${variant.hgvs}`}</span>
       {variant.gene_context && (
-          <>gene context: <Link
-          to={{
-              pathname: tracksUrl,
-              state: { locus: variant.gene_context },
-          }}
-        >
-          <Button>{variant.gene_context}</Button>
-        </Link></>
+          <>gene context:
+            <Link onClick={() => dispatch(setIgvPosition(variant.gene_context))}
+                  to={{
+                      pathname: tracksUrl,
+                  }}
+            >
+            <Button>{variant.gene_context}</Button>
+            </Link>
+          </>
       )}
     </div>;
     };

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -15,6 +15,7 @@ export const NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION = "EXPLORER.NEUTRALIZE_AUTO_Q
 export const FREE_TEXT_SEARCH = createNetworkActionTypes("FREE_TEXT_SEARCH");
 export const SET_OTHER_THRESHOLD_PERCENTAGE = "EXPLORER.SET_OTHER_THRESHOLD_PERCENTAGE";
 export const SET_TABLE_SORT_ORDER = "EXPLORER.SET_TABLE_SORT_ORDER";
+export const SET_IGV_POSITION = "EXPLORER.SET_IGV_POSITION";
 
 const performSearch = networkAction((datasetID, dataTypeQueries, excludeFromAutoJoin = []) =>
     (dispatch, getState) => ({
@@ -148,4 +149,9 @@ export const performFreeTextSearchIfPossible = (datasetID, term) => (dispatch, _
 export const setOtherThresholdPercentage = (threshold) => ({
     type: SET_OTHER_THRESHOLD_PERCENTAGE,
     otherThresholdPercentage: threshold
+});
+
+export const setIgvPosition = (igvPosition) => ({
+    type: SET_IGV_POSITION,
+    igvPosition
 });

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -40,7 +40,8 @@ export const explorer = (
         autoQuery: {
             isAutoQuery: false,
         },
-        otherThresholdPercentage: readFromLocalStorage("otherThresholdPercentage") ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE,
+        otherThresholdPercentage:
+            readFromLocalStorage("otherThresholdPercentage") ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE,
         igvPosition: undefined
     },
     action

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -22,7 +22,8 @@ import {
     SET_AUTO_QUERY_PAGE_TRANSITION,
     NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION,
     FREE_TEXT_SEARCH,
-    SET_OTHER_THRESHOLD_PERCENTAGE
+    SET_OTHER_THRESHOLD_PERCENTAGE,
+    SET_IGV_POSITION
 } from "./actions";
 
 // TODO: Could this somehow be combined with discovery?
@@ -39,7 +40,8 @@ export const explorer = (
         autoQuery: {
             isAutoQuery: false,
         },
-        otherThresholdPercentage: readFromLocalStorage("otherThresholdPercentage") ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE
+        otherThresholdPercentage: readFromLocalStorage("otherThresholdPercentage") ?? DEFAULT_OTHER_THRESHOLD_PERCENTAGE,
+        igvPosition: undefined
     },
     action
 ) => {
@@ -203,6 +205,11 @@ export const explorer = (
             return {
                 ...state,
                 otherThresholdPercentage: action.otherThresholdPercentage,
+            };
+        case SET_IGV_POSITION:
+            return {
+                ...state,
+                igvPosition: action.igvPosition
             };
 
         default:


### PR DESCRIPTION
Store last IGV position in redux. 

When tabbing between "Tracks" and other parts of individual overview (Biosamples, Experiments, etc), the position of the IGV browser will be preserved, instead of defaulting to the "zoomed out" view. Position will also persist across individuals, unless a hard refresh occurs. 

A few subtleties are worth noting:

- position is monitored by listening to IGV's `locuschange` event. This can produce a very large number of calls, so storing every change degrades performance. Instead, lodash `debounce` is used to handle only the last event over a particular time frame (currently set to 500 ms).

- igv position is retrieved from the redux store only on the first render.