### PR TITLE
Features/configurable extra properties schemas

### DIFF
--- a/src/components/manager/projects/ProjectJsonSchemaModal.js
+++ b/src/components/manager/projects/ProjectJsonSchemaModal.js
@@ -8,6 +8,7 @@ import PropTypes from "prop-types";
 const ProjectJsonSchemaModal = ({projectId, visible, onOk, onCancel}) => {
     const dispatch = useDispatch();
     const isCreatingJsonSchema = useSelector((state) => state.projects.isCreatingJsonSchema);
+    const extraPropertiesSchemaTypes = useSelector((state) => state.projects.extraPropertiesSchemaTypes);
     const [inputFormFields, setInputFormFields] = useState({});
     const [fileContent, setFileContent] = useState(null);
 
@@ -50,7 +51,7 @@ const ProjectJsonSchemaModal = ({projectId, visible, onOk, onCancel}) => {
             ]}
         >
             <ProjectJsonSchemaForm
-                schemaTypes={["PHENOPACKET", "BIOSAMPLE", "INDIVIDUAL"]}
+                schemaTypes={extraPropertiesSchemaTypes ? Object.keys(extraPropertiesSchemaTypes) : []}
                 initialValues={{}}
                 formValues={inputFormFields}
                 onChange={setInputFormFields}
@@ -67,6 +68,7 @@ ProjectJsonSchemaModal.propTypes = {
 
     onOk: PropTypes.func,
     onCancel: PropTypes.func,
+    extraPropertiesSchemaTypes: PropTypes.object.isRequired,
 };
 
 export default ProjectJsonSchemaModal;

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -32,6 +32,8 @@ export const CREATE_PROJECT = createNetworkActionTypes("CREATE_PROJECT");
 export const DELETE_PROJECT = createNetworkActionTypes("DELETE_PROJECT");
 export const SAVE_PROJECT = createNetworkActionTypes("SAVE_PROJECT");
 
+
+export const FETCH_EXTRA_PROPERTIES_SCHEMA_TYPES = createNetworkActionTypes("FETCH_EXTRA_PROPERTIES_SCHEMA_TYPES");
 export const CREATE_PROJECT_JSON_SCHEMA = createNetworkActionTypes("CREATE_PROJECT_JSON_SCHEMA");
 export const DELETE_PROJECT_JSON_SCHEMA = createNetworkActionTypes("DELETE_PROJECT_JSON_SCHEMA");
 
@@ -81,6 +83,7 @@ export const fetchProjectsWithDatasetsAndTables = () => async (dispatch, getStat
     dispatch(beginFlow(FETCHING_PROJECTS_WITH_TABLES));
     await dispatch(fetchProjects());
     await dispatch(fetchProjectTables(getState().projects.itemsByID));
+    await dispatch(fetchExtraPropertiesSchemaTypes());
     dispatch(endFlow(FETCHING_PROJECTS_WITH_TABLES));
 };
 
@@ -103,6 +106,11 @@ export const createProjectIfPossible = (project, history) => (dispatch, getState
     return dispatch(createProject(project, history));
 };
 
+export const fetchExtraPropertiesSchemaTypes = networkAction(() => (dispatch, getState) => ({
+    types: FETCH_EXTRA_PROPERTIES_SCHEMA_TYPES,
+    url: `${getState().services.metadataService.url}/api/extra_properties_schema_types`,
+    error: "Error fetching extra properties schema types",
+}));
 
 const createProjectJsonSchema = networkAction(projectJsonSchema => (dispatch, getState) => ({
     types: CREATE_PROJECT_JSON_SCHEMA,

--- a/src/modules/metadata/reducers.js
+++ b/src/modules/metadata/reducers.js
@@ -9,6 +9,7 @@ import {
     DELETE_PROJECT,
     SAVE_PROJECT,
 
+    FETCH_EXTRA_PROPERTIES_SCHEMA_TYPES,
     ADD_PROJECT_DATASET,
     SAVE_PROJECT_DATASET,
     DELETE_PROJECT_DATASET,
@@ -41,10 +42,12 @@ export const projects = (
         isAddingDataset: false,
         isSavingDataset: false,
         isDeletingDataset: false,
+        isFetchingExtraPropertiesSchemaInfo: false,
 
         isCreatingJsonSchema: false,
         isDeletingJsonSchema: false,
 
+        extraPropertiesSchemaTypes: {},
         items: [],
         itemsByID: {},
     },
@@ -203,7 +206,16 @@ export const projects = (
         case DELETE_PROJECT_DATASET.FINISH:
             return {...state, isDeletingDataset: false};
 
-        // CREATE_PROJECT_JSON_SCHEMA
+
+            // FETCH_EXTRA_PROPERTIES_SCHEMA_TYPES
+        case FETCH_EXTRA_PROPERTIES_SCHEMA_TYPES.REQUEST:
+            return {...state, isFetchingExtraPropertiesSchemaInfo: true};
+        case FETCH_EXTRA_PROPERTIES_SCHEMA_TYPES.RECEIVE:
+            return {...state, extraPropertiesSchemaTypes: action.data};
+        case FETCH_EXTRA_PROPERTIES_SCHEMA_TYPES.FINISH:
+            return {...state, isFetchingExtraPropertiesSchemaInfo: false};
+
+            // CREATE_PROJECT_JSON_SCHEMA
         case CREATE_PROJECT_JSON_SCHEMA.REQUEST:
             return {...state, isCreatingJsonSchema: true};
         case CREATE_PROJECT_JSON_SCHEMA.RECEIVE:


### PR DESCRIPTION
This PR implements the fetching of extra properties schema types. It allows retrieval of schema types dynamically from katsu.
The changes include:

- Updates in the actions.js file where a new action fetchExtraPropertiesSchemaTypes has been defined. This action hits the API endpoint api/extra_properties_schema_types to retrieve the data.
- Updates in the reducers.js file, where handling for the new action types is defined. 
- Updates in the component ProjectJsonSchemaModal that uses the ProjectJsonSchemaForm, where the extraPropertiesSchemaTypes are fetched from the Redux state and passed as a prop to the form component.