### PR TITLE
Start work on support new chord_services format for bentoV2; improve WES run sorting; add web service-info

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - master
+      - releases/**
   push:
     branches:
       - master

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$/src" libraries="{@types/prop-types, @types/react, @types/react-dom, @types/react-redux, @types/react-router-dom}" />
-    <file url="PROJECT" libraries="{@types/react-redux, @types/react-router, @types/react-router-dom}" />
-  </component>
-</project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ COPY package-lock.json .
 RUN npm ci
 
 # Explicitly choose what to copy to speed up builds
-#  - Copy in build configuration
+#  - Copy in build requirements
 COPY .babelrc .
+COPY create_service_info.js .
 COPY webpack.config.js .
 #  - Copy in source code
 COPY src src

--- a/create_service_info.js
+++ b/create_service_info.js
@@ -1,0 +1,30 @@
+const packageData = require("./package.json");
+
+const serviceType = {
+    group: "ca.c3g.bento",
+    artifact: "web",
+    version: packageData.version,
+};
+
+const serviceID = process.env.SERVICE_ID || `${serviceType.group}:${serviceType.artifact}`;
+
+const serviceInfo = () => ({
+    id: serviceID,
+    name: "Bento Web",
+    description: "Private-access web interface for the Bento platform.",
+    type: serviceType,
+    version: packageData.version,
+    organization: {
+        name: "C3G",
+        url: "https://www.computationalgenomics.ca",
+    },
+    contactUrl: "mailto:info@c3g.ca",
+});
+
+if (typeof require !== "undefined" && require.main === module) {
+    console.log(JSON.stringify(serviceInfo(), null, 2));
+}
+
+module.exports = {
+    serviceInfo,
+};

--- a/create_service_info.js
+++ b/create_service_info.js
@@ -19,6 +19,9 @@ const serviceInfo = () => ({
         url: "https://www.computationalgenomics.ca",
     },
     contactUrl: "mailto:info@c3g.ca",
+    bento: {
+        serviceKind: "web",
+    },
 });
 
 if (typeof require !== "undefined" && require.main === module) {

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -13,7 +13,6 @@ WORKDIR /web
 
 COPY package.json .
 COPY package-lock.json .
-COPY entrypoint.dev.sh .
 
 COPY --from=install /web/node_modules ./node_modules
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /web
 
 COPY package.json .
 COPY package-lock.json .
+COPY entrypoint.dev.sh .
 
 COPY --from=install /web/node_modules ./node_modules
 

--- a/entrypoint.bash
+++ b/entrypoint.bash
@@ -21,5 +21,9 @@ fi
 echo '};' >> "${CONFIG_FILE}"
 # ----- End -----------------------------------------------------------
 
+# ----- Begin /service-info creation ----------------------------------
+node ./create_service_info.js > dist/static/service-info.json
+# ----- End -----------------------------------------------------------
+
 echo "[bento_web] [entrypoint] starting NGINX"
 nginx -g 'daemon off;'

--- a/entrypoint.dev.sh
+++ b/entrypoint.dev.sh
@@ -5,5 +5,9 @@ if [ -z "${BENTO_WEB_PORT}" ]; then
   export BENTO_WEB_PORT=80
 fi
 
+# ----- Begin /service-info creation ----------------------------------
+node ./create_service_info.js > dist/static/service-info.json
+# ----- End -----------------------------------------------------------
+
 npm install
 npm run start

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,5 +17,10 @@ http {
             root /web/dist;
             try_files $uri $uri/ /index.html;
         }
+
+        location /service-info {
+            default_type application/json;
+            alias /web/dist/static/service-info.json;
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "watch": "npx webpack --watch --mode development",
     "build": "npx webpack --mode production",
     "build-dev": "npx webpack --mode development",
-    "start": "npx webpack serve --mode development"
+    "start": "npx webpack serve --mode development --no-web-socket-server"
   },
   "repository": {
     "type": "git",

--- a/src/components/ServiceList.js
+++ b/src/components/ServiceList.js
@@ -90,7 +90,8 @@ const ServiceList = () => {
         Object.entries(state.chordServices.itemsByArtifact).map(([artifact, service]) => ({
             ...service,
             key: artifact,
-            artifact,  // TODO: Remove this when no longer required for backwards compatibility with old chord_services
+            artifact,  // TODO: Remove this when no longer required for ba$ckwards compatibility with old chord_services
+            url: service.url ?? state.services.itemsByArtifact[artifact]?.url, // TODO: "
             serviceInfo: state.services.itemsByArtifact[artifact] ?? null,
             status: {
                 status: artifact in state.services.itemsByArtifact,

--- a/src/components/ServiceList.js
+++ b/src/components/ServiceList.js
@@ -28,7 +28,7 @@ const renderGitInfo = (tag, record, key) => <Tag key={key} color={tag.color}>{ta
 const serviceColumns = (isOwner) => [
     {
         title: "Artifact",
-        dataIndex: "type.artifact",
+        dataIndex: "artifact",
         render: (artifact) =>
             artifact ? (
                 isOwner ? (
@@ -58,7 +58,7 @@ const serviceColumns = (isOwner) => [
     },
     {
         title: "URL",
-        dataIndex: "serviceInfo.url",
+        dataIndex: "url",
         // url is undefined when service-registry does not receive replies from
         // the container.
         render: (url) => url ? <a href={`${url}/service-info`}>{`${url}/service-info`}</a> : "N/A",
@@ -87,12 +87,12 @@ const serviceColumns = (isOwner) => [
 
 const ServiceList = () => {
     const dataSource = useSelector((state) =>
-        state.chordServices.items.map((service) => ({
+        Object.entries(state.chordServices.itemsByArtifact).map(([artifact, service]) => ({
             ...service,
-            key: `${service.type.organization}:${service.type.artifact}`,
-            serviceInfo: state.services.itemsByArtifact[service.type.artifact] || null,
+            key: artifact,
+            serviceInfo: state.services.itemsByArtifact[artifact] || null,
             status: {
-                status: state.services.itemsByArtifact.hasOwnProperty(service.type.artifact),
+                status: state.services.itemsByArtifact.hasOwnProperty(artifact),
                 dataService: service.data_service,
             },
             loading: state.services.isFetching,

--- a/src/components/ServiceList.js
+++ b/src/components/ServiceList.js
@@ -90,9 +90,9 @@ const ServiceList = () => {
         Object.entries(state.chordServices.itemsByArtifact).map(([artifact, service]) => ({
             ...service,
             key: artifact,
-            serviceInfo: state.services.itemsByArtifact[artifact] || null,
+            serviceInfo: state.services.itemsByArtifact[artifact] ?? null,
             status: {
-                status: state.services.itemsByArtifact.hasOwnProperty(artifact),
+                status: artifact in state.services.itemsByArtifact,
                 dataService: service.data_service,
             },
             loading: state.services.isFetching,

--- a/src/components/ServiceList.js
+++ b/src/components/ServiceList.js
@@ -90,6 +90,7 @@ const ServiceList = () => {
         Object.entries(state.chordServices.itemsByArtifact).map(([artifact, service]) => ({
             ...service,
             key: artifact,
+            artifact,  // TODO: Remove this when no longer required for backwards compatibility with old chord_services
             serviceInfo: state.services.itemsByArtifact[artifact] ?? null,
             status: {
                 status: artifact in state.services.itemsByArtifact,

--- a/src/components/datasets/DatasetTables.js
+++ b/src/components/datasets/DatasetTables.js
@@ -23,7 +23,6 @@ const NA_TEXT = <span style={{ color: "#999", fontStyle: "italic" }}>N/A</span>;
 const DatasetTables = ({ isPrivate, project, dataset, onTableIngest, isFetchingTables }) => {
     const dispatch = useDispatch();
 
-    const chordServicesByArtifact = useSelector((state) => state.chordServices.itemsByArtifact);
     const serviceInfoByArtifact = useSelector((state) => state.services.itemsByArtifact);
 
     const dataTypesByArtifact = useSelector(state => state.serviceDataTypes.dataTypesByServiceArtifact);

--- a/src/components/datasets/DatasetTables.js
+++ b/src/components/datasets/DatasetTables.js
@@ -63,13 +63,7 @@ const DatasetTables = ({ isPrivate, project, dataset, onTableIngest, isFetchingT
     };
 
     const showTableSummaryModal = (table) => {
-        dispatch(
-            fetchTableSummaryIfPossible(
-                chordServicesByArtifact[table.service_artifact],
-                serviceInfoByArtifact[table.service_artifact],
-                table.table_id
-            )
-        );
+        dispatch(fetchTableSummaryIfPossible(serviceInfoByArtifact[table.service_artifact], table.table_id));
         setTableSummaryModalVisible(true);
         setSelectedTable(table);
     };

--- a/src/components/datasets/table/TableAdditionModal.js
+++ b/src/components/datasets/table/TableAdditionModal.js
@@ -10,7 +10,7 @@ import {datasetPropTypesShape, projectPropTypesShape} from "../../../propTypes";
 
 
 const modalTitle = (dataset, project) =>
-    `Add Table to Dataset "${(dataset || {}).title || ""}" (Project "${(project || {}).title || ""}")`;
+    `Add Table to Dataset "${dataset?.title || ""}" (Project "${project?.title || ""}")`;
 
 class TableAdditionModal extends Component {
     componentDidMount() {

--- a/src/components/datasets/table/TableForm.js
+++ b/src/components/datasets/table/TableForm.js
@@ -16,13 +16,13 @@ class TableForm extends Component {
         return <Form style={this.props.style || {}}>
             <Form.Item label="Name">
                 {this.props.form.getFieldDecorator("name", {
-                    initialValue: (this.props.initialValue || {name: ""}).name || "",
+                    initialValue: this.props.initialValue?.name || "",
                     rules: [{required: true}, {min: 3}]
                 })(<Input placeholder="My Variant Dataset" size="large" />)}
             </Form.Item>
             <Form.Item label="Data Type">
                 {this.props.form.getFieldDecorator("dataType", {
-                    initialValue: (this.props.initialValue || {dataType: null}).dataType || null,
+                    initialValue: this.props.initialValue?.dataType || null,
                     rules: [{required: true}]
                 })(<Select style={{width: "100%"}}>{dataTypeOptions}</Select>)}
             </Form.Item>

--- a/src/components/manager/ManagerFilesContent.js
+++ b/src/components/manager/ManagerFilesContent.js
@@ -44,7 +44,7 @@ import {
 const sortByName = (a, b) => a.name.localeCompare(b.name);
 const generateFileTree = directory => [...directory].sort(sortByName).map(entry =>
     <Tree.TreeNode title={entry.name} key={entry.path} isLeaf={!entry.hasOwnProperty("contents")}>
-        {(entry || {contents: []}).contents ? generateFileTree(entry.contents) : null}
+        {entry?.contents ? generateFileTree(entry.contents) : null}
     </Tree.TreeNode>);
 
 const resourceLoadError = resource => `An error was encountered while loading ${resource}`;
@@ -115,16 +115,13 @@ class ManagerFilesContent extends Component {
         try {
             this.setState({loadingFileContents: true});
 
-            // TODO: Proper url stuff
-            // TODO: Don't hard-code replace
-            const r = await fetch(`${this.props.dropBoxService.url}/objects${
-                file.replace("/chord/data/drop-box", "")}`);
+            const r = await fetch(`${this.props.dropBoxService.url}/objects/${file}`);
 
             this.setState({
                 loadingFileContents: false,
                 fileContents: {
                     ...this.state.fileContents,
-                    [file]: r.ok ? await r.text() : resourceLoadError(file)
+                    [file]: r.ok ? await r.text() : resourceLoadError(file),
                 }
             });
         } catch (e) {
@@ -133,7 +130,7 @@ class ManagerFilesContent extends Component {
                 loadingFileContents: false,
                 fileContents: {
                     ...this.state.fileContents,
-                    [file]: resourceLoadError(file)
+                    [file]: resourceLoadError(file),
                 }
             });
         }

--- a/src/components/manager/projects/RoutedProject.js
+++ b/src/components/manager/projects/RoutedProject.js
@@ -119,10 +119,8 @@ class RoutedProject extends Component {
             console.log("tbl", tables);
 
             const tableList = projectTableRecords
-                .filter(tableOwnership => {
-                    console.log("to", tableOwnership, tables[tableOwnership.service_id]);
-                    return tableOwnership.table_id in (tables[tableOwnership.service_id]?.tablesByID ?? {});
-                })
+                .filter(tableOwnership =>
+                    tableOwnership.table_id in (tables[tableOwnership.service_id]?.tablesByID ?? {}))
                 .map(tableOwnership => ({
                     ...tableOwnership,
                     ...tables[tableOwnership.service_id].tablesByID[tableOwnership.table_id],

--- a/src/components/manager/projects/RoutedProject.js
+++ b/src/components/manager/projects/RoutedProject.js
@@ -194,7 +194,7 @@ RoutedProject.propTypes = {
     projectsByID: PropTypes.objectOf(projectPropTypesShape),
 
     projectTables: PropTypes.arrayOf(PropTypes.object),  // TODO: Shape
-    projectTablesByProjectID: PropTypes.objectOf(PropTypes.object),  // TODO: Shape
+    projectTablesByProjectID: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)),  // TODO: Shape
 
     loadingProjects: PropTypes.bool,
 

--- a/src/components/manager/runs/RunListContent.js
+++ b/src/components/manager/runs/RunListContent.js
@@ -54,13 +54,13 @@ RunListContent.propTypes = {
 
 const mapStateToProps = state => ({
     runs: state.runs.items.map(r => {
-        const runDetails = (state.runs.itemsByID[r.run_id] || {details: null}).details;
+        const {name, start_time, end_time} = state.runs.itemsByID[r.run_id]?.details?.run_log ?? {};
         return {
             ...r,
             purpose: "Ingestion",  // TODO: Not hard-coded, Ingestion or Analysis
-            name: (runDetails || {run_log: {name: ""}}).run_log.name || "",
-            start_time: (runDetails || {run_log: {start_time: ""}}).run_log.start_time || "",
-            end_time: (runDetails || {run_log: {end_time: ""}}).run_log.end_time || ""
+            name: name || "",
+            start_time: start_time || "",
+            end_time: end_time || "",
         };
     }),
     servicesFetching: state.services.isFetchingAll,

--- a/src/components/manager/runs/RunListContent.js
+++ b/src/components/manager/runs/RunListContent.js
@@ -54,13 +54,13 @@ RunListContent.propTypes = {
 
 const mapStateToProps = state => ({
     runs: state.runs.items.map(r => {
-        const {name, start_time, end_time} = state.runs.itemsByID[r.run_id]?.details?.run_log ?? {};
+        const {name, start_time: startTime, end_time: endTime} = state.runs.itemsByID[r.run_id]?.details?.run_log ?? {};
         return {
             ...r,
             purpose: "Ingestion",  // TODO: Not hard-coded, Ingestion or Analysis
             name: name || "",
-            start_time: start_time || "",
-            end_time: end_time || "",
+            startTime: startTime || "",
+            endTime: endTime || "",
         };
     }),
     servicesFetching: state.services.isFetchingAll,

--- a/src/components/manager/runs/utils.js
+++ b/src/components/manager/runs/utils.js
@@ -17,7 +17,7 @@ export const sortDate = (a, b, dateProperty) =>
 
 // If end times are unset, sort by start times
 const sortEndDate = (a, b) =>
-    sortDate(a, b, (!a.end_time || !b.end_time) ? "start_time" : "end_time");
+    sortDate(a, b, (!a.startTime || !b.endTime) ? "startTime" : "endTime");
 
 export const RUN_STATE_TAG_COLORS = {
     UNKNOWN: "",
@@ -53,14 +53,14 @@ export const RUN_TABLE_COLUMNS = [
     },
     {
         title: "Started",
-        dataIndex: "start_time",
+        dataIndex: "startTime",
         width: 205,
         render: renderDate,
-        sorter: (a, b) => sortDate(a, b, "start_time"),
+        sorter: (a, b) => sortDate(a, b, "startTime"),
     },
     {
         title: "Ended",
-        dataIndex: "end_time",
+        dataIndex: "endTime",
         width: 205,
         render: renderDate,
         sorter: sortEndDate,

--- a/src/components/manager/runs/utils.js
+++ b/src/components/manager/runs/utils.js
@@ -15,6 +15,10 @@ export const sortDate = (a, b, dateProperty) =>
     (new Date(Date.parse(a[dateProperty])).getTime() || Infinity) -
     (new Date(Date.parse(b[dateProperty])).getTime() || Infinity);
 
+// If end times are unset, sort by start times
+const sortEndDate = (a, b) =>
+    sortDate(a, b, (!a.end_time || !b.end_time) ? "start_time" : "end_time");
+
 export const RUN_STATE_TAG_COLORS = {
     UNKNOWN: "",
     QUEUED: "blue",
@@ -33,40 +37,40 @@ export const RUN_TABLE_COLUMNS = [
         title: "Run ID",
         dataIndex: "run_id",
         sorter: (a, b) => a.run_id.localeCompare(b.run_id),
-        render: runID => <Link to={withBasePath(`admin/data/manager/runs/${runID}`)} style={{fontFamily: "monospace"}}>
-            {runID}</Link>
+        render: runID => <Link to={withBasePath(`admin/data/manager/runs/${runID}`)}
+                               style={{fontFamily: "monospace"}}>{runID}</Link>
     },
     {
         title: "Purpose",
         dataIndex: "purpose",
         width: 120,
-        sorter: (a, b) => a.purpose.localeCompare(b.purpose)
+        sorter: (a, b) => a.purpose.localeCompare(b.purpose),
     },
     {
         title: "Name",
         dataIndex: "name",
-        sorter: (a, b) => a.name.localeCompare(b.name)
+        sorter: (a, b) => a.name.localeCompare(b.name),
     },
     {
         title: "Started",
         dataIndex: "start_time",
         width: 205,
         render: renderDate,
-        sorter: (a, b) => sortDate(a, b, "start_time")
+        sorter: (a, b) => sortDate(a, b, "start_time"),
     },
     {
         title: "Ended",
         dataIndex: "end_time",
         width: 205,
         render: renderDate,
-        sorter: (a, b) => sortDate(a, b, "end_time"),
-        defaultSortOrder: "descend"
+        sorter: sortEndDate,
+        defaultSortOrder: "descend",
     },
     {
         title: "State",
         dataIndex: "state",
         width: 150,
         render: state => <Tag color={RUN_STATE_TAG_COLORS[state]}>{state}</Tag>,
-        sorter: (a, b) => a.state.localeCompare(b.state)
+        sorter: (a, b) => a.state.localeCompare(b.state),
     }
 ];

--- a/src/components/notifications/NotificationDrawer.js
+++ b/src/components/notifications/NotificationDrawer.js
@@ -18,20 +18,30 @@ class NotificationDrawer extends Component {
         this.seeAllNotifications = this.seeAllNotifications.bind(this);
     }
 
+    markAllAsRead() {
+        // TODO: Implement
+    }
+
     seeAllNotifications() {
         this.props.hideNotificationDrawer();
         this.props.history.push(withBasePath("notifications"));
     }
 
     render() {
-        return <Drawer title={"Notifications"}
+        const unreadNotifications = this.props.notifications.filter(n => !n.read);
+        return <Drawer bodyStyle={{padding: 0}} title="Notifications"
                        visible={this.props.notificationDrawerVisible}
-                       width="auto"
+                       width="500"
                        onClose={() => this.props.hideNotificationDrawer()}>
-            <NotificationList small={true} notifications={this.props.notifications.filter(n => !n.read)} />
-              <Divider />
-              <Button type="link" style={{width: "100%"}} onClick={this.seeAllNotifications}>
-                  See Read Notifications</Button>
+            <div style={{padding: "16px 24px", display: "flex", gap: "16px"}}>
+                <Button style={{flex: 1}} onClick={() => this.markAllAsRead()}
+                        disabled={!unreadNotifications}>Mark All as Read</Button>
+                <Button style={{flex: 1}} onClick={() => this.seeAllNotifications()}>See All Notifications</Button>
+            </div>
+            <Divider style={{margin: 0}} />
+            <div style={{padding: "0 24px"}}>
+                <NotificationList small={true} notifications={unreadNotifications} />
+            </div>
         </Drawer>;
     }
 }

--- a/src/components/notifications/NotificationDrawer.js
+++ b/src/components/notifications/NotificationDrawer.js
@@ -1,61 +1,50 @@
-import React, {Component} from "react";
-import {connect} from "react-redux";
-import {withRouter} from "react-router-dom";
-import PropTypes from "prop-types";
+import React, {useCallback, useMemo} from "react";
+import {useDispatch, useSelector} from "react-redux";
+import {useHistory} from "react-router-dom";
 
 import {Button, Divider, Drawer} from "antd";
 
 import NotificationList from "./NotificationList";
 
-import {hideNotificationDrawer} from "../../modules/notifications/actions";
+import {hideNotificationDrawer, markAllNotificationsAsRead} from "../../modules/notifications/actions";
 import {withBasePath} from "../../utils/url";
-import {notificationPropTypesShape} from "../../propTypes";
 
 
-class NotificationDrawer extends Component {
-    constructor(props) {
-        super(props);
-        this.seeAllNotifications = this.seeAllNotifications.bind(this);
-    }
+const NotificationDrawer = React.memo(() => {
+    const dispatch = useDispatch();
+    const history = useHistory();
 
-    markAllAsRead() {
-        // TODO: Implement
-    }
+    const markAllAsRead = useCallback(() => {
+        dispatch(markAllNotificationsAsRead());
+    }, []);
+    const seeAllNotifications = useCallback(() => {
+        dispatch(hideNotificationDrawer());
+        history.push(withBasePath("notifications"));
+    }, [dispatch, history]);
+    const hideNotificationDrawer_ = useCallback(() => {
+        dispatch(hideNotificationDrawer());
+    }, [dispatch]);
 
-    seeAllNotifications() {
-        this.props.hideNotificationDrawer();
-        this.props.history.push(withBasePath("notifications"));
-    }
+    const notifications = useSelector(state => state.notifications.items);
+    const unreadNotifications = useMemo(() => notifications.filter(n => !n.read), [notifications]);
+    const isMarkingAllAsRead = useSelector(state => state.notifications.isMarkingAllAsRead);
 
-    render() {
-        const unreadNotifications = this.props.notifications.filter(n => !n.read);
-        return <Drawer bodyStyle={{padding: 0}} title="Notifications"
-                       visible={this.props.notificationDrawerVisible}
-                       width="500"
-                       onClose={() => this.props.hideNotificationDrawer()}>
-            <div style={{padding: "16px 24px", display: "flex", gap: "16px"}}>
-                <Button style={{flex: 1}} onClick={() => this.markAllAsRead()}
-                        disabled={!unreadNotifications}>Mark All as Read</Button>
-                <Button style={{flex: 1}} onClick={() => this.seeAllNotifications()}>See All Notifications</Button>
-            </div>
-            <Divider style={{margin: 0}} />
-            <div style={{padding: "0 24px"}}>
-                <NotificationList small={true} notifications={unreadNotifications} />
-            </div>
-        </Drawer>;
-    }
-}
+    const notificationDrawerVisible = useSelector(state => state.notifications.drawerVisible);
 
-NotificationDrawer.propTypes = {
-    notificationDrawerVisible: PropTypes.bool,
-    notifications: PropTypes.arrayOf(notificationPropTypesShape),
-
-    hideNotificationDrawer: PropTypes.func,
-};
-
-const mapStateToProps = state => ({
-    notificationDrawerVisible: state.notifications.drawerVisible,
-    notifications: state.notifications.items,
+    return <Drawer bodyStyle={{padding: 0}} title="Unread Notifications"
+                   visible={notificationDrawerVisible}
+                   width="500"
+                   onClose={hideNotificationDrawer_}>
+        <div style={{padding: "16px 24px", display: "flex", gap: "16px"}}>
+            <Button style={{flex: 1}} onClick={markAllAsRead}
+                    disabled={!unreadNotifications} loading={isMarkingAllAsRead}>Mark All as Read</Button>
+            <Button style={{flex: 1}} onClick={seeAllNotifications}>See All Notifications</Button>
+        </div>
+        <Divider style={{margin: 0}} />
+        <div style={{padding: "0 24px"}}>
+            <NotificationList small={true} notifications={unreadNotifications} />
+        </div>
+    </Drawer>;
 });
 
-export default withRouter(connect(mapStateToProps, {hideNotificationDrawer})(NotificationDrawer));
+export default NotificationDrawer;

--- a/src/components/notifications/NotificationList.js
+++ b/src/components/notifications/NotificationList.js
@@ -59,13 +59,15 @@ class NotificationList extends Component {
                   renderItem={n => (
                       <List.Item key={n.id} actions={[
                           ...this.getNotificationActions(n),
-                          <Button key="mark-as-read"
-                                  type="link"
-                                  icon="read"
-                                  style={{padding: 0}}
-                                  onClick={() => this.props.markNotificationAsRead(n.id)}>
-                              Mark as Read
-                          </Button>
+                          ...(n.read ? [] : [
+                              <Button key="mark-as-read"
+                                      type="link"
+                                      icon="read"
+                                      style={{padding: 0}}
+                                      onClick={() => this.props.markNotificationAsRead(n.id)}>
+                                  Mark as Read
+                              </Button>
+                          ]),
                       ]}>
                           <List.Item.Meta
                               title={<>{n.title} <span style={{

--- a/src/components/notifications/NotificationList.js
+++ b/src/components/notifications/NotificationList.js
@@ -26,7 +26,11 @@ class NotificationList extends Component {
             case NOTIFICATION_WES_RUN_COMPLETED:
             case NOTIFICATION_WES_RUN_FAILED:
                 return [
-                    <Button key="run-details" onClick={() => this.props.navigateToWESRun(notification.action_target)}>
+                    <Button key="run-details" onClick={() => {
+                        // If they act on this notification, they read it.
+                        this.props.markNotificationAsRead(notification.id);
+                        this.props.navigateToWESRun(notification.action_target);
+                    }}>
                         Run Details
                     </Button>
                 ];
@@ -63,8 +67,17 @@ class NotificationList extends Component {
                               Mark as Read
                           </Button>
                       ]}>
-                          <List.Item.Meta title={n.title} description={n.description} style={{marginBottom: "8px"}} />
-                          {n.timestamp.toLocaleString()}
+                          <List.Item.Meta
+                              title={<>{n.title} <span style={{
+                                  color: "#999",
+                                  float: "right",
+                                  fontStyle: "italic",
+                                  fontWeight: "normal",
+                              }}>
+                                  {n.timestamp.toLocaleString()}
+                              </span></>}
+                              style={{marginBottom: "8px"}} />
+                          {n.description}
                       </List.Item>
                   )} />
         );

--- a/src/events.js
+++ b/src/events.js
@@ -10,6 +10,8 @@ const handlerSets = [
 
 // Global message handler
 export default async (message, history) => {
+    console.debug("Handling event", message);
+
     const handlers = handlerSets
         .flatMap(Object.entries)
         .filter(([p, _]) => message.channel.match(new RegExp(p)) !== null)

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import App from "./components/App";
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 export const store = createStore(rootReducer, composeEnhancers(applyMiddleware(thunkMiddleware)));
 
-const BENTO_URL_WITH_TRAILING_SLASH = BENTO_URL.endsWith("/") ? BENTO_URL : `${BENTO_URL}/`;
+const BENTO_URL_WITH_TRAILING_SLASH = BENTO_URL ? (BENTO_URL.endsWith("/") ? BENTO_URL : `${BENTO_URL}/`) : null;
 
 document.addEventListener("DOMContentLoaded", () => {
     const root = document.getElementById("root");

--- a/src/index.js
+++ b/src/index.js
@@ -18,13 +18,15 @@ import App from "./components/App";
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 export const store = createStore(rootReducer, composeEnhancers(applyMiddleware(thunkMiddleware)));
 
+const BENTO_URL_WITH_TRAILING_SLASH = BENTO_URL.endsWith("/") ? BENTO_URL : `${BENTO_URL}/`;
+
 document.addEventListener("DOMContentLoaded", () => {
     const root = document.getElementById("root");
-
+    
     // Fall back to checking path name if the front-end was built without CHORD_URL set
     // TODO: Use url.js base path for this? Do we care about the host?
     const isPopupAuthCallback = BENTO_URL
-        ? window.location.href.startsWith(`${BENTO_URL}${POPUP_AUTH_CALLBACK_URL}`)
+        ? window.location.href.startsWith(`${BENTO_URL_WITH_TRAILING_SLASH}${POPUP_AUTH_CALLBACK_URL}`)
         : window.location.pathname.includes(`/${POPUP_AUTH_CALLBACK_URL}`);  // TODO: Can we only use the fallback?
 
     // Handle auth popup callback

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const BENTO_URL_WITH_TRAILING_SLASH = BENTO_URL.endsWith("/") ? BENTO_URL : `${B
 
 document.addEventListener("DOMContentLoaded", () => {
     const root = document.getElementById("root");
-    
+
     // Fall back to checking path name if the front-end was built without CHORD_URL set
     // TODO: Use url.js base path for this? Do we care about the host?
     const isPopupAuthCallback = BENTO_URL

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -403,15 +403,7 @@ export const deleteProjectTableIfPossible = (project, table) => (dispatch, getSt
     if (getState().projectTables.isDeleting) return;
 
     const serviceType = getState().services.itemsByID[table.service_id].type;
-
-    // Backwards compatibility for:
-    // - old type ("group:artifact:version")
-    // - and new  ({"group": "...", "artifact": "...", "version": "..."})
-    const serviceArtifact = (typeof serviceType === "string")
-        ? serviceType.split(":")[1]
-        : serviceType.artifact;
-
-    const chordServiceInfo = getState().chordServices.itemsByArtifact[serviceArtifact];
+    const chordServiceInfo = getState().chordServices.itemsByArtifact[serviceType.artifact];
     if (chordServiceInfo.manageable_tables === false) {
         // If manageable_tables is set and not true, we can't delete the table.
         return;

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -100,7 +100,7 @@ export const fetchVariantTableSummaries = () => async (dispatch, getState) => {
     if (chordService) {
         for (const table of getState().projectTables.items) {
             if (table.service_artifact === "variant") {
-                await dispatch(fetchTableSummaryIfPossible(chordService,
+                await dispatch(fetchTableSummaryIfPossible(
                     {url: withBasePath("api/variant")}, table.table_id));
             }
         }

--- a/src/modules/notifications/actions.js
+++ b/src/modules/notifications/actions.js
@@ -14,19 +14,25 @@ export const addNotification = data => ({
 });
 
 export const FETCH_NOTIFICATIONS = createNetworkActionTypes("FETCH_NOTIFICATIONS");
-
-export const MARK_NOTIFICATION_AS_READ = createNetworkActionTypes("MARK_NOTIFICATION_AS_READ");
-
 export const fetchNotifications = networkAction(() => (dispatch, getState) => ({
     types: FETCH_NOTIFICATIONS,
     url: `${getState().services.notificationService.url}/notifications`,
     err: "Error fetching notifications"
 }));
 
+export const MARK_NOTIFICATION_AS_READ = createNetworkActionTypes("MARK_NOTIFICATION_AS_READ");
 export const markNotificationAsRead = networkAction(notificationID => (dispatch, getState) => ({
     types: MARK_NOTIFICATION_AS_READ,
     params: {notificationID},
     url: `${getState().services.notificationService.url}/notifications/${notificationID}/read`,
     req: {method: "PUT"},
     err: "Error marking notification as read"
+}));
+
+export const MARK_ALL_NOTIFICATIONS_AS_READ = createNetworkActionTypes("MARK_ALL_NOTIFICATIONS_AS_READ");
+export const markAllNotificationsAsRead = networkAction(() => (dispatch, getState) => ({
+    types: MARK_ALL_NOTIFICATIONS_AS_READ,
+    url: `${getState().services.notificationService.url}/notifications/all-read`,
+    req: {method: "PUT"},
+    err: "Error marking all notifications as read"
 }));

--- a/src/modules/notifications/events.js
+++ b/src/modules/notifications/events.js
@@ -10,7 +10,7 @@ const NOTIFICATION_WES_RUN_FAILED = "wes_run_failed";
 const NOTIFICATION_WES_RUN_COMPLETED = "wes_run_completed";
 
 export default {
-    [/^chord\.service\.notification$/.source]: (message, history) => async dispatch => {
+    [/^bento\.service\.notification$/.source]: (message, history) => async dispatch => {
         if (message.type !== EVENT_NOTIFICATION) return;
 
         const messageData = message.data || {};

--- a/src/modules/notifications/reducers.js
+++ b/src/modules/notifications/reducers.js
@@ -4,12 +4,14 @@ import {
     ADD_NOTIFICATION,
     FETCH_NOTIFICATIONS,
     MARK_NOTIFICATION_AS_READ,
+    MARK_ALL_NOTIFICATIONS_AS_READ,
 } from "./actions";
 
 export const notifications = (
     state = {
         isFetching: false,
         isMarkingAsRead: false,
+        isMarkingAllAsRead: false,
         drawerVisible: false,
         items: [],
         itemsByID: {}
@@ -54,6 +56,18 @@ export const notifications = (
             };
         case MARK_NOTIFICATION_AS_READ.FINISH:
             return {...state, isMarkingAsRead: false};
+
+        case MARK_ALL_NOTIFICATIONS_AS_READ.REQUEST:
+            return {...state, isMarkingAllAsRead: true};
+        case MARK_ALL_NOTIFICATIONS_AS_READ.RECEIVE:
+            return {
+                ...state,
+                items: state.items.map(i => !i.read ? {...i, read: true} : i),
+                itemsByID: Object.fromEntries(Object.entries(state.itemsByID)
+                    .map(([k, v]) => [k, v.read ? v : {...v, read: true}])),
+            };
+        case MARK_ALL_NOTIFICATIONS_AS_READ.FINISH:
+            return {...state, isMarkingAllAsRead: false};
 
         case SHOW_NOTIFICATION_DRAWER:
             return {...state, drawerVisible: true};

--- a/src/modules/services/actions.js
+++ b/src/modules/services/actions.js
@@ -103,7 +103,7 @@ export const fetchServicesWithMetadataAndDataTypesAndTables = () => async (dispa
 
     // - Skip services that don't provide data (i.e. no data types/workflows/etc.)
 
-    const dataServicesInfo = getState().services.items.map(s => {
+    const dataServicesInfo = getState().services.items.filter(s?.type).map(s => {
         // Backwards compatibility for:
         // - old type ("group:artifact:version")
         // - and new  ({"group": "...", "artifact": "...", "version": "..."})

--- a/src/modules/services/actions.js
+++ b/src/modules/services/actions.js
@@ -103,7 +103,7 @@ export const fetchServicesWithMetadataAndDataTypesAndTables = () => async (dispa
 
     // - Skip services that don't provide data (i.e. no data types/workflows/etc.)
 
-    const dataServicesInfo = getState().services.items.filter(s?.type).map(s => {
+    const dataServicesInfo = getState().services.items.filter(s => s?.type).map(s => {
         // Backwards compatibility for:
         // - old type ("group:artifact:version")
         // - and new  ({"group": "...", "artifact": "...", "version": "..."})

--- a/src/modules/services/actions.js
+++ b/src/modules/services/actions.js
@@ -145,7 +145,7 @@ export const fetchServicesWithMetadataAndDataTypesAndTables = () => async (dispa
 
 export const fetchServicesWithMetadataAndDataTypesAndTablesIfNeeded = () => (dispatch, getState) => {
     const state = getState();
-    if ((Object.keys(state.chordServices.itemsByID).length === 0 || state.services.items.length === 0 ||
+    if ((Object.keys(state.chordServices.itemsByArtifact).length === 0 || state.services.items.length === 0 ||
             Object.keys(state.serviceDataTypes.dataTypesByServiceID).length === 0) &&
             !state.services.isFetchingAll) {
         return dispatch(fetchServicesWithMetadataAndDataTypesAndTables());

--- a/src/modules/services/actions.js
+++ b/src/modules/services/actions.js
@@ -67,23 +67,23 @@ export const fetchServices = networkAction(() => ({
     err: "Error fetching services"
 }));
 
-export const fetchDataServiceDataTypes = networkAction((chordService, serviceInfo) => ({
+export const fetchDataServiceDataTypes = networkAction((serviceInfo) => ({
     types: FETCH_SERVICE_DATA_TYPES,
-    params: {chordService, serviceInfo},
+    params: {serviceInfo},
     url: `${serviceInfo.url}/data-types`,
     err: `Error fetching data types from service '${serviceInfo.name}'`
 }));
 
-export const fetchDataServiceDataTypeTables = networkAction((chordService, serviceInfo, dataType) => ({
+export const fetchDataServiceDataTypeTables = networkAction((serviceInfo, dataType) => ({
     types: FETCH_SERVICE_TABLES,
-    params: {chordService, serviceInfo, dataTypeID: dataType.id},
+    params: {serviceInfo, dataTypeID: dataType.id},
     url: `${serviceInfo.url}/tables?${createURLSearchParams({"data-type": dataType.id}).toString()}`,
     err: `Error fetching tables from service '${serviceInfo.name}' (data type ${dataType.id})`
 }));
 
-export const fetchDataServiceWorkflows = networkAction((chordService, serviceInfo) => ({
+export const fetchDataServiceWorkflows = networkAction((serviceInfo) => ({
     types: FETCH_SERVICE_WORKFLOWS,
-    params: {chordService, serviceInfo},
+    params: {serviceInfo},
     url: `${serviceInfo.url}/workflows`
 }));
 
@@ -121,13 +121,13 @@ export const fetchServicesWithMetadataAndDataTypesAndTables = () => async (dispa
     await Promise.all([
         (async () => {
             dispatch(beginFlow(LOADING_SERVICE_DATA_TYPES));
-            await Promise.all(dataServicesInfo.map(s => dispatch(fetchDataServiceDataTypes(s.chordService, s))));
+            await Promise.all(dataServicesInfo.map(s => dispatch(fetchDataServiceDataTypes(s))));
             dispatch(endFlow(LOADING_SERVICE_DATA_TYPES));
         })(),
 
         (async () => {
             dispatch(beginFlow(LOADING_SERVICE_WORKFLOWS));
-            await Promise.all(dataServicesInfo.map(s => dispatch(fetchDataServiceWorkflows(s.chordService, s))));
+            await Promise.all(dataServicesInfo.map(s => dispatch(fetchDataServiceWorkflows(s))));
             dispatch(endFlow(LOADING_SERVICE_WORKFLOWS));
         })()
     ]);
@@ -137,7 +137,7 @@ export const fetchServicesWithMetadataAndDataTypesAndTables = () => async (dispa
     dispatch(beginFlow(LOADING_SERVICE_TABLES));
     await Promise.all(dataServicesInfo.flatMap(s =>
         (getState().serviceDataTypes.dataTypesByServiceID[s.id]?.items ?? [])
-            .map(dt => dispatch(fetchDataServiceDataTypeTables(s.chordService, s, dt)))));
+            .map(dt => dispatch(fetchDataServiceDataTypeTables(s, dt)))));
     dispatch(endFlow(LOADING_SERVICE_TABLES));
 
     dispatch(endFlow(LOADING_ALL_SERVICE_DATA));

--- a/src/modules/services/actions.js
+++ b/src/modules/services/actions.js
@@ -14,8 +14,8 @@ import {withBasePath} from "../../utils/url";
 
 /**
  * @typedef {Object} CHORDService
- * @property {string} type.organization
- * @property {string} type.artifact
+ * @property {string} artifact
+ * @property {string} url
  * @property {boolean} data_service
  * @property {?boolean} manageable_tables
  */
@@ -145,7 +145,7 @@ export const fetchServicesWithMetadataAndDataTypesAndTables = () => async (dispa
 
 export const fetchServicesWithMetadataAndDataTypesAndTablesIfNeeded = () => (dispatch, getState) => {
     const state = getState();
-    if ((state.chordServices.items.length === 0 || state.services.items.length === 0 ||
+    if ((Object.keys(state.chordServices.itemsByID).length === 0 || state.services.items.length === 0 ||
             Object.keys(state.serviceDataTypes.dataTypesByServiceID).length === 0) &&
             !state.services.isFetchingAll) {
         return dispatch(fetchServicesWithMetadataAndDataTypesAndTables());

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -33,10 +33,10 @@ export const chordServices = (
         case FETCH_CHORD_SERVICES.RECEIVE:
             return {
                 ...state,
-                itemsByArtifact: Object.fromEntries(Object.entries(action.data.map(([composeID, service]) => ([
+                itemsByArtifact: Object.fromEntries(Object.entries(action.data).map(([composeID, service]) => ([
                     service.artifact,
                     {...service, composeID},
-                ])))),
+                ]))),
             };
         case FETCH_CHORD_SERVICES.FINISH:
             return {...state, isFetching: false};

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -23,8 +23,7 @@ import {
 export const chordServices = (
     state = {
         isFetching: false,
-        items: [],
-        itemsByArtifact: {}
+        itemsByArtifact: {},
     },
     action
 ) => {
@@ -34,8 +33,8 @@ export const chordServices = (
         case FETCH_CHORD_SERVICES.RECEIVE:
             return {
                 ...state,
-                items: action.data,
-                itemsByArtifact: Object.fromEntries(action.data.map(s => [s.type.artifact, s]))
+                itemsByArtifact: action.data,
+                // itemsByArtifact: Object.fromEntries(action.data.map(s => [s.type.artifact, s]))
             };
         case FETCH_CHORD_SERVICES.FINISH:
             return {...state, isFetching: false};

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -124,27 +124,30 @@ export const serviceDataTypes = (
         case LOADING_SERVICE_DATA_TYPES.TERMINATE:
             return {...state, isFetchingAll: false};
 
-        case FETCH_SERVICE_DATA_TYPES.REQUEST:
+        case FETCH_SERVICE_DATA_TYPES.REQUEST: {
+            const {serviceInfo} = action;
             return {
                 ...state,
                 dataTypesByServiceID: {
                     ...state.dataTypesByServiceID,
-                    [action.serviceInfo.id]: {
-                        ...(state.dataTypesByServiceID[action.serviceInfo.id] ?? {items: null, itemsByID: null}),
+                    [serviceInfo.id]: {
+                        ...(state.dataTypesByServiceID[serviceInfo.id] ?? {items: null, itemsByID: null}),
                         isFetching: true
                     }
                 },
                 dataTypesByServiceArtifact: {
                     ...state.dataTypesByServiceArtifact,
-                    [action.chordService.type.artifact]: {
-                        ...(state.dataTypesByServiceArtifact[action.chordService.artifact] ??
+                    [serviceInfo.type.artifact]: {
+                        ...(state.dataTypesByServiceArtifact[serviceInfo.type.artifact] ??
                             {items: null, itemsByID: null}),
                         isFetching: true
                     }
                 }
             };
+        }
 
         case FETCH_SERVICE_DATA_TYPES.RECEIVE: {
+            const {serviceInfo} = action;
             const itemsByID = Object.fromEntries(action.data.map(d => [d.id, d]));
             return {
                 ...state,
@@ -154,36 +157,37 @@ export const serviceDataTypes = (
                 },
                 dataTypesByServiceID: {
                     ...state.dataTypesByServiceID,
-                    [action.serviceInfo.id]: {items: action.data, itemsByID, isFetching: false}
+                    [serviceInfo.id]: {items: action.data, itemsByID, isFetching: false},
                 },
                 dataTypesByServiceArtifact: {
                     ...state.dataTypesByServiceArtifact,
-                    // TODO: use serviceInfo.type.artifact instead when all use newest version
-                    [action.chordService.type.artifact]: {items: action.data, itemsByID, isFetching: false}
+                    [serviceInfo.type.artifact]: {items: action.data, itemsByID, isFetching: false},
                 },
                 lastUpdated: action.receivedAt
             };
         }
 
-        case FETCH_SERVICE_DATA_TYPES.ERROR:
+        case FETCH_SERVICE_DATA_TYPES.ERROR: {
+            const {serviceInfo} = action;
             return {
                 ...state,
                 dataTypesByServiceID: {
                     ...state.dataTypesByServiceID,
                     [action.serviceID]: {
-                        ...(state.dataTypesByServiceID[action.serviceInfo.id] ?? {items: null, itemsByID: null}),
-                        isFetching: false
+                        ...(state.dataTypesByServiceID[serviceInfo.id] ?? {items: null, itemsByID: null}),
+                        isFetching: false,
                     }
                 },
                 dataTypesByServiceArtifact: {
                     ...state.dataTypesByServiceArtifact,
                     [action.serviceID]: {
-                        ...(state.dataTypesByServiceArtifact[action.chordService.type.artifact] ||
-                            {items: null, itemsByID: null}),
-                        isFetching: false
+                        ...(state.dataTypesByServiceArtifact[serviceInfo.type.artifact]
+                            ?? {items: null, itemsByID: null}),
+                        isFetching: false,
                     }
                 }
             };
+        }
 
         default:
             return state;

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -77,11 +77,18 @@ export const services = (
                         // Backwards compatibility for:
                         // - old type ("group:artifact:version")
                         // - and new  ({"group": "...", "artifact": "...", "version": "..."})
-                        const serviceArtifact = (typeof s.type === "string")
-                            ? s.type.split(":")[1]
-                            : s.type.artifact;
 
-                        return [serviceArtifact, s];
+                        let serviceType = s.type;
+                        if (typeof serviceType === "string") {
+                            const [group, artifact, version] = s.type.split(":");
+                            serviceType = {
+                                group,
+                                artifact,
+                                version,
+                            };
+                        }
+
+                        return [serviceType.artifact, {...s, type: serviceType}];
                     }));
             return {
                 ...state,

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -151,7 +151,6 @@ export const serviceDataTypes = (
         case FETCH_SERVICE_DATA_TYPES.RECEIVE: {
             const {serviceInfo} = action;
             const itemsByID = Object.fromEntries(action.data.map(d => [d.id, d]));
-            console.log(serviceInfo, action.data);
             return {
                 ...state,
                 itemsByID: {

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -137,7 +137,7 @@ export const serviceDataTypes = (
                 dataTypesByServiceArtifact: {
                     ...state.dataTypesByServiceArtifact,
                     [action.chordService.type.artifact]: {
-                        ...(state.dataTypesByServiceArtifact[action.chordService.type.artifact] ??
+                        ...(state.dataTypesByServiceArtifact[action.chordService.artifact] ??
                             {items: null, itemsByID: null}),
                         isFetching: true
                     }

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -69,16 +69,20 @@ export const services = (
             return {...state, isFetching: true};
 
         case FETCH_SERVICES.RECEIVE: {
-            const itemsByArtifact = Object.fromEntries(action.data.map(s => {
-                // Backwards compatibility for:
-                // - old type ("group:artifact:version")
-                // - and new  ({"group": "...", "artifact": "...", "version": "..."})
-                const serviceArtifact = (typeof s.type === "string")
-                    ? s.type.split(":")[1]
-                    : s.type.artifact;
+            // Filter out services without a valid serviceInfo.type
+            const itemsByArtifact = Object.fromEntries(
+                action.data
+                    .filter(s => s?.type)
+                    .map(s => {
+                        // Backwards compatibility for:
+                        // - old type ("group:artifact:version")
+                        // - and new  ({"group": "...", "artifact": "...", "version": "..."})
+                        const serviceArtifact = (typeof s.type === "string")
+                            ? s.type.split(":")[1]
+                            : s.type.artifact;
 
-                return [serviceArtifact, s];
-            }));
+                        return [serviceArtifact, s];
+                    }));
             return {
                 ...state,
 

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -222,7 +222,7 @@ export const serviceTables = (
         case LOADING_SERVICE_TABLES.TERMINATE:
             return {...state, isFetchingAll: false};
 
-        case FETCH_SERVICE_TABLES.REQUEST:
+        case FETCH_SERVICE_TABLES.REQUEST: {
             const {serviceInfo} = action;
             return {
                 ...state,
@@ -234,6 +234,7 @@ export const serviceTables = (
                     }
                 },
             };
+        }
 
         case FETCH_SERVICE_TABLES.RECEIVE: {
             const {serviceInfo: {id: serviceID}, data, dataTypeID} = action;

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -31,11 +31,7 @@ export const chordServices = (
         case FETCH_CHORD_SERVICES.REQUEST:
             return {...state, isFetching: true};
         case FETCH_CHORD_SERVICES.RECEIVE:
-            return {
-                ...state,
-                itemsByArtifact: action.data,
-                // itemsByArtifact: Object.fromEntries(action.data.map(s => [s.type.artifact, s]))
-            };
+            return {...state, itemsByArtifact: action.data};
         case FETCH_CHORD_SERVICES.FINISH:
             return {...state, isFetching: false};
 

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -31,7 +31,13 @@ export const chordServices = (
         case FETCH_CHORD_SERVICES.REQUEST:
             return {...state, isFetching: true};
         case FETCH_CHORD_SERVICES.RECEIVE:
-            return {...state, itemsByArtifact: action.data};
+            return {
+                ...state,
+                itemsByArtifact: Object.fromEntries(Object.entries(action.data.map(([composeID, service]) => ([
+                    service.artifact,
+                    {...service, composeID},
+                ])))),
+            };
         case FETCH_CHORD_SERVICES.FINISH:
             return {...state, isFetching: false};
 

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -80,7 +80,7 @@ export const services = (
 
                         let serviceType = s.type;
                         if (typeof serviceType === "string") {
-                            const [group, artifact, version] = s.type.split(":");
+                            const [group, artifact, version] = serviceType.split(":");
                             serviceType = {
                                 group,
                                 artifact,

--- a/src/modules/services/reducers.js
+++ b/src/modules/services/reducers.js
@@ -36,7 +36,12 @@ export const chordServices = (
                 // Handle old CHORD services format
                 // TODO: Remove when no longer relevant
                 console.warn("The old chord_services.json format will be deprecated soon.");
-                return Object.fromEntries(action.data.map(s => [s.type.artifact, s]));
+                const byArtifact = Object.fromEntries(action.data.map(s => [s.type.artifact, s]));
+                return {
+                    ...state,
+                    itemsByArtifact: byArtifact,
+                    itemsByKind: byArtifact,  // technically wrong but only rarely; deprecated code to be removed
+                };
             }
 
             // Handle the new CHORD services format: an object with the docker-compose service ID as the key

--- a/src/modules/tables/actions.js
+++ b/src/modules/tables/actions.js
@@ -2,13 +2,13 @@ import {createNetworkActionTypes, networkAction} from "../../utils/actions";
 
 export const FETCH_TABLE_SUMMARY = createNetworkActionTypes("FETCH_TABLE_SUMMARY");
 
-const fetchTableSummary = networkAction((chordService, serviceInfo, tableID) => ({
+const fetchTableSummary = networkAction((serviceInfo, tableID) => ({
     types: FETCH_TABLE_SUMMARY,
-    params: {chordService, tableID},
+    params: {serviceInfo, tableID},
     url: `${serviceInfo.url}/tables/${tableID}/summary`  // TODO: Private...
 }));
 
-export const fetchTableSummaryIfPossible = (chordService, serviceInfo, tableID) => (dispatch, getState) => {
+export const fetchTableSummaryIfPossible = (serviceInfo, tableID) => (dispatch, getState) => {
     if (getState().tableSummaries.isFetching) return;
-    return dispatch(fetchTableSummary(chordService, serviceInfo, tableID));
+    return dispatch(fetchTableSummary(serviceInfo, tableID));
 };

--- a/src/modules/tables/reducers.js
+++ b/src/modules/tables/reducers.js
@@ -15,8 +15,8 @@ export const tableSummaries = (
                 ...state,
                 summariesByServiceArtifactAndTableID: {
                     ...state.summariesByServiceArtifactAndTableID,
-                    [action.chordService.type.artifact]: {
-                        ...(state.summariesByServiceArtifactAndTableID[action.chordService.type.artifact] || {}),
+                    [action.chordService.artifact]: {
+                        ...(state.summariesByServiceArtifactAndTableID[action.chordService.artifact] || {}),
                         [action.tableID]: action.data,
                     }
                 }

--- a/src/modules/tables/reducers.js
+++ b/src/modules/tables/reducers.js
@@ -10,17 +10,19 @@ export const tableSummaries = (
     switch (action.type) {
         case FETCH_TABLE_SUMMARY.REQUEST:
             return {...state, isFetching: true};
-        case FETCH_TABLE_SUMMARY.RECEIVE:
+        case FETCH_TABLE_SUMMARY.RECEIVE: {
+            const {serviceInfo: {type: {artifact}}, tableID, data} = action;
             return {
                 ...state,
                 summariesByServiceArtifactAndTableID: {
                     ...state.summariesByServiceArtifactAndTableID,
-                    [action.chordService.artifact]: {
-                        ...(state.summariesByServiceArtifactAndTableID[action.chordService.artifact] || {}),
-                        [action.tableID]: action.data,
+                    [artifact]: {
+                        ...(state.summariesByServiceArtifactAndTableID[artifact] || {}),
+                        [tableID]: data,
                     }
                 }
             };
+        }
         case FETCH_TABLE_SUMMARY.FINISH:
             return {...state, isFetching: false};
         default:

--- a/src/modules/wes/events.js
+++ b/src/modules/wes/events.js
@@ -3,7 +3,7 @@ import {receiveRunDetails} from "./actions";
 const EVENT_WES_RUN_UPDATED = "wes_run_updated";
 
 export default {
-    [/^chord\.service\.wes$/.source]: message => async dispatch => {
+    [/^bento\.service\.wes$/.source]: message => async dispatch => {
         if (message.type === EVENT_WES_RUN_UPDATED) {
             await dispatch(receiveRunDetails(message.data.run_id, message.data));
         }

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -31,15 +31,13 @@ export const serviceInfoPropTypesShape = PropTypes.shape({
 });
 
 export const chordServicePropTypesMixin = {
-    type: PropTypes.shape({
-        organization: PropTypes.string,
-        artifact: PropTypes.string,
-        language: PropTypes.string,
-    }),
+    artifact: PropTypes.string,
     repository: PropTypes.string,
     data_service: PropTypes.bool,
     manageable_tables: PropTypes.bool,
-    wsgi: PropTypes.bool,
+    disabled: PropTypes.bool,
+    url_template: PropTypes.string,
+    url: PropTypes.string,
 };
 
 // Gives components which include this in their state to props connection access to the drop box and loading status.

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -28,6 +28,14 @@ export const serviceInfoPropTypesShape = PropTypes.shape({
     updatedAt: PropTypes.string,
     environment: PropTypes.string,
     version: PropTypes.string.isRequired,
+    git_tag: PropTypes.string,
+    git_branch: PropTypes.string,
+    bento: PropTypes.shape({
+        serviceKind: PropTypes.string,
+        gitTag: PropTypes.string,
+        gitBranch: PropTypes.string,
+        gitCommit: PropTypes.string,
+    }),
 });
 
 export const chordServicePropTypesMixin = {

--- a/src/utils/serviceInfo.js
+++ b/src/utils/serviceInfo.js
@@ -1,0 +1,20 @@
+export const normalizeServiceInfo = serviceInfo => {
+    // Backwards compatibility for:
+    // - old type ("group:artifact:version")
+    // - and new  ({"group": "...", "artifact": "...", "version": "..."})
+
+    let serviceType = serviceInfo.type;
+    if (typeof serviceType === "string") {
+        const [group, artifact, version] = serviceType.split(":");
+        serviceType = {
+            group,
+            artifact,
+            version,
+        };
+    }
+
+    return {
+        ...serviceInfo,
+        type: serviceType,
+    };
+};

--- a/static/service-info.json
+++ b/static/service-info.json
@@ -1,0 +1,3 @@
+{
+  "error": "No service-info content provided"
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,9 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const BENTO_URL = process.env.BENTO_URL || process.env.CHORD_URL || null;
 const BASE_PATH = BENTO_URL ? (new URL(BENTO_URL)).pathname : "/";
 
+const createServiceInfo = require("./create_service_info");
+
+// noinspection JSUnusedGlobalSymbols
 module.exports = {
     entry: ["babel-polyfill", path.resolve(__dirname, "./src/index.js")],
     module: {
@@ -65,9 +68,35 @@ module.exports = {
             directory: path.join(__dirname, "static"),
         },
         compress: true,
-        port: process.env.BENTO_WEB_PORT ?? 9000,
         historyApiFallback: true,
 
-        allowedHosts: "all"
+        host: "0.0.0.0",
+        port: process.env.BENTO_WEB_PORT ?? 9000,
+
+        watchFiles: {
+            paths: [
+                "src/**/*.js",
+                "src/**/*.html",
+                "static/**/*",
+            ],
+            options: {
+                usePolling: true,
+            },
+        },
+
+        setupMiddlewares(middlewares, devServer) {
+            if (!devServer) {
+                throw new Error("webpack-dev-server is not defined");
+            }
+
+            devServer.app.get("/service-info", (req, res) => {
+                res.header("Content-Type", "application/json");
+                res.json(createServiceInfo.serviceInfo());
+            });
+
+            return middlewares;
+        },
+
+        allowedHosts: "all",
     },
 };


### PR DESCRIPTION
* Support new `bento_services.json` format while maintaining backwards-compatibility
* Reduce reliance on `bento_services.json` data wherever possible
* Improve WES run sorting by not pushing formerly stuck runs to the top
* Add a web `/service-info` endpoint 
* Lets Katsu (v2.17+) do its own table ownership deletion
* Rewrites/fixes issues with notifications & related components

**Requires Katsu v2.17 with garbage collect changes.**