### PR TITLE
[12] fix: fetch Gohan overview

### DIFF
--- a/src/modules/discovery/actions.js
+++ b/src/modules/discovery/actions.js
@@ -6,7 +6,7 @@ export const PERFORM_GOHAN_GENE_SEARCH = createNetworkActionTypes("GOHAN_GENE_SE
 
 
 export const performGohanGeneSearchIfPossible = (searchTerm, assemblyId) => (dispatch, getState) => {
-    const gohanUrl = getState()?.services?.gohan?.url;
+    const gohanUrl = getState()?.services?.itemsByKind?.gohan?.url;
     if (!gohanUrl) return;
     const queryString = `/genes/search?term=${searchTerm}&assemblyId=${assemblyId}`;
     const searchUrl = `${gohanUrl}${queryString}`;

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -154,7 +154,7 @@ export const setIgvPosition = (igvPosition) => ({
 });
 
 export const performGetGohanVariantsOverviewIfPossible = () => (dispatch, getState) => {
-    const gohanUrl = getState()?.services?.gohan?.url;
+    const gohanUrl = getState()?.services?.itemsByArtifact?.gohan?.url;
     if (!gohanUrl) return;
     const overviewPath = "/variants/overview";
     const getUrl = `${gohanUrl}${overviewPath}`;

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -154,7 +154,7 @@ export const setIgvPosition = (igvPosition) => ({
 });
 
 export const performGetGohanVariantsOverviewIfPossible = () => (dispatch, getState) => {
-    const gohanUrl = getState()?.services?.itemsByArtifact?.gohan?.url;
+    const gohanUrl = getState()?.services?.itemsByKind?.gohan?.url;
     if (!gohanUrl) return;
     const overviewPath = "/variants/overview";
     const getUrl = `${gohanUrl}${overviewPath}`;


### PR DESCRIPTION
Obtains the gohan url from service artifacts rather than services