### PR TITLE
[13] fix: retain search table settings and order

### DIFF
--- a/src/components/explorer/BiosamplesTable.js
+++ b/src/components/explorer/BiosamplesTable.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { useSortedColumns } from "./hooks/explorerHooks";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { countNonNullElements } from "../../utils/misc";
 import ExplorerSearchResultsTable from "./ExplorerSearchResultsTable";
@@ -9,6 +9,7 @@ import ExplorerSearchResultsTable from "./ExplorerSearchResultsTable";
 const NO_EXPERIMENTS_VALUE = -Infinity;
 
 const BiosampleRender = ({ biosample, alternateIds, individualId }) => {
+    const location = useLocation();
     const alternateIdsList = alternateIds ?? [];
     const listRender = alternateIdsList.length ? ` (${alternateIdsList.join(", ")})` : "";
     return (

--- a/src/components/explorer/BiosamplesTable.js
+++ b/src/components/explorer/BiosamplesTable.js
@@ -1,12 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { useSortedColumns, useCurrentTab} from "./hooks/explorerHooks";
 import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
 import { countNonNullElements } from "../../utils/misc";
 import ExplorerSearchResultsTable from "./ExplorerSearchResultsTable";
 
 const NO_EXPERIMENTS_VALUE = -Infinity;
 
 const BiosampleRender = ({ biosample, alternateIds, individualId }) => {
+    const { currentTab } = useCurrentTab();
     const alternateIdsList = alternateIds ?? [];
     const listRender = alternateIdsList.length ? ` (${alternateIdsList.join(", ")})` : "";
     return (
@@ -14,7 +17,7 @@ const BiosampleRender = ({ biosample, alternateIds, individualId }) => {
             <Link
                 to={{
                     pathname: `/data/explorer/individuals/${individualId}/biosamples`,
-                    state: { backUrl: location.pathname },
+                    state: { backUrl: location.pathname, currentTab },
                 }}
             >
                 {biosample}
@@ -166,12 +169,26 @@ const SEARCH_RESULT_COLUMNS_BIOSAMPLE = [
     },
 ];
 
-const BiosamplesTable = ({ data }) => {
+const BiosamplesTable = ({ data, datasetID }) => {
+    const tableSortOrder = useSelector(
+        (state) => state.explorer.tableSortOrderByDatasetID[datasetID]?.["biosamples"],
+    );
+
+    const { sortedData, columnsWithSortOrder } = useSortedColumns(
+        data,
+        tableSortOrder,
+        SEARCH_RESULT_COLUMNS_BIOSAMPLE,
+    );
+
     return (
         <ExplorerSearchResultsTable
             dataStructure={SEARCH_RESULT_COLUMNS_BIOSAMPLE}
-            data={data}
+            data={sortedData}
+            sortColumnKey={tableSortOrder?.sortColumnKey}
+            sortOrder={tableSortOrder?.sortOrder}
             activeTab="biosamples"
+            columns={columnsWithSortOrder}
+            currentPage={tableSortOrder?.currentPage}
         />
     );
 };
@@ -193,6 +210,7 @@ BiosamplesTable.propTypes = {
             experimentTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
         }),
     ).isRequired,
+    datasetID: PropTypes.string.isRequired,
 };
 
 

--- a/src/components/explorer/ExperimentsTable.js
+++ b/src/components/explorer/ExperimentsTable.js
@@ -1,9 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
+import { useSortedColumns, useCurrentTab } from "./hooks/explorerHooks";
 import ExplorerSearchResultsTable from "./ExplorerSearchResultsTable";
 
 const ExperimentRender = ({ experimentId, individual }) => {
+    const { currentTab } = useCurrentTab();
     const alternateIds = individual.alternate_ids ?? [];
     const listRender = alternateIds.length ? `(${alternateIds.join(", ")})` : "";
 
@@ -13,7 +16,7 @@ const ExperimentRender = ({ experimentId, individual }) => {
                 to={{
                     pathname: `/data/explorer/individuals/${individual.id}/experiments`,
                     hash: "#" + experimentId,
-                    state: { backUrl: location.pathname },
+                    state: { backUrl: location.pathname, currentTab },
                 }}
             >
                 {experimentId}
@@ -69,9 +72,26 @@ const SEARCH_RESULT_COLUMNS_EXP = [
     },
 ];
 
-const ExperimentsTable = ({ data }) => {
+const ExperimentsTable = ({ data, datasetID }) => {
+    const tableSortOrder = useSelector(
+        (state) => state.explorer.tableSortOrderByDatasetID[datasetID]?.["experiments"],
+    );
+
+    const { sortedData, columnsWithSortOrder } = useSortedColumns(
+        data,
+        tableSortOrder,
+        SEARCH_RESULT_COLUMNS_EXP,
+    );
     return (
-        <ExplorerSearchResultsTable dataStructure={SEARCH_RESULT_COLUMNS_EXP} data={data} activeTab="experiments" />
+        <ExplorerSearchResultsTable
+            dataStructure={SEARCH_RESULT_COLUMNS_EXP}
+            data={sortedData}
+            sortColumnKey={tableSortOrder?.sortColumnKey}
+            sortOrder={tableSortOrder?.sortOrder}
+            activeTab="experiments"
+            columns={columnsWithSortOrder}
+            currentPage={tableSortOrder?.currentPage}
+        />
     );
 };
 
@@ -88,6 +108,7 @@ ExperimentsTable.propTypes = {
             experimentType: PropTypes.string.isRequired,
         }),
     ).isRequired,
+    datasetID: PropTypes.string.isRequired,
 };
 
 export default ExperimentsTable;

--- a/src/components/explorer/ExperimentsTable.js
+++ b/src/components/explorer/ExperimentsTable.js
@@ -1,11 +1,12 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import { useSortedColumns } from "./hooks/explorerHooks";
 import ExplorerSearchResultsTable from "./ExplorerSearchResultsTable";
 
 const ExperimentRender = ({ experimentId, individual }) => {
+    const location = useLocation();
     const alternateIds = individual.alternate_ids ?? [];
     const listRender = alternateIds.length ? `(${alternateIds.join(", ")})` : "";
 

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -15,6 +15,7 @@ import {
     removeDataTypeQueryForm,
     updateDataTypeQueryForm,
     setSelectedRows,
+    resetTableSortOrder,
 } from "../../modules/explorer/actions";
 
 import IndividualsTable from "./IndividualsTable";
@@ -68,6 +69,7 @@ const ExplorerDatasetSearch = () => {
     };
 
     const performSearch = () => {
+        dispatch(resetTableSortOrder(dataset));
         dispatch(performSearchIfPossible(dataset));
     };
 

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -102,16 +102,22 @@ const ExplorerDatasetSearch = () => {
                 (showTabs ? (
                     <Tabs defaultActiveKey={TAB_KEYS.INDIVIDUAL} onChange={onTabChange} activeKey={activeKey}>
                         <TabPane tab="Individual" key={TAB_KEYS.INDIVIDUAL}>
-                            <IndividualsTable data={searchResults.searchFormattedResults} />
+                            <IndividualsTable
+                                data={searchResults.searchFormattedResults}
+                                datasetID={dataset}/>
                         </TabPane>
                         {hasBiosamples && (
                             <TabPane tab="Biosamples" key={TAB_KEYS.BIOSAMPLES}>
-                                <BiosamplesTable data={searchResults.searchFormattedResultsBiosamples} />
+                                <BiosamplesTable
+                                    data={searchResults.searchFormattedResultsBiosamples}
+                                    datasetID={dataset}/>
                             </TabPane>
                         )}
                         {hasExperiments && (
                             <TabPane tab="Experiments" key={TAB_KEYS.EXPERIMENTS}>
-                                <ExperimentsTable data={searchResults.searchFormattedResultsExperiment} />
+                                <ExperimentsTable
+                                    data={searchResults.searchFormattedResultsExperiment}
+                                    datasetID={dataset}/>
                             </TabPane>
                         )}
                     </Tabs>

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -35,10 +35,7 @@ const hasNonEmptyArrayProperty = (targetObject, propertyKey) => {
 };
 
 const ExplorerDatasetSearch = () => {
-    const location = useLocation();
-    const history = useHistory();
-    const initialActiveKey = new URLSearchParams(location.search).get("tab") || TAB_KEYS.INDIVIDUAL;
-    const [activeKey, setActiveKey] = useState(initialActiveKey);
+    const [activeKey, setActiveKey] = useState(TAB_KEYS.INDIVIDUAL);
     const dispatch = useDispatch();
     const { dataset } = useParams();
 
@@ -63,9 +60,6 @@ const ExplorerDatasetSearch = () => {
     const onTabChange = (newActiveKey) => {
         setActiveKey(newActiveKey);
         handleSetSelectedRows([]);
-        const params = new URLSearchParams(location.search);
-        params.set("tab", newActiveKey);
-        history.replace({ ...location, search: params.toString() });
     };
 
     const performSearch = () => {

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -66,6 +66,7 @@ const ExplorerDatasetSearch = () => {
     };
 
     const performSearch = () => {
+        dispatch(setActiveTab(dataset, TAB_KEYS.INDIVIDUAL));
         dispatch(resetTableSortOrder(dataset));
         dispatch(performSearchIfPossible(dataset));
     };

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { useParams } from "react-router-dom";
+import {useHistory, useLocation, useParams } from "react-router-dom";
 
 import { Typography, Tabs } from "antd";
 

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -34,7 +34,10 @@ const hasNonEmptyArrayProperty = (targetObject, propertyKey) => {
 };
 
 const ExplorerDatasetSearch = () => {
-    const [activeKey, setActiveKey] = useState(TAB_KEYS.INDIVIDUAL);
+    const location = useLocation();
+    const history = useHistory();
+    const initialActiveKey = new URLSearchParams(location.search).get("tab") || TAB_KEYS.INDIVIDUAL;
+    const [activeKey, setActiveKey] = useState(initialActiveKey);
     const dispatch = useDispatch();
     const { dataset } = useParams();
 
@@ -59,6 +62,9 @@ const ExplorerDatasetSearch = () => {
     const onTabChange = (newActiveKey) => {
         setActiveKey(newActiveKey);
         handleSetSelectedRows([]);
+        const params = new URLSearchParams(location.search);
+        params.set("tab", newActiveKey);
+        history.replace({ ...location, search: params.toString() });
     };
 
     const performSearch = () => {

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -106,7 +106,7 @@ const ExplorerDatasetSearch = () => {
                                 datasetID={dataset}/>
                         </TabPane>
                         {hasBiosamples && (
-                            <TabPane tab="Biosamplesx" key={TAB_KEYS.BIOSAMPLES}>
+                            <TabPane tab="Biosamples" key={TAB_KEYS.BIOSAMPLES}>
                                 <BiosamplesTable
                                     data={searchResults.searchFormattedResultsBiosamples}
                                     datasetID={dataset}/>

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import {useHistory, useLocation, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import { Typography, Tabs } from "antd";
 

--- a/src/components/explorer/ExplorerIndividualContent.js
+++ b/src/components/explorer/ExplorerIndividualContent.js
@@ -42,6 +42,7 @@ class ExplorerIndividualContent extends Component {
 
         this.state = {
             backUrl: null,
+            currentTab: null,
             selectedTab: "overview",
         };
     }
@@ -61,8 +62,10 @@ class ExplorerIndividualContent extends Component {
     }
 
     componentDidMount() {
-        const backUrl = (this.props.location.state || {}).backUrl;
-        if (backUrl) this.setState({backUrl});
+        const { location } = this.props;
+        const { backUrl, currentTab } = location.state || {};
+        if (backUrl) this.setState({ backUrl });
+        if (currentTab) this.setState({ currentTab });
         this.fetchIndividualData();
     }
 
@@ -108,8 +111,11 @@ class ExplorerIndividualContent extends Component {
         return <>
             <SitePageHeader title={headerTitle(individual) || "Loading..."}
                             withTabBar={true}
-                            onBack={this.state.backUrl
-                                ? (() => this.props.history.push(this.state.backUrl)) : undefined}
+                            onBack={() => {
+                                const urlToNavigate = this.state.currentTab ?
+                                    `${this.state.backUrl}${this.state.currentTab}` : this.state.backUrl;
+                                this.props.history.push(urlToNavigate);
+                            }}
                             footer={
                                 <Menu mode="horizontal" style={MENU_STYLE} selectedKeys={selectedKeys}>
                                     {individualMenu.map(renderMenuItem)}

--- a/src/components/explorer/ExplorerIndividualContent.js
+++ b/src/components/explorer/ExplorerIndividualContent.js
@@ -42,8 +42,6 @@ class ExplorerIndividualContent extends Component {
 
         this.state = {
             backUrl: null,
-            currentTab: null,
-            selectedTab: "overview",
         };
     }
 
@@ -63,9 +61,8 @@ class ExplorerIndividualContent extends Component {
 
     componentDidMount() {
         const { location } = this.props;
-        const { backUrl, currentTab } = location.state || {};
+        const { backUrl } = location.state || {};
         if (backUrl) this.setState({ backUrl });
-        if (currentTab) this.setState({ currentTab });
         this.fetchIndividualData();
     }
 
@@ -111,11 +108,8 @@ class ExplorerIndividualContent extends Component {
         return <>
             <SitePageHeader title={headerTitle(individual) || "Loading..."}
                             withTabBar={true}
-                            onBack={() => {
-                                const urlToNavigate = this.state.currentTab ?
-                                    `${this.state.backUrl}${this.state.currentTab}` : this.state.backUrl;
-                                this.props.history.push(urlToNavigate);
-                            }}
+                            onBack={this.state.backUrl
+                                ? (() => this.props.history.push(this.state.backUrl)) : undefined}
                             footer={
                                 <Menu mode="horizontal" style={MENU_STYLE} selectedKeys={selectedKeys}>
                                     {individualMenu.map(renderMenuItem)}

--- a/src/components/explorer/ExplorerSearchResultsTable.js
+++ b/src/components/explorer/ExplorerSearchResultsTable.js
@@ -17,7 +17,14 @@ import {
 
 const PAGE_SIZE = 25;
 
-const ExplorerSearchResultsTable = ({ data, activeTab, columns, currentPage: initialCurrentPage, ...props }) => {
+const ExplorerSearchResultsTable = ({
+    data,
+    activeTab,
+    columns,
+    currentPage: initialCurrentPage,
+    sortOrder,
+    sortColumnKey,
+}) => {
     const { dataset } = useParams();
     //const [currentPage, setCurrentPage] = useState(1);
     const [currentPage, setCurrentPage] = useState(initialCurrentPage || 1);
@@ -62,7 +69,6 @@ const ExplorerSearchResultsTable = ({ data, activeTab, columns, currentPage: ini
         pointerEvents: fetchingSearch ? "none" : "auto",
     };
 
-
     const rowSelection = {
         type: "checkbox",
         selectedRowKeys: selectedRows,
@@ -86,12 +92,13 @@ const ExplorerSearchResultsTable = ({ data, activeTab, columns, currentPage: ini
         ],
     };
 
-    const sortedInfo = useMemo(() => {
-        return {
-            order: props.sortOrder,
-            columnKey: props.sortColumnKey,
-        };
-    }, [props.sortOrder, props.sortColumnKey]);
+    const sortedInfo = useMemo(
+        () => ({
+            order: sortOrder,
+            columnKey: sortColumnKey,
+        }),
+        [sortOrder, sortColumnKey],
+    );
 
     return (
         <div>

--- a/src/components/explorer/ExplorerSearchResultsTable.js
+++ b/src/components/explorer/ExplorerSearchResultsTable.js
@@ -26,7 +26,6 @@ const ExplorerSearchResultsTable = ({
     sortColumnKey,
 }) => {
     const { dataset } = useParams();
-    //const [currentPage, setCurrentPage] = useState(1);
     const [currentPage, setCurrentPage] = useState(initialCurrentPage || 1);
     const [numResults] = useState(data.length);
 

--- a/src/components/explorer/ExplorerSearchResultsTable.js
+++ b/src/components/explorer/ExplorerSearchResultsTable.js
@@ -12,13 +12,15 @@ import {
     performIndividualsDownloadCSVIfPossible,
     performBiosamplesDownloadCSVIfPossible,
     performExperimentsDownloadCSVIfPossible,
+    setTableSortOrder,
 } from "../../modules/explorer/actions";
 
 const PAGE_SIZE = 25;
 
-const ExplorerSearchResultsTable = ({ data, activeTab, ...props }) => {
+const ExplorerSearchResultsTable = ({ data, activeTab, columns, currentPage: initialCurrentPage, ...props }) => {
     const { dataset } = useParams();
-    const [currentPage, setCurrentPage] = useState(1);
+    //const [currentPage, setCurrentPage] = useState(1);
+    const [currentPage, setCurrentPage] = useState(initialCurrentPage || 1);
     const [numResults] = useState(data.length);
 
     const [summaryModalVisible, setSummaryModalVisible] = useState(false);
@@ -50,8 +52,9 @@ const ExplorerSearchResultsTable = ({ data, activeTab, ...props }) => {
         }
     };
 
-    const onPageChange = (pageObj) => {
+    const onPageChange = (pageObj, filters, sorter) => {
         setCurrentPage(pageObj.current);
+        dispatch(setTableSortOrder(dataset, sorter.field, sorter.order, activeTab, pageObj.current));
     };
 
     const tableStyle = {
@@ -82,6 +85,13 @@ const ExplorerSearchResultsTable = ({ data, activeTab, ...props }) => {
             },
         ],
     };
+
+    const sortedInfo = useMemo(() => {
+        return {
+            order: props.sortOrder,
+            columnKey: props.sortColumnKey,
+        };
+    }, [props.sortOrder, props.sortColumnKey]);
 
     return (
         <div>
@@ -132,8 +142,9 @@ const ExplorerSearchResultsTable = ({ data, activeTab, ...props }) => {
                     bordered
                     disabled={fetchingSearch}
                     size="middle"
-                    columns={props.dataStructure}
+                    columns={columns}
                     dataSource={data || []}
+                    sortedInfo={sortedInfo}
                     onChange={onPageChange}
                     pagination={{
                         pageSize: PAGE_SIZE,
@@ -173,6 +184,10 @@ ExplorerSearchResultsTable.propTypes = {
     type: PropTypes.string,
     data: PropTypes.arrayOf(PropTypes.object),
     activeTab: PropTypes.string.isRequired,
+    columns: PropTypes.arrayOf(PropTypes.object).isRequired,
+    sortOrder: PropTypes.string,
+    sortColumnKey: PropTypes.string,
+    currentPage: PropTypes.number,
 };
 
 export default ExplorerSearchResultsTable;

--- a/src/components/explorer/IndividualsTable.js
+++ b/src/components/explorer/IndividualsTable.js
@@ -1,11 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { useSortedColumns } from "./hooks/explorerHooks";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
 import ExplorerSearchResultsTable from "./ExplorerSearchResultsTable";
 
 const IndividualRender = ({individual}) => {
+    const location = useLocation();
     const alternateIds = individual.alternate_ids ?? [];
     const listRender = alternateIds.length ? " (" + alternateIds.join(", ") + ")" : "";
     return (

--- a/src/components/explorer/IndividualsTable.js
+++ b/src/components/explorer/IndividualsTable.js
@@ -1,18 +1,21 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { useSortedColumns, useCurrentTab} from "./hooks/explorerHooks";
 import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
 import ExplorerSearchResultsTable from "./ExplorerSearchResultsTable";
 
 const IndividualRender = ({individual}) => {
+    const { currentTab } = useCurrentTab();
     const alternateIds = individual.alternate_ids ?? [];
     const listRender = alternateIds.length ? " (" + alternateIds.join(", ") + ")" : "";
     return (
         <>
             <Link
-                to={(location) => ({
+                to={{
                     pathname: `/data/explorer/individuals/${individual.id}/overview`,
-                    state: { backUrl: location.pathname },
-                })}
+                    state: { backUrl: location.pathname, currentTab },
+                }}
             >
                 {individual.id}
             </Link>{" "}
@@ -59,18 +62,34 @@ const SEARCH_RESULT_COLUMNS = [
     },
 ];
 
-const IndividualsTable = ({ data }) => {
+const IndividualsTable = ({ data, datasetID }) => {
+    const tableSortOrder = useSelector(
+        (state) => state.explorer.tableSortOrderByDatasetID[datasetID]?.["individuals"],
+    );
+    console.log("IndividualsTableXOXOXO", tableSortOrder);
+
+    const { sortedData, columnsWithSortOrder } = useSortedColumns(
+        data,
+        tableSortOrder,
+        SEARCH_RESULT_COLUMNS,
+    );
+
     return (
         <ExplorerSearchResultsTable
             dataStructure={SEARCH_RESULT_COLUMNS}
-            data={data}
+            data={sortedData}
+            sortColumnKey={tableSortOrder?.sortColumnKey}
+            sortOrder={tableSortOrder?.sortOrder}
             activeTab="individuals"
+            columns={columnsWithSortOrder}
+            currentPage={tableSortOrder?.currentPage}
         />
     );
 };
 
 IndividualsTable.propTypes = {
     data: PropTypes.array.isRequired,
+    datasetID: PropTypes.string.isRequired,
 };
 
 export default IndividualsTable;

--- a/src/components/explorer/hooks/explorerHooks.js
+++ b/src/components/explorer/hooks/explorerHooks.js
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import { useLocation } from "react-router-dom";
+
+export const useSortedColumns = (data, tableSortOrder, columnsDefinition) => {
+    const sortColumnKey = tableSortOrder?.sortColumnKey;
+    const sortOrder = tableSortOrder?.sortOrder;
+
+    const sortData = (dataToSort, sortKey, order) => {
+        const column = columnsDefinition.find((col) => col.dataIndex === sortKey);
+        if (column && column.sorter) {
+            return [...dataToSort].sort((a, b) => {
+                return order === "ascend" ? column.sorter(a, b) : -column.sorter(a, b);
+            });
+        }
+        return dataToSort;
+    };
+
+    const sortedData = useMemo(() => {
+        return sortData(data, sortColumnKey, sortOrder);
+    }, [data, sortColumnKey, sortOrder, columnsDefinition]);
+
+    const columnsWithSortOrder = useMemo(() => {
+        return columnsDefinition.map((column) => {
+            if (column.dataIndex === sortColumnKey) {
+                return { ...column, sortOrder };
+            }
+            return column;
+        });
+    }, [sortColumnKey, sortOrder, columnsDefinition]);
+
+    return { sortedData, columnsWithSortOrder };
+};
+
+
+export const useCurrentTab = (defaultTab = "1") => {
+    const location = useLocation();
+    const { search } = location;
+    const params = new URLSearchParams(search);
+    const currentTabNum = params.get("tab") || defaultTab;
+    return { currentTab: `?tab=${currentTabNum}` };
+
+};

--- a/src/components/explorer/hooks/explorerHooks.js
+++ b/src/components/explorer/hooks/explorerHooks.js
@@ -8,7 +8,7 @@ export const useSortedColumns = (data, tableSortOrder, columnsDefinition) => {
         const column = columnsDefinition.find((col) => col.dataIndex === sortKey);
         if (column && column.sorter) {
             return [...dataToSort].sort((a, b) => {
-                return order === "ascend" ? column.sorter(a, b) : -column.sorter(a, b);
+                return order === "ascend" ? column.sorter(a, b) : column.sorter(b, a);
             });
         }
         return dataToSort;

--- a/src/modules/explorer/actions.js
+++ b/src/modules/explorer/actions.js
@@ -17,6 +17,7 @@ export const NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION = "EXPLORER.NEUTRALIZE_AUTO_Q
 export const FREE_TEXT_SEARCH = createNetworkActionTypes("FREE_TEXT_SEARCH");
 export const SET_OTHER_THRESHOLD_PERCENTAGE = "EXPLORER.SET_OTHER_THRESHOLD_PERCENTAGE";
 export const SET_TABLE_SORT_ORDER = "EXPLORER.SET_TABLE_SORT_ORDER";
+export const RESET_TABLE_SORT_ORDER = "EXPLORER.RESET_TABLE_SORT_ORDER";
 export const SET_IGV_POSITION = "EXPLORER.SET_IGV_POSITION";
 
 const performSearch = networkAction((datasetID, dataTypeQueries, excludeFromAutoJoin = []) => (dispatch, getState) => ({
@@ -131,11 +132,18 @@ export const setSelectedRows = (datasetID, selectedRows) => ({
     selectedRows,
 });
 
-export const setTableSortOrder = (datasetID, sortColumnKey, sortOrder) => ({
+export const setTableSortOrder = (datasetID, sortColumnKey, sortOrder, activeTab, currentPage) => ({
     type: SET_TABLE_SORT_ORDER,
     datasetID,
     sortColumnKey,
     sortOrder,
+    activeTab,
+    currentPage,
+});
+
+export const resetTableSortOrder = (datasetID) => ({
+    type: RESET_TABLE_SORT_ORDER,
+    datasetID,
 });
 
 export const setAutoQueryPageTransition = (priorPageUrl, type, field, value) => ({

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -23,6 +23,7 @@ import {
     UPDATE_DATA_TYPE_QUERY_FORM,
     SET_SELECTED_ROWS,
     SET_TABLE_SORT_ORDER,
+    RESET_TABLE_SORT_ORDER,
     SET_AUTO_QUERY_PAGE_TRANSITION,
     NEUTRALIZE_AUTO_QUERY_PAGE_TRANSITION,
     FREE_TEXT_SEARCH,
@@ -213,11 +214,27 @@ export const explorer = (
                 tableSortOrderByDatasetID: {
                     ...state.tableSortOrderByDatasetID,
                     [action.datasetID]: {
-                        sortColumnKey: action.sortColumnKey,
-                        sortOrder: action.sortOrder,
+                        ...state.tableSortOrderByDatasetID[action.datasetID],
+                        [action.activeTab]: {
+                            sortColumnKey: action.sortColumnKey,
+                            sortOrder: action.sortOrder,
+                            currentPage: action.currentPage,
+                        },
                     },
                 },
             };
+
+        case RESET_TABLE_SORT_ORDER: {
+            console.log("RESET_TABLE_SORT_ORDER action:", action);
+
+            const updatedTableSortOrder = { ...state.tableSortOrderByDatasetID };
+            delete updatedTableSortOrder[action.datasetID];
+
+            return {
+                ...state,
+                tableSortOrderByDatasetID: updatedTableSortOrder,
+            };
+        }
 
         // Auto-Queries start here ----
         case SET_AUTO_QUERY_PAGE_TRANSITION:

--- a/src/modules/explorer/reducers.js
+++ b/src/modules/explorer/reducers.js
@@ -225,8 +225,6 @@ export const explorer = (
             };
 
         case RESET_TABLE_SORT_ORDER: {
-            console.log("RESET_TABLE_SORT_ORDER action:", action);
-
             const updatedTableSortOrder = { ...state.tableSortOrderByDatasetID };
             delete updatedTableSortOrder[action.datasetID];
 


### PR DESCRIPTION
This PR implements changes to retain the sorting and pagination information in the explorer results tables. These changes allow the navigation back to the tables, preserving the user's preferred sorting order and the selected tab and pagination. The main changes introduced with this PR are:

Persistent sorting: The sorting order for the columns is now saved and reapplied when navigating back to the explorer result tables

Saved pagination state: The current page is stored and retrieved when returning to the tables, keeping the user's position in the dataset.

Redux integration: Updated the redux actions and state to handle the storing and retrieval of sorting and pagination information, making it accessible across different components.

Code refactoring: Refactored the code including the implementation of custom sorting hook and the ExplorerSearchResultsTable component.