### PR TITLE
Fix/project creation modal

### DIFF
--- a/src/components/manager/projects/ManagerProjectDatasetContent.js
+++ b/src/components/manager/projects/ManagerProjectDatasetContent.js
@@ -41,20 +41,23 @@ const ManagerProjectDatasetContent = () => {
         () => dispatch(toggleProjectCreationModalAction()), [dispatch]);
 
     if (!isFetchingDependentData && projectMenuItems.length === 0) {
-        return <Layout>
-            <Layout.Content style={LAYOUT_CONTENT_STYLE}>
-                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={false}>
-                    <Typography.Title level={3}>No Projects</Typography.Title>
-                    <Typography.Paragraph style={PROJECT_HELP_TEXT_STYLE}>
-                        To create datasets and ingest data, you have to create a Bento project
-                        first. Bento projects have a name and description, and let you group related
-                        datasets together. You can then specify project-wide consent codes and data use
-                        restrictions to control data access.
-                    </Typography.Paragraph>
-                    <Button type="primary" icon="plus" onClick={toggleProjectCreationModal}>Create Project</Button>
-                </Empty>
-            </Layout.Content>
-        </Layout>;
+        return  <>
+            <ProjectCreationModal />
+            <Layout>
+                <Layout.Content style={LAYOUT_CONTENT_STYLE}>
+                    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={false}>
+                        <Typography.Title level={3}>No Projects</Typography.Title>
+                        <Typography.Paragraph style={PROJECT_HELP_TEXT_STYLE}>
+                            To create datasets and ingest data, you have to create a Bento project
+                            first. Bento projects have a name and description, and let you group related
+                            datasets together. You can then specify project-wide consent codes and data use
+                            restrictions to control data access.
+                        </Typography.Paragraph>
+                        <Button type="primary" icon="plus" onClick={toggleProjectCreationModal}>Create Project</Button>
+                    </Empty>
+                </Layout.Content>
+            </Layout>
+        </>
     }
 
     return <>

--- a/src/components/manager/projects/ManagerProjectDatasetContent.js
+++ b/src/components/manager/projects/ManagerProjectDatasetContent.js
@@ -57,7 +57,7 @@ const ManagerProjectDatasetContent = () => {
                     </Empty>
                 </Layout.Content>
             </Layout>
-        </>
+        </>;
     }
 
     return <>

--- a/src/components/manager/projects/ProjectCreationModal.js
+++ b/src/components/manager/projects/ProjectCreationModal.js
@@ -1,67 +1,55 @@
-import React, {Component} from "react";
-import {connect} from "react-redux";
-import {withRouter} from "react-router-dom";
+import React, {useCallback, useRef, useEffect} from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { withRouter, useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 
-import {Button, Modal} from "antd";
+import { Button, Modal } from "antd";
 
 import ProjectForm from "./ProjectForm";
 
-import {toggleProjectCreationModal} from "../../../modules/manager/actions";
-import {createProjectIfPossible} from "../../../modules/metadata/actions";
+import { toggleProjectCreationModal } from "../../../modules/manager/actions";
+import { createProjectIfPossible } from "../../../modules/metadata/actions";
 
+const ProjectCreationModal = () => {
 
-class ProjectCreationModal extends Component {
-    componentDidMount() {
-        this.handleCreateCancel = this.handleCreateCancel.bind(this);
-        this.handleCreateSubmit = this.handleCreateSubmit.bind(this);
-    }
+    const dispatch = useDispatch();
+    const history = useHistory();
 
-    handleCreateCancel() {
-        this.props.toggleProjectCreationModal();
-    }
+    const form = useRef(null);
 
-    handleCreateSubmit() {
-        this.form.validateFields(async (err, values) => {
+    const showCreationModal = useSelector(state => state.manager.projectCreationModal);
+    const isCreatingProject = useSelector(state => state.projects.isCreating);
+
+    const handleCreateCancel = useCallback(() => {
+        dispatch(toggleProjectCreationModal());
+    }, [dispatch]);
+
+    const handleCreateSubmit = useCallback(() => {
+        if (!form.current) {
+            console.error("Missing form ref.");
+        }
+
+        form.current.validateFields(async (err, values) => {
             if (err) {
                 console.error(err);
                 return;
             }
 
-            await this.props.createProjectIfPossible(values, this.props.history);
-
-            // TODO: Only clear values and close modal if submission was a success
-            this.form.resetFields();
-            this.props.toggleProjectCreationModal();
+            await dispatch(createProjectIfPossible(values, history));
+            form.current.resetFields();
+            dispatch(toggleProjectCreationModal());
         });
-    }
+    }, [dispatch])
 
-    render() {
-        return <Modal visible={this.props.showCreationModal} title="Create Project" width={600} footer={[
-            <Button key="cancel" onClick={this.handleCreateCancel}>Cancel</Button>,
-            <Button key="create"
-                    icon="plus"
-                    type="primary"
-                    onClick={this.handleCreateSubmit}
-                    loading={this.props.isCreatingProject}>Create</Button>,
-        ]} onCancel={this.handleCreateCancel}><ProjectForm ref={form => this.form = form} /></Modal>;
-    }
-}
+    return <Modal visible={showCreationModal} title="Create Project" width={600} footer={[
+        <Button key="cancel" onClick={handleCreateCancel}>Cancel</Button>,
+        <Button key="create"
+            icon="plus"
+            type="primary"
+            onClick={handleCreateSubmit}
+            loading={isCreatingProject}>Create</Button>,
+    ]} onCancel={handleCreateCancel}><ProjectForm ref={ref => form.current = ref} /></Modal>;
 
-ProjectCreationModal.propTypes = {
-    showCreationModal: PropTypes.bool,
-    isCreatingProject: PropTypes.bool,
-
-    toggleProjectCreationModal: PropTypes.func,
-    createProjectIfPossible: PropTypes.func,
 };
 
-const mapStateToProps = state => ({
-    showCreationModal: state.manager.projectCreationModal,
-    isCreatingProject: state.projects.isCreating,
-});
-
-export default withRouter(connect(mapStateToProps, {
-    toggleProjectCreationModal,
-    createProjectIfPossible,
-})(ProjectCreationModal));
+export default ProjectCreationModal;

--- a/src/components/manager/projects/ProjectCreationModal.js
+++ b/src/components/manager/projects/ProjectCreationModal.js
@@ -1,7 +1,6 @@
-import React, {useCallback, useRef, useEffect} from "react";
+import React, { useCallback, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { withRouter, useHistory } from "react-router-dom";
-import PropTypes from "prop-types";
+import { useHistory } from "react-router-dom";
 
 import { Button, Modal } from "antd";
 
@@ -39,15 +38,15 @@ const ProjectCreationModal = () => {
             form.current.resetFields();
             dispatch(toggleProjectCreationModal());
         });
-    }, [dispatch])
+    }, [dispatch]);
 
     return <Modal visible={showCreationModal} title="Create Project" width={600} footer={[
         <Button key="cancel" onClick={handleCreateCancel}>Cancel</Button>,
         <Button key="create"
-            icon="plus"
-            type="primary"
-            onClick={handleCreateSubmit}
-            loading={isCreatingProject}>Create</Button>,
+                icon="plus"
+                type="primary"
+                onClick={handleCreateSubmit}
+                loading={isCreatingProject}>Create</Button>,
     ]} onCancel={handleCreateCancel}><ProjectForm ref={ref => form.current = ref} /></Modal>;
 
 };


### PR DESCRIPTION
**Issue:** Conditional rendering in ManagerProjectDatasetContent would not render a ProjectCreationModal if `projectMenuItems.length === 0`. This prevented the modal to appear when clicking on the "Create Project" button.

**Solution:** Make `ManagerProjectDatasetContent` render a ProjectCreationModal, so that it can react to redux state changes.

**Additional change:** refactored ProjectCreationModal to a functional component.