### PR TITLE
Features/data type counts

### DIFF
--- a/src/components/discovery/DataTypeExplorationModal.js
+++ b/src/components/discovery/DataTypeExplorationModal.js
@@ -77,22 +77,26 @@ class DataTypeExplorationModal extends Component {
                 </Radio.Group>
                 <Tabs>
                     {Object.values(this.props.dataTypes).flatMap(ds => (ds.items ?? [])
-                        .filter(dataType => dataType.queryable && dataType.count > 0)
+                        .filter(dataType => (dataType.queryable ?? true) && dataType.count > 0)
                         .map(dataType =>
-                        <Tabs.TabPane tab={dataType.label ?? dataType.id} key={dataType.id}>
-                            {this.state.view === "tree" ? (
-                                <SchemaTree schema={dataType.schema} />
-                            ) : (
-                                <>
-                                    <Input.Search allowClear={true}
-                                                  onChange={e => this.onFilterChange(e.target.value)}
-                                                  placeholder="Search for a field..." style={{marginBottom: "16px"}} />
-                                    <Table bordered={true}
-                                           columns={FIELD_COLUMNS}
-                                           dataSource={this.getTableData(dataType)} />
-                                </>
-                            )}
-                        </Tabs.TabPane>
+                            <Tabs.TabPane tab={dataType.label ?? dataType.id} key={dataType.id}>
+                                {this.state.view === "tree" ? (
+                                    <SchemaTree schema={dataType.schema} />
+                                ) : (
+                                    <>
+                                        <Input.Search
+                                            allowClear={true}
+                                            onChange={e => this.onFilterChange(e.target.value)}
+                                            placeholder="Search for a field..."
+                                            style={{marginBottom: "16px"}}
+                                        />
+                                        <Table
+                                            bordered={true}
+                                            columns={FIELD_COLUMNS}
+                                            dataSource={this.getTableData(dataType)} />
+                                    </>
+                                )}
+                            </Tabs.TabPane>
                         ))}
                 </Tabs>
             </div>

--- a/src/components/discovery/DataTypeExplorationModal.js
+++ b/src/components/discovery/DataTypeExplorationModal.js
@@ -76,7 +76,9 @@ class DataTypeExplorationModal extends Component {
                     <Radio.Button value="table"><Icon type="table" /> Table Detail View</Radio.Button>
                 </Radio.Group>
                 <Tabs>
-                    {Object.values(this.props.dataTypes).flatMap(ds => (ds.items ?? []).map(dataType =>
+                    {Object.values(this.props.dataTypes).flatMap(ds => (ds.items ?? [])
+                        .filter(dataType => dataType.queryable && dataType.count > 0)
+                        .map(dataType =>
                         <Tabs.TabPane tab={dataType.label ?? dataType.id} key={dataType.id}>
                             {this.state.view === "tree" ? (
                                 <SchemaTree schema={dataType.schema} />
@@ -91,7 +93,7 @@ class DataTypeExplorationModal extends Component {
                                 </>
                             )}
                         </Tabs.TabPane>
-                    ))}
+                        ))}
                 </Tabs>
             </div>
         </Modal>;

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -138,7 +138,7 @@ class DiscoveryQueryBuilder extends Component {
                     .filter(s => (this.props.dataTypes[s.id]?.items ?? []).length)
                     .flatMap(s =>
                         this.props.dataTypes[s.id].items
-                            .filter(dt => dt.queryable && dt.count > 0)
+                            .filter(dt => (dt.queryable ?? true) && dt.count > 0)
                             .map(dt =>
                                 <Menu.Item key={`${s.id}:${dt.id}`}>{dt.label ?? dt.id}</Menu.Item>
                             )

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -137,9 +137,12 @@ class DiscoveryQueryBuilder extends Component {
                 {this.props.servicesInfo
                     .filter(s => (this.props.dataTypes[s.id]?.items ?? []).length)
                     .flatMap(s =>
-                        this.props.dataTypes[s.id].items.map(dt =>
-                            <Menu.Item key={`${s.id}:${dt.id}`}>{dt.label ?? dt.id}</Menu.Item>
-                        ))
+                        this.props.dataTypes[s.id].items
+                            .filter(dt => dt.queryable && dt.count > 0)
+                            .map(dt =>
+                                <Menu.Item key={`${s.id}:${dt.id}`}>{dt.label ?? dt.id}</Menu.Item>
+                            )
+                    )
                 }
             </Menu>
         );


### PR DESCRIPTION
Add filtering for queryable and non-zero count dataTypes.

In this PR, the DiscoveryQueryBuilder and DataTypeExplorationModal components are updated to filter out the data types that are not queryable or have zero counts.

Changes include:

- Filtering non-queryable dataTypes: The component now lists data types with the queryable property set to true.
- Filtering zero count dataTypes: The component also filters out the data types with zero counts. 