### PR TITLE
Features/variant search improvements

### DIFF
--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -86,7 +86,7 @@ class DiscoveryQueryBuilder extends Component {
 
     handleSubmit = async () => {
         // signal to variants components, may work better in redux
-        this.setState({isSubmitting: true})                 
+        this.setState({isSubmitting: true});
 
         try {
             await Promise.all(Object.entries(this.forms).filter(f => f[1]).map(([_dt, f]) =>
@@ -103,7 +103,7 @@ class DiscoveryQueryBuilder extends Component {
             (this.props.onSubmit ?? nop)();
         } catch (err) {
             console.error(err);
-            this.setState({isSubmitting: false})
+            this.setState({isSubmitting: false});
         }
     };
 

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -85,7 +85,9 @@ class DiscoveryQueryBuilder extends Component {
     }
 
     handleSubmit = async () => {
-        this.setState({isSubmitting: true});
+        // signal to variants components, may work better in redux
+        this.setState({isSubmitting: true})                 
+
         try {
             await Promise.all(Object.entries(this.forms).filter(f => f[1]).map(([_dt, f]) =>
                 new Promise((resolve, reject) => {
@@ -101,6 +103,7 @@ class DiscoveryQueryBuilder extends Component {
             (this.props.onSubmit ?? nop)();
         } catch (err) {
             console.error(err);
+            this.setState({isSubmitting: false})
         }
     };
 

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -18,7 +18,8 @@ class DiscoveryQueryBuilder extends Component {
         super(props);
 
         this.state = {
-            schemasModalShown: false
+            schemasModalShown: false,
+            isSubmitting: false
         };
 
         this.handleSubmit = this.handleSubmit.bind(this);
@@ -84,6 +85,7 @@ class DiscoveryQueryBuilder extends Component {
     }
 
     handleSubmit = async () => {
+        this.setState({isSubmitting: true});
         try {
             await Promise.all(Object.entries(this.forms).filter(f => f[1]).map(([_dt, f]) =>
                 new Promise((resolve, reject) => {
@@ -155,6 +157,7 @@ class DiscoveryQueryBuilder extends Component {
                     wrappedComponentRef={form => this.forms[id] = form}
                     onChange={fields => this.handleFormChange(dataType, fields)}
                     handleVariantHiddenFieldChange={this.handleVariantHiddenFieldChange}
+                    isSubmitting={this.state.isSubmitting}
                 />
             </Tabs.TabPane>;
         });

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -43,7 +43,7 @@ const CONDITION_RULES = [
 
             // noinspection JSCheckFunctionSignatures
             if (
-                !VARIANT_OPTIONAL_FIELDS.includes(value.field) && 
+                !VARIANT_OPTIONAL_FIELDS.includes(value.field) &&
                 (searchValue === null ||
                     (!isEnum && !searchValue) ||
                     (isEnum && !value.fieldSchema.enum.includes(searchValue)))
@@ -247,7 +247,7 @@ class DiscoverySearchForm extends Component {
         if (values.hasOwnProperty("ref")) {
             updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].reference", ref);
         }
-        
+
         if (values.hasOwnProperty("alt")) {
             updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].alternative", alt);
         }
@@ -455,6 +455,7 @@ DiscoverySearchForm.propTypes = {
     isInternal: PropTypes.bool,
     formValues: PropTypes.object,
     handleVariantHiddenFieldChange: PropTypes.func,
+    isSubmitting: PropTypes.bool
 };
 
 export default Form.create({

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -50,7 +50,6 @@ class DiscoverySearchForm extends Component {
         this.state = {
             conditionsHelp: {},
             fieldSchemas: {},
-            variantSearchValues: {},
             isVariantSearch: props.dataType.id === "variant",
             isPhenopacketSearch: props.dataType.id === "phenopacket",
         };
@@ -72,9 +71,7 @@ class DiscoverySearchForm extends Component {
                 getFieldSchema(this.props.dataType.schema, f).search?.required ?? false)
             : [];
 
-        const stateUpdates = this.state.isVariantSearch
-            ? this.hiddenVariantSearchFields().map((c) => this.addCondition(c, undefined, true))
-            : requiredFields.map((c) => this.addCondition(c, undefined, true));
+        const stateUpdates = requiredFields.map(c => this.addCondition(c, undefined, true));
 
         // Add a single default condition if necessary
         // if (requiredFields.length === 0 && this.props.conditionType !== "join") {
@@ -175,15 +172,15 @@ class DiscoverySearchForm extends Component {
 
     // methods for user-friendly variant search
 
-    hiddenVariantSearchFields = () =>  [
-        "[dataset item].assembly_id",
-        "[dataset item].chromosome",
-        "[dataset item].start",
-        "[dataset item].end",
-        "[dataset item].calls.[item].genotype_type",
-        "[dataset item].alternative",
-        "[dataset item].reference",
-    ];
+    // hiddenVariantSearchFields = () =>  [
+    //     "[dataset item].assembly_id",
+    //     "[dataset item].chromosome",
+    //     "[dataset item].start",
+    //     "[dataset item].end",
+    //     "[dataset item].calls.[item].genotype_type",
+    //     "[dataset item].alternative",
+    //     "[dataset item].reference",
+    // ];
 
     updateConditions = (conditions, fieldName, newValue) => {
         console.log({CONDITIONSIN: conditions});
@@ -197,8 +194,6 @@ class DiscoverySearchForm extends Component {
 
     // fill hidden variant forms according to input in user-friendly variant search
     addVariantSearchValues = (values) => {
-        this.setState({variantSearchValues: {...this.state.variantSearchValues, ...values}});
-
         const {assemblyId, chrom, start, end, genotypeType, ref, alt } = values;
         const fields = this.props.formValues;
         let updatedConditionsArray = fields?.conditions;
@@ -275,7 +270,7 @@ class DiscoverySearchForm extends Component {
             case "[dataset item].end":
                 return OP_LESS_THAN_OR_EQUAL;
 
-          // assemblyID, chromosome, genotype
+          // assemblyID, chromosome, genotype, ref, alt
             default:
                 return OP_EQUALS;
         }
@@ -372,7 +367,12 @@ class DiscoverySearchForm extends Component {
         ));
 
         //for variant search, only show user-added fields, hide everything else
+        // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        // can probably accomplish the same thing, but with filter()
         const nonHiddenFields = formItems.slice(NUM_HIDDEN_VARIANT_FORM_ITEMS);
+
+        console.log({formItems: formItems})
+
 
         return <Form onSubmit={this.onSubmit}>
             {this.props.dataType.id === "variant" && (

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -379,6 +379,7 @@ class DiscoverySearchForm extends Component {
                 <VariantSearchHeader
                     addVariantSearchValues={this.addVariantSearchValues}
                     dataType={this.props.dataType}
+                    isSubmitting={this.props.isSubmitting}
                 />
             )}
             {this.state.isVariantSearch ? nonHiddenFields : formItems}

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -13,9 +13,10 @@ const geneDropdownText = (g) => {
     return `${g.name} chromosome: ${g.chrom} start: ${g.start} end: ${g.end}`;
 };
 
-const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
+const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, setLocusValidity}) => {
     const [autoCompleteOptions, setAutoCompleteOptions] = useState([]);
     const geneSearchResults = useSelector((state) => state.discovery.geneNameSearchResponse);
+    const [currentLocus, setCurrentLocus] = useState({chrom: null, start: null, end: null}) //needed for onBlur checking
     const dispatch = useDispatch();
 
     const showAutoCompleteOptions = assemblyId === "GRCh37" || assemblyId === "GRCh38";
@@ -25,6 +26,8 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
         const result = parse.exec(value);
 
         if (!result) {
+            setCurrentLocus({chrom: null, start: null, end: null})
+            setLocusValidity(false) 
             return;
         }
 
@@ -32,6 +35,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
         const start = Number(result[2]);
         const end = Number(result[3]);
 
+        setCurrentLocus({chrom: chrom, start: start, end: end})
         addVariantSearchValues({chrom: chrom, start: start, end: end});
     };
 
@@ -40,6 +44,10 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
     // handle position notation
         if (value.includes(":")) {
             parsePosition(value);
+
+            // let user finish typing position before showing error
+            setLocusValidity(true) 
+
             setAutoCompleteOptions([]);
             return;
         }
@@ -51,6 +59,12 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
         dispatch(performGohanGeneSearchIfPossible(value, assemblyId));
     };
 
+    const handleOnBlur = () => {
+        // antd has no "select on tab" option
+        // so check if there's a valid locus when tabbing away
+        handleLocusChange(currentLocus);
+    }
+
     const handleSelect = (value, options) => {
         const locus = options.props?.locus;
 
@@ -59,9 +73,10 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
             return;
         }
 
-    // don't use locus.assemblyId, since this is the lookup value
         const {chrom, start, end} = locus;
         addVariantSearchValues({chrom: chrom, start: start, end: end});
+        setCurrentLocus({chrom: chrom, start: start, end: end})
+        handleLocusChange(locus);
     };
 
     useEffect(() => {
@@ -73,6 +88,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
       options={autoCompleteOptions}
       onChange={handleChange}
       onSelect={handleSelect}
+      onBlur={handleOnBlur}
       // dropdownMenuStyle={}
       // backfill={true}
     >
@@ -93,6 +109,8 @@ const LocusSearch = ({assemblyId, addVariantSearchValues}) => {
 LocusSearch.propTypes = {
     assemblyId: PropTypes.string,
     addVariantSearchValues: PropTypes.func,
+    handleLocusChange: PropTypes.func,
+    setLocusValidity: PropTypes.func
 };
 
 

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -16,7 +16,8 @@ const geneDropdownText = (g) => {
 const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, setLocusValidity}) => {
     const [autoCompleteOptions, setAutoCompleteOptions] = useState([]);
     const geneSearchResults = useSelector((state) => state.discovery.geneNameSearchResponse);
-    const [currentLocus, setCurrentLocus] = useState({chrom: null, start: null, end: null}) //needed for onBlur checking
+    const [currentLocus, setCurrentLocus] = useState(
+        {chrom: null, start: null, end: null}); //needed for onBlur checking
     const dispatch = useDispatch();
 
     const showAutoCompleteOptions = assemblyId === "GRCh37" || assemblyId === "GRCh38";
@@ -26,8 +27,8 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
         const result = parse.exec(value);
 
         if (!result) {
-            setCurrentLocus({chrom: null, start: null, end: null})
-            setLocusValidity(false) 
+            setCurrentLocus({chrom: null, start: null, end: null});
+            setLocusValidity(false);
             return;
         }
 
@@ -35,7 +36,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
         const start = Number(result[2]);
         const end = Number(result[3]);
 
-        setCurrentLocus({chrom: chrom, start: start, end: end})
+        setCurrentLocus({chrom: chrom, start: start, end: end});
         addVariantSearchValues({chrom: chrom, start: start, end: end});
     };
 
@@ -46,7 +47,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
             parsePosition(value);
 
             // let user finish typing position before showing error
-            setLocusValidity(true) 
+            setLocusValidity(true);
 
             setAutoCompleteOptions([]);
             return;
@@ -63,7 +64,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
         // antd has no "select on tab" option
         // so check if there's a valid locus when tabbing away
         handleLocusChange(currentLocus);
-    }
+    };
 
     const handleSelect = (value, options) => {
         const locus = options.props?.locus;
@@ -75,7 +76,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
 
         const {chrom, start, end} = locus;
         addVariantSearchValues({chrom: chrom, start: start, end: end});
-        setCurrentLocus({chrom: chrom, start: start, end: end})
+        setCurrentLocus({chrom: chrom, start: start, end: end});
         handleLocusChange(locus);
     };
 

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -11,17 +11,16 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
   // Declare a state variable and a function to update it
     const [refFormReceivedValidKeystroke, setRefFormReceivedValidKeystroke ] = useState(true);
     const [altFormReceivedValidKeystroke , setAltFormReceivedValidKeystroke ] = useState(true);
+    const [activeRefValue, setActiveRefValue] = useState(null);
+    const [activeAltValue, setActiveAltValue] = useState(null);
+    const [lookupAssemblyId, setLookupAssemblyId] = useState(null);
 
-
-    // global state vars
+  // global state vars
     const variantsOverviewResults = useSelector((state) => state.explorer.variantsOverviewResponse);
     const overviewAssemblyIds = variantsOverviewResults?.assemblyIDs !== undefined
         ? Object.keys(variantsOverviewResults?.assemblyIDs)
         : [];
-    const [activeRefValue, setActiveRefValue] = useState(null);
-    const [activeAltValue, setActiveAltValue] = useState(null);
 
-    const [lookupAssemblyId, setLookupAssemblyId] = useState(null);
     const assemblySchema = dataType.schema?.properties?.assembly_id;
     const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type;
 
@@ -50,8 +49,7 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
                 setRefFormReceivedValidKeystroke(true);
             }, 1000);
         }
-        setActiveRefValue(validatedRef)
-
+        setActiveRefValue(validatedRef);
         addVariantSearchValues({ref: validatedRef});
     };
 
@@ -67,7 +65,7 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
             }, 1000);
         }
 
-        setActiveAltValue(validatedAlt)
+        setActiveAltValue(validatedAlt);
         addVariantSearchValues({alt: validatedAlt});
     };
 

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -6,7 +6,7 @@ import { useSelector } from "react-redux";
 
 import { notAlleleCharactersRegex } from "../../utils/misc";
 
-const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
+const VariantSearchHeader = ({dataType, addVariantSearchValues, isSubmitting}) => {
   // local state
   // Declare a state variable and a function to update it
     const [refFormReceivedValidKeystroke, setRefFormReceivedValidKeystroke ] = useState(true);
@@ -97,6 +97,8 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
 // Select needs
 // style
 // getSearchValue ??
+
+    console.log(`isSubmitting: ${isSubmitting}`)
 
     return (<>
     <Form.Item

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -19,7 +19,6 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
     const [activeRefValue, setActiveRefValue] = useState(null)
     const [activeAltValue, setActiveAltValue] = useState(null)
 
-  // or default to GRCh37?
     const [lookupAssemblyId, setLookupAssemblyId] = useState(null);
     const assemblySchema = dataType.schema?.properties?.assembly_id;
     const genotypeSchema = dataType.schema?.properties?.calls?.items?.properties?.genotype_type;

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -16,7 +16,8 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
   // global state vars
     const varOvRes = useSelector((state) => state.explorer.variantsOverviewResponse);
     const ovAsmIds = varOvRes?.assemblyIDs !== undefined ? Object.keys(varOvRes?.assemblyIDs) : [];
-
+    const [activeRefValue, setActiveRefValue] = useState(null)
+    const [activeAltValue, setActiveAltValue] = useState(null)
 
   // or default to GRCh37?
     const [lookupAssemblyId, setLookupAssemblyId] = useState(null);
@@ -27,15 +28,6 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
     const labelCol = {lg: { span: 24 }, xl: { span: 4 }, xxl: { span: 3 }};
     const wrapperCol = {lg: { span: 24 }, xl: { span: 20 }, xxl: { span: 18 }};
 
-    // obtain ref and alt values from state
-    const form = useSelector(state =>
-        state.explorer?.dataTypeFormsByDatasetID[Object.keys(state.explorer.dataTypeFormsByDatasetID)[0]]);
-    const activeRefValue = form[0].formValues?.conditions === undefined ? "" : form[0].formValues.conditions.filter(c =>
-        c.value.field === "[dataset item].reference"
-    )[0].value.searchValue;
-    const activeAltValue = form[0].formValues?.conditions === undefined ? "" : form[0].formValues.conditions.filter(c =>
-        c.value.field === "[dataset item].alternative"
-    )[0].value.searchValue;
     const handleAssemblyIdChange = (value) => {
 
         addVariantSearchValues({assemblyId: value});
@@ -57,8 +49,11 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
                 setRefFormReceivedValidKeystroke(true);
             }, 1000);
         }
+        setActiveRefValue(validatedRef)
+
         addVariantSearchValues({ref: validatedRef});
     };
+
     const handleAltChange = (e) => {
         const latestInputValue = e.target.value;
         const validatedAlt = validateAlleleText(latestInputValue);
@@ -70,6 +65,8 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
                 setAltFormReceivedValidKeystroke(true);
             }, 1000);
         }
+
+        setActiveAltValue(validatedAlt)
         addVariantSearchValues({alt: validatedAlt});
     };
 

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -13,7 +13,6 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues, isSubmitting}) =
     const [activeAltValue, setActiveAltValue] = useState(null);
     const [assemblyId, setAssemblyId] = useState(null);
     const [locus, setLocus] = useState({chrom: null, start: null, end: null});
-    const [genotype, setGenotype] = useState(null);
 
     // begin with required fields considered valid, so user isn't assaulted with error messages
     const initialValidity = {
@@ -44,7 +43,7 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues, isSubmitting}) =
 
     // custom validation since this form isn't submitted, it's just used to fill fields in hidden form
     // each field is validated invididually elsewhere
-    // for final validation, we only need to make sure required fields are non-empty  
+    // for final validation, we only need to make sure required fields are non-empty
     const validateVariantSearchForm = () => {
 
       // check assembly
@@ -62,29 +61,29 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues, isSubmitting}) =
     };
 
     useEffect(() => {
-      if (isSubmitting){
-        validateVariantSearchForm()
-      }
-    }, [isSubmitting])
+        if (isSubmitting) {
+            validateVariantSearchForm();
+        }
+    }, [isSubmitting]);
 
 
     const isValidLocus = (locus) => {
-      return locus.chrom != null  && locus.start != null && locus.end != null
-    }
+        return locus.chrom !== null  && locus.start !== null && locus.end !== null;
+    };
 
     const setLocusValidity = (isValid) => {
-      setFieldsValidity({...fieldsValidity, "locus": isValid});
-    }
+        setFieldsValidity({...fieldsValidity, "locus": isValid});
+    };
 
     const handleLocusChange = (locus) => {
         const {chrom, start, end} = locus;
 
-        if (isValidLocus(locus)){
-          setLocusValidity(true)
+        if (isValidLocus(locus)) {
+            setLocusValidity(true);
 
         } else {
-          setLocusValidity(false);
-          return
+            setLocusValidity(false);
+            return;
         }
 
         setLocus({chrom: chrom, start: start, end: end});
@@ -180,7 +179,10 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues, isSubmitting}) =
         validateStatus={fieldsValidity.locus ? "success" : "error"}
         required
     >
-      <LocusSearch assemblyId={assemblyId} addVariantSearchValues={addVariantSearchValues} handleLocusChange={handleLocusChange} setLocusValidity={setLocusValidity}/>
+      <LocusSearch assemblyId={assemblyId}
+                   addVariantSearchValues={addVariantSearchValues}
+                   handleLocusChange={handleLocusChange}
+                   setLocusValidity={setLocusValidity}/>
     </Form.Item>
     <Form.Item
       labelCol={labelCol}

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -13,11 +13,13 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
     const [altFormReceivedValidKeystroke , setAltFormReceivedValidKeystroke ] = useState(true);
 
 
-  // global state vars
-    const varOvRes = useSelector((state) => state.explorer.variantsOverviewResponse);
-    const ovAsmIds = varOvRes?.assemblyIDs !== undefined ? Object.keys(varOvRes?.assemblyIDs) : [];
-    const [activeRefValue, setActiveRefValue] = useState(null)
-    const [activeAltValue, setActiveAltValue] = useState(null)
+    // global state vars
+    const variantsOverviewResults = useSelector((state) => state.explorer.variantsOverviewResponse);
+    const overviewAssemblyIds = variantsOverviewResults?.assemblyIDs !== undefined
+        ? Object.keys(variantsOverviewResults?.assemblyIDs)
+        : [];
+    const [activeRefValue, setActiveRefValue] = useState(null);
+    const [activeAltValue, setActiveAltValue] = useState(null);
 
     const [lookupAssemblyId, setLookupAssemblyId] = useState(null);
     const assemblySchema = dataType.schema?.properties?.assembly_id;
@@ -81,7 +83,7 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
     };
 
     // set default selected assemblyId if only 1 is present
-    const shouldTriggerAssemblyIdChange = ovAsmIds.length === 1;
+    const shouldTriggerAssemblyIdChange = overviewAssemblyIds.length === 1;
     useEffect(() => {
         if (shouldTriggerAssemblyIdChange) {
             // wait some time before
@@ -89,7 +91,7 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
             // allow for the form and formValues
             // in the parent element to populate
             setTimeout(function() {
-                handleAssemblyIdChange(ovAsmIds[0]);
+                handleAssemblyIdChange(overviewAssemblyIds[0]);
             }, 500);
         }
     }, [shouldTriggerAssemblyIdChange]);
@@ -107,9 +109,9 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
     >
       <Select
         onChange={handleAssemblyIdChange}
-        defaultValue={ovAsmIds && shouldTriggerAssemblyIdChange && ovAsmIds[0]}
+        defaultValue={overviewAssemblyIds && shouldTriggerAssemblyIdChange && overviewAssemblyIds[0]}
       >
-       {ovAsmIds.map(v => <Select.Option key={v} value={v}>{v}</Select.Option>)}
+       {overviewAssemblyIds.map(v => <Select.Option key={v} value={v}>{v}</Select.Option>)}
       </Select>
     </Form.Item>
     <Form.Item

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -27,6 +27,12 @@ export const DEFAULT_SEARCH_PARAMETERS = {
     queryable: "all",
 };
 
+const VARIANT_OPTIONAL_FIELDS = [
+    "[dataset item].calls.[item].genotype_type",
+    "[dataset item].alternative",
+    "[dataset item].reference",
+];
+
 export const addDataTypeFormIfPossible = (dataTypeForms, dataType) =>
     (dataTypeForms.map(d => d.dataType.id).includes(dataType.id))
         ? dataTypeForms
@@ -46,7 +52,12 @@ export const extractQueryConditionsFromFormValues = formValues =>
         .filter(c => c !== null);
 
 export const conditionsToQuery = conditions => {
-    const filteredConditions = conditions.filter(c => c.value && c.value.field);
+
+    // temp hack: remove any optional variant fields that are empty
+    // greatly simplifies management of variant forms UI
+    const afterVariantCleaning = conditions.filter(c => (!(VARIANT_OPTIONAL_FIELDS.includes(c.value.field) && !c.value.searchValue)));
+
+    const filteredConditions = afterVariantCleaning.filter(c => c.value && c.value.field);
     if (filteredConditions.length === 0) return null;
 
     return filteredConditions

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -55,7 +55,8 @@ export const conditionsToQuery = conditions => {
 
     // temp hack: remove any optional variant fields that are empty
     // greatly simplifies management of variant forms UI
-    const afterVariantCleaning = conditions.filter(c => (!(VARIANT_OPTIONAL_FIELDS.includes(c.value.field) && !c.value.searchValue)));
+    const afterVariantCleaning = conditions.filter(c =>
+        (!(VARIANT_OPTIONAL_FIELDS.includes(c.value.field) && !c.value.searchValue)));
 
     const filteredConditions = afterVariantCleaning.filter(c => c.value && c.value.field);
     if (filteredConditions.length === 0) return null;


### PR DESCRIPTION
This PR addresses multiple issues in the variants search UI, including accommodations for new issues (Redmine 
[1400](https://206.12.92.46/issues/1400), [1401](https://206.12.92.46/issues/1401), [1402](https://206.12.92.46/issues/1402)) along with some older headaches ([1404](https://206.12.92.46/issues/1404), [957](https://206.12.92.46/issues/957))

Large changes: 
- Variants search UI now handles optional fields. Any optional field left unfilled when search is launched will be ignored.
- `Genotype` field is now optional, so can be left empty. It is now also possible to make a selection but then remove it (with the "x" at the right edge of the input box).
- `Reference` and `Alternate` fields can be filled or left blank. Note that they only accept `ACGT/acgt`and `backspace` and will give error feedback for anything else. (This was added in pr #199).
- There is now some form verification for variants (Redmine [#1404](https://206.12.92.46/issues/1404)). Previously when a form was incorrectly filled no feedback was given.  User feedback is given on submit, there are still edge cases (such as multiple repeated and edited searches) where it appears earlier. 
- There is now also feedback when you tab away from the `Gene / position` field without making a correct entry. This is a partial solution to Redmine [#957](https://206.12.92.46/issues/957). A full solution to that issue is probably possible only by replacing antd's Autocomplete with one from a different library. 

Also:
- Fixed a bug in the legacy code that would generate duplicate form keys in some circumstances, leading to weird behaviour when deleting search conditions and adding new ones. 

### Notes

- Requires latest Gohan to test
- Owing to a [Prettier bug](https://github.com/prettier/prettier-vscode/issues/2041), there are several useless whitespace changes, I have not had time to revert them all. 
- ... and finally, this is not perfect code. Most of the problems grow out of the design issues: having a user-facing form that is not actually submitted, but instead controls fields in a different form that is hidden from the user. This is not ideal, and not an edge case that UI libraries will bother with. In the long term a better solution is to have a distinct "user-friendly" search interface that is independent of the existing one, rather than bolted onto it. This will be easier to use and easier to code. 