### PR TITLE
feat(explorer): improve phenotypic feature display

### DIFF
--- a/src/components/explorer/IndividualPhenotypicFeatures.js
+++ b/src/components/explorer/IndividualPhenotypicFeatures.js
@@ -76,7 +76,7 @@ const IndividualPhenotypicFeatures = ({ individual }) => {
                 ...pf,
                 key: `${pf.type.id}:${pf.negated}`,
             })),
-        ])
+        ]);
     }, [individual]);
 
     return (

--- a/src/components/explorer/IndividualPhenotypicFeatures.js
+++ b/src/components/explorer/IndividualPhenotypicFeatures.js
@@ -1,61 +1,87 @@
-import React, { useMemo } from "react";
+import React, {useCallback, useMemo} from "react";
 
-import { Table } from "antd";
+import {Card, Icon, Table} from "antd";
 
 import { EM_DASH } from "../../constants";
 import { individualPropTypesShape } from "../../propTypes";
 import OntologyTerm from "./OntologyTerm";
 
 const IndividualPhenotypicFeatures = ({ individual }) => {
-    // TODO: this logic might be technically incorrect with different versions of the same resource (i.e. ontology)
-    //  across multiple phenopackets
-    const phenotypicFeatures = useMemo(
-        () =>
-            Object.values(
-                Object.fromEntries(
-                    (individual?.phenopackets ?? [])
-                        .flatMap(p => (p.phenotypic_features ?? []))
-                        .map(pf => {
-                            const pfID = `${pf.type.id}:${pf.negated}`;
-                            return [pfID, {...pf, id: pfID}];
-                        }),
-                ),
-            ),
-        [individual],
-    );
-
     const columns = useMemo(() => [
         {
-            title: "Type",
-            dataIndex: "type",
-            render: (type) => (
-                <OntologyTerm individual={individual} term={type} />
-            ),
-        },
-        {
-            title: "Negated",
-            dataIndex: "negated",
-            render: (negated) => (negated ?? "false").toString(),
+            title: "Feature",
+            key: "feature",
+            render: ({ header, type, negated }) => ({
+                children: header ? (
+                    <h4 style={{ marginBottom: 0 }} className="phenotypic-features--phenopacket-header">
+                        Phenopacket:{" "}
+                        <span style={{ fontFamily: "monospace", fontStyle: "italic", fontWeight: "normal" }}>
+                            {header}
+                        </span>
+                    </h4>
+                ) : <>
+                    <OntologyTerm individual={individual} term={type} />{" "}
+                    {negated ? (
+                        <span style={{ color: "#CC3333" }}>
+                            (<span style={{ fontWeight: "bold" }}>Excluded:</span>{" "}
+                            Found to be absent{" "}
+                            <a href="https://phenopacket-schema.readthedocs.io/en/2.0.0/phenotype.html#excluded"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                <Icon type="link" />
+                            </a>)
+                        </span>
+                    ) : null}
+                </>,
+                props: {
+                    colSpan: header ? 2 : 1,
+                },
+            }),
         },
         {
             title: "Extra Properties",
             dataIndex: "extra_properties",
-            render: (extraProperties) =>
-                (Object.keys(extraProperties ?? {}).length)
-                    ?  <div><pre>{JSON.stringify(extraProperties ?? {}, null, 2)}</pre></div>
-                    : EM_DASH,
+            render: (extraProperties, feature) => {
+                console.log(feature);
+                const nExtraProperties = Object.keys(extraProperties ?? {}).length;
+                return {
+                    children: nExtraProperties ? (
+                        <div>
+                            <pre style={{marginBottom: 0, fontSize: "12px"}}>
+                                {JSON.stringify(
+                                    extraProperties,
+                                    null,
+                                    nExtraProperties === 1 ? null : 2,
+                                )}
+                            </pre>
+                        </div>
+                    ) : EM_DASH,   // If no extra properties, just show a dash
+                    props: {
+                        colSpan: feature.header ? 0 : 1,
+                    },
+                };
+            },
         },
 
     ], [individual]);
 
+    const data = useMemo(() => (individual?.phenopackets ?? []).flatMap((p) => [
+        {
+            header: p.id,
+            key: p.id,
+        },
+        ...p.phenotypic_features.map((pf) => ({...pf, key: `${pf.type.id}:${pf.negated}`})),
+    ]), [individual]);
+
     return (
         <Table
+            className="phenotypic-features-table"
             bordered
             size="middle"
-            pagination={{pageSize: 25}}
+            pagination={false}
             columns={columns}
             rowKey="id"
-            dataSource={phenotypicFeatures}
+            dataSource={data}
         />
     );
 };

--- a/src/components/explorer/IndividualPhenotypicFeatures.js
+++ b/src/components/explorer/IndividualPhenotypicFeatures.js
@@ -65,13 +65,19 @@ const IndividualPhenotypicFeatures = ({ individual }) => {
 
     ], [individual]);
 
-    const data = useMemo(() => (individual?.phenopackets ?? []).flatMap((p) => [
-        {
-            header: p.id,
-            key: p.id,
-        },
-        ...p.phenotypic_features.map((pf) => ({...pf, key: `${pf.type.id}:${pf.negated}`})),
-    ]), [individual]);
+    const data = useMemo(() => {
+        const phenopackets = (individual?.phenopackets ?? []);
+        return phenopackets.flatMap((p) => [
+            ...(phenopackets.length > 1 ? [{
+                header: p.id,
+                key: p.id,
+            }] : []),  // If there is just 1 phenopacket, don't include a header row
+            ...p.phenotypic_features.map((pf) => ({
+                ...pf,
+                key: `${pf.type.id}:${pf.negated}`,
+            })),
+        ])
+    }, [individual]);
 
     return (
         <Table

--- a/src/components/explorer/IndividualPhenotypicFeatures.js
+++ b/src/components/explorer/IndividualPhenotypicFeatures.js
@@ -1,6 +1,6 @@
-import React, {useCallback, useMemo} from "react";
+import React, { useMemo } from "react";
 
-import {Card, Icon, Table} from "antd";
+import { Icon, Table } from "antd";
 
 import { EM_DASH } from "../../constants";
 import { individualPropTypesShape } from "../../propTypes";

--- a/src/components/explorer/explorer.css
+++ b/src/components/explorer/explorer.css
@@ -10,6 +10,13 @@
   vertical-align: top !important;
 }
 
+/* Phenotypic Features tab */
+
+.phenotypic-features-table td[colspan="2"] {
+  /*background-color: red;*/
+  border-top: 2px solid #e8e8e8;
+}
+
 /* Variants tab */
 
 .variantDescriptions .ant-descriptions-item-label{


### PR DESCRIPTION
* separate phenotypic features by phenopacket (encounter)
* remove separate column for negated/excluded & link to definition if true
* render extra properties more compactly if only one is present