### PR TITLE
Patch variant autocomplete

### DIFF
--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -219,7 +219,9 @@ class DiscoverySearchForm extends Component {
             return;
         }
 
-        if (assemblyId) {
+        // some fields may be undefined, so check for key names, not values
+
+        if (values.hasOwnProperty("assemblyId")) {
             updatedConditionsArray = this.updateConditions(
                 updatedConditionsArray,
                 "[dataset item].assembly_id",
@@ -227,14 +229,11 @@ class DiscoverySearchForm extends Component {
             );
         }
 
-        if (chrom && start && end) {
+        if (values.hasOwnProperty("chrom") && values.hasOwnProperty("start") && values.hasOwnProperty("end")) {
             updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].chromosome", chrom);
             updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].start", start);
             updatedConditionsArray = this.updateConditions(updatedConditionsArray, "[dataset item].end", end);
         }
-
-        // optional fields are of interest even if undefined, so check for existence of keys instead of values
-        // ... user may have entered a value in an optional field, but then deleted it
 
         if (values.hasOwnProperty("genotypeType")) {
             updatedConditionsArray = this.updateConditions(

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -26,7 +26,6 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
         const result = parse.exec(value);
 
         if (!result) {
-            setLocusValidity(false);
             return {chrom: null, start: null, end: null};
         }
 

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -98,8 +98,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
             return;
         }
 
-        const {chrom, start, end} = locus;
-        addVariantSearchValues({chrom, start, end});
+        addVariantSearchValues(locus);
         handleLocusChange(locus);
     };
 
@@ -125,7 +124,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
             value={`${g.name}_${g.assemblyId}_autocomplete_option`}
 
             label={`${g.name} chrom: ${g.chrom}`}
-            locus={g}
+            locus={{"chrom": g.chrom, "start": g.start, "end": g.end}}
             // style={optionStyle}
           >{geneDropdownText(g)}</Option>
         ))}

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -34,7 +34,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
         const start = Number(result[2]);
         const end = Number(result[3]);
 
-        addVariantSearchValues({chrom: chrom, start: start, end: end});
+        addVariantSearchValues({chrom, start, end});
     };
 
     const handleChange = (value) => {
@@ -81,7 +81,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
         }
 
         const {chrom, start, end} = locus;
-        addVariantSearchValues({chrom: chrom, start: start, end: end});
+        addVariantSearchValues({chrom, start, end});
         handleLocusChange(locus);
     };
 
@@ -103,7 +103,7 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
           <Option
             key={`${g.name}_${g.assemblyId}`}
 
-            //add suffix to selection text to distinguish from user text
+            //add suffix to selection text to distinguish from user text, this text is not shown
             value={`${g.name}_${g.assemblyId}_autocomplete_option`}  
 
             label={`${g.name} chrom: ${g.chrom}`}

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -13,6 +13,21 @@ const geneDropdownText = (g) => {
     return `${g.name} chromosome: ${g.chrom} start: ${g.start} end: ${g.end}`;
 };
 
+const parsePosition = (value) => {
+    const parse = /(?:CHR|chr)([0-9]{1,2}|X|x|Y|y|M|m):(\d+)-(\d+)/;
+    const result = parse.exec(value);
+
+    if (!result) {
+        return {chrom: null, start: null, end: null};
+    }
+
+    const chrom = result[1].toUpperCase(); //for eg 'x', has no effect on numbers
+    const start = Number(result[2]);
+    const end = Number(result[3]);
+    return {chrom, start, end};
+};
+
+
 const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, setLocusValidity}) => {
     const [autoCompleteOptions, setAutoCompleteOptions] = useState([]);
     const geneSearchResults = useSelector((state) => state.discovery.geneNameSearchResponse);
@@ -20,21 +35,6 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
     const dispatch = useDispatch();
 
     const showAutoCompleteOptions = assemblyId === "GRCh37" || assemblyId === "GRCh38";
-
-    const parsePosition = (value) => {
-        const parse = /(?:CHR|chr)([0-9]{1,2}|X|x|Y|y|M|m):(\d+)-(\d+)/;
-        const result = parse.exec(value);
-
-        if (!result) {
-            return {chrom: null, start: null, end: null};
-        }
-
-        const chrom = result[1].toUpperCase(); //for eg 'x', has no effect on numbers
-        const start = Number(result[2]);
-        const end = Number(result[3]);
-
-        return {chrom, start, end};
-    };
 
     const handlePositionNotation = (value) => {
         const {chrom, start, end} = parsePosition(value);

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -83,9 +83,9 @@ const LocusSearch = ({assemblyId, addVariantSearchValues, handleLocusChange, set
         }
 
         if (isPositionNotation) {
-            const {chrom, start, end} = parsePosition(inputValue);
-            handleLocusChange({chrom, start, end});
-            addVariantSearchValues({chrom, start, end});
+            const position = parsePosition(inputValue);
+            handleLocusChange(position);
+            addVariantSearchValues(position);
         }
     };
 

--- a/src/components/discovery/VariantSearchHeader.js
+++ b/src/components/discovery/VariantSearchHeader.js
@@ -78,17 +78,10 @@ const VariantSearchHeader = ({dataType, addVariantSearchValues}) => {
     };
 
     const handleLocusChange = (locus) => {
-        const {chrom, start, end} = locus;
+        setLocusValidity(isValidLocus(locus));
 
-        if (isValidLocus(locus)) {
-            setLocusValidity(true);
-
-        } else {
-            setLocusValidity(false);
-            return;
-        }
-
-        setLocus({chrom: chrom, start: start, end: end});
+        // set even if invalid so we don't keep old values
+        setLocus(locus);
     };
 
     const handleAssemblyIdChange = (value) => {


### PR DESCRIPTION
Improved onBlur handling for Gene / position input in variants search: track current input value in component state and re-verify when tabbing away from input. 

Should resolve remaining issues with Redmine [#1404](https://206.12.92.46/issues/1404)
