### PR TITLE
feat(explorer): new table/single-descriptions-based linkable experiments view

### DIFF
--- a/src/components/datasets/DatasetDataTypes.js
+++ b/src/components/datasets/DatasetDataTypes.js
@@ -16,17 +16,15 @@ const DatasetDataTypes = React.memo(
     ({isPrivate, project, dataset, onDatasetIngest}) => {
         const dispatch = useDispatch();
         const datasetDataTypes = useSelector((state) => Object.values(
-            state.datasetDataTypes.itemsById[dataset.identifier]?.itemsById ?? {}));
-        const datasetSummaries = useSelector((state) => state.datasetSummaries.itemsById[dataset.identifier]);
+            state.datasetDataTypes.itemsByID[dataset.identifier]?.itemsByID ?? {}));
+        const datasetSummaries = useSelector((state) => state.datasetSummaries.itemsByID[dataset.identifier]);
         const isFetchingDataset = useSelector(
-            (state) => state.datasetDataTypes.itemsById[dataset.identifier]?.isFetching);
+            (state) => state.datasetDataTypes.itemsByID[dataset.identifier]?.isFetching);
 
         const [datatypeSummaryVisible, setDatatypeSummaryVisible] = useState(false);
         const [selectedDataType, setSelectedDataType] = useState(null);
 
-        const selectedSummary = (selectedDataType !== null && datasetSummaries)
-            ? datasetSummaries[selectedDataType.id]
-            : {};
+        const selectedSummary = datasetSummaries?.data?.[selectedDataType?.id] ?? {};
 
         const handleClearDataType = useCallback((dataType) => {
             genericConfirm({

--- a/src/components/datasets/DatasetOverview.js
+++ b/src/components/datasets/DatasetOverview.js
@@ -9,8 +9,8 @@ import {EM_DASH} from "../../constants";
 import { useSelector } from "react-redux";
 
 const DatasetOverview = ({isPrivate, project, dataset}) => {
-    const datasetsDataTypes = useSelector((state) => state.datasetDataTypes.itemsById);
-    const dataTypesSummary = Object.values(datasetsDataTypes[dataset.identifier]?.itemsById || {});
+    const datasetsDataTypes = useSelector((state) => state.datasetDataTypes.itemsByID);
+    const dataTypesSummary = Object.values(datasetsDataTypes[dataset.identifier]?.itemsByID || {});
     const isFetchingDataset = datasetsDataTypes[dataset.identifier]?.isFetching;
 
     // Count data types which actually have data in them for showing in the overview

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -133,7 +133,7 @@ class DiscoveryQueryBuilder extends Component {
     render() {
         const { activeDataset, dataTypesByDataset} = this.props;
 
-        const dataTypesForActiveDataset = Object.values(dataTypesByDataset.itemsById[activeDataset] || {})
+        const dataTypesForActiveDataset = Object.values(dataTypesByDataset.itemsByID[activeDataset] || {})
             .filter(dt => typeof dt === "object");
 
         const filteredDataTypes = dataTypesForActiveDataset

--- a/src/components/explorer/ExplorerDatasetSearch.js
+++ b/src/components/explorer/ExplorerDatasetSearch.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, {useCallback, useEffect} from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { useParams } from "react-router-dom";
 
@@ -22,6 +22,7 @@ import {
 import IndividualsTable from "./searchResultsTables/IndividualsTable";
 import BiosamplesTable from "./searchResultsTables/BiosamplesTable";
 import ExperimentsTable from "./searchResultsTables/ExperimentsTable";
+import {fetchDatasetResourcesIfNecessary} from "../../modules/datasets/actions";
 
 const { TabPane } = Tabs;
 
@@ -36,42 +37,45 @@ const hasNonEmptyArrayProperty = (targetObject, propertyKey) => {
 };
 
 const ExplorerDatasetSearch = () => {
-    const { dataset } = useParams();
+    const { dataset: datasetID } = useParams();
     const dispatch = useDispatch();
 
     const datasetsByID = useSelector((state) => state.projects.datasetsByID);
 
-    const activeKey = useSelector((state) => state.explorer.activeTabByDatasetID[dataset]) || TAB_KEYS.INDIVIDUAL;
-    const dataTypeForms = useSelector((state) => state.explorer.dataTypeFormsByDatasetID[dataset] || []);
-    const fetchingSearch = useSelector((state) => state.explorer.fetchingSearchByDatasetID[dataset] || false);
+    const activeKey = useSelector((state) => state.explorer.activeTabByDatasetID[datasetID]) || TAB_KEYS.INDIVIDUAL;
+    const dataTypeForms = useSelector((state) => state.explorer.dataTypeFormsByDatasetID[datasetID] || []);
+    const fetchingSearch = useSelector((state) => state.explorer.fetchingSearchByDatasetID[datasetID] || false);
     const fetchingTextSearch = useSelector((state) => state.explorer.fetchingTextSearch || false);
-    const searchResults = useSelector((state) => state.explorer.searchResultsByDatasetID[dataset] || null);
+    const searchResults = useSelector((state) => state.explorer.searchResultsByDatasetID[datasetID] || null);
 
     console.debug("search results: ", searchResults);
 
-    const handleSetSelectedRows = (...args) => dispatch(setSelectedRows(dataset, ...args));
+    const handleSetSelectedRows = useCallback(
+        (...args) => dispatch(setSelectedRows(datasetID, ...args)),
+        [dispatch, datasetID],
+    );
 
     useEffect(() => {
         // Ensure user is at the top of the page after transition
         window.scrollTo(0, 0);
     }, []);
 
-    const onTabChange = (newActiveKey) => {
-        dispatch(setActiveTab(dataset, newActiveKey));
+    const onTabChange = useCallback((newActiveKey) => {
+        dispatch(setActiveTab(datasetID, newActiveKey));
         handleSetSelectedRows([]);
-    };
+    }, [dispatch, datasetID, handleSetSelectedRows]);
 
-    const performSearch = () => {
-        dispatch(setActiveTab(dataset, TAB_KEYS.INDIVIDUAL));
-        dispatch(resetTableSortOrder(dataset));
-        dispatch(performSearchIfPossible(dataset));
-    };
+    const performSearch = useCallback(() => {
+        dispatch(setActiveTab(datasetID, TAB_KEYS.INDIVIDUAL));
+        dispatch(resetTableSortOrder(datasetID));
+        dispatch(performSearchIfPossible(datasetID));
+    }, [dispatch, datasetID]);
 
-    if (!dataset) return null;
+    useEffect(() => {
+        dispatch(fetchDatasetResourcesIfNecessary(datasetID));
+    }, [dispatch, datasetID]);
 
-    const selectedDataset = datasetsByID[dataset];
-
-    if (!selectedDataset) return null;
+    const selectedDataset = datasetsByID[datasetID];
 
     const isFetchingSearchResults = fetchingSearch || fetchingTextSearch;
 
@@ -80,19 +84,20 @@ const ExplorerDatasetSearch = () => {
     const hasBiosamples = hasNonEmptyArrayProperty(searchResults, "searchFormattedResultsBiosamples");
     const showTabs = hasResults && (hasExperiments || hasBiosamples);
 
+    if (!selectedDataset) return null;
     return (
         <>
             <Typography.Title level={4}>Explore Dataset {selectedDataset.title}</Typography.Title>
-            <SearchAllRecords datasetID={dataset} />
+            <SearchAllRecords datasetID={datasetID} />
             <DiscoveryQueryBuilder
-                activeDataset={dataset}
+                activeDataset={datasetID}
                 isInternal={true}
                 dataTypeForms={dataTypeForms}
                 onSubmit={performSearch}
                 searchLoading={fetchingSearch}
-                addDataTypeQueryForm={(form) => dispatch(addDataTypeQueryForm(dataset, form))}
-                updateDataTypeQueryForm={(index, form) => dispatch(updateDataTypeQueryForm(dataset, index, form))}
-                removeDataTypeQueryForm={(index) => dispatch(removeDataTypeQueryForm(dataset, index))}
+                addDataTypeQueryForm={(form) => dispatch(addDataTypeQueryForm(datasetID, form))}
+                updateDataTypeQueryForm={(index, form) => dispatch(updateDataTypeQueryForm(datasetID, index, form))}
+                removeDataTypeQueryForm={(index) => dispatch(removeDataTypeQueryForm(datasetID, index))}
             />
             {hasResults &&
                 !isFetchingSearchResults &&
@@ -101,14 +106,14 @@ const ExplorerDatasetSearch = () => {
                         <TabPane tab="Individual" key={TAB_KEYS.INDIVIDUAL}>
                             <IndividualsTable
                                 data={searchResults.searchFormattedResults}
-                                datasetID={dataset}
+                                datasetID={datasetID}
                             />
                         </TabPane>
                         {hasBiosamples && (
                             <TabPane tab="Biosamples" key={TAB_KEYS.BIOSAMPLES}>
                                 <BiosamplesTable
                                     data={searchResults.searchFormattedResultsBiosamples}
-                                    datasetID={dataset}
+                                    datasetID={datasetID}
                                 />
                             </TabPane>
                         )}
@@ -116,13 +121,13 @@ const ExplorerDatasetSearch = () => {
                             <TabPane tab="Experiments" key={TAB_KEYS.EXPERIMENTS}>
                                 <ExperimentsTable
                                     data={searchResults.searchFormattedResultsExperiment}
-                                    datasetID={dataset}
+                                    datasetID={datasetID}
                                 />
                             </TabPane>
                         )}
                     </Tabs>
                 ) : (
-                    <IndividualsTable data={searchResults.searchFormattedResults} datasetID={dataset} />
+                    <IndividualsTable data={searchResults.searchFormattedResults} datasetID={datasetID} />
                 ))}
         </>
     );

--- a/src/components/explorer/ExplorerIndividualContent.js
+++ b/src/components/explorer/ExplorerIndividualContent.js
@@ -4,11 +4,12 @@ import { Redirect, Route, Switch, useHistory, useLocation, useParams, useRouteMa
 
 import { Layout, Menu, Skeleton } from "antd";
 
-import { fetchDatasetResourcesIfNecessary } from "../../modules/datasets/actions";
+import { BENTO_URL } from "../../config";
 import { fetchIndividualIfNecessary } from "../../modules/metadata/actions";
 import { LAYOUT_CONTENT_STYLE } from "../../styles/layoutContent";
 import { matchingMenuKeys, renderMenuItem } from "../../utils/menu";
 import { urlPath } from "../../utils/url";
+import { useIndividualResources } from "./utils";
 
 import SitePageHeader from "../SitePageHeader";
 import IndividualOverview from "./IndividualOverview";
@@ -16,13 +17,11 @@ import IndividualPhenotypicFeatures from "./IndividualPhenotypicFeatures";
 import IndividualBiosamples from "./IndividualBiosamples";
 import IndividualExperiments from "./IndividualExperiments";
 import IndividualDiseases from "./IndividualDiseases";
-import IndividualMetadata from "./IndividualMetadata";
+import IndividualOntologies from "./IndividualOntologies";
 import IndividualVariants from "./IndividualVariants";
 import IndividualGenes from "./IndividualGenes";
 import IndividualTracks from "./IndividualTracks";
 import IndividualPhenopackets from "./IndividualPhenopackets";
-
-import { BENTO_URL } from "../../config";
 
 const MENU_STYLE = {
     marginLeft: "-24px",
@@ -62,12 +61,8 @@ const ExplorerIndividualContent = () => {
 
     const { isFetching: individualIsFetching, data: individual } = individuals[individualID] ?? {};
 
-    useEffect(() => {
-        // TODO: when individual belongs to a single dataset, use that instead
-        if (individual) {
-            individual.phenopackets.map((p) => dispatch(fetchDatasetResourcesIfNecessary(p.dataset)));
-        }
-    }, [dispatch, individual]);
+    // Trigger resource loading
+    useIndividualResources(individual);
 
     const overviewUrl = `${individualUrl}/overview`;
     const phenotypicFeaturesUrl = `${individualUrl}/phenotypic-features`;
@@ -76,7 +71,7 @@ const ExplorerIndividualContent = () => {
     const variantsUrl = `${individualUrl}/variants`;
     const genesUrl = `${individualUrl}/genes`;
     const diseasesUrl = `${individualUrl}/diseases`;
-    const metadataUrl = `${individualUrl}/metadata`;
+    const ontologiesUrl = `${individualUrl}/ontologies`;
     const tracksUrl = `${individualUrl}/tracks`;
     const phenopacketsUrl = `${individualUrl}/phenopackets`;
 
@@ -89,7 +84,7 @@ const ExplorerIndividualContent = () => {
         {url: variantsUrl, text: "Variants"},
         {url: genesUrl, text: "Genes"},
         {url: diseasesUrl, text: "Diseases"},
-        {url: metadataUrl, text: "Metadata"},
+        {url: ontologiesUrl, text: "Ontologies"},
         {url: phenopacketsUrl, text: "Phenopackets JSON"},
     ];
 
@@ -133,8 +128,8 @@ const ExplorerIndividualContent = () => {
                     <Route path={diseasesUrl.replace(":", "\\:")}>
                         <IndividualDiseases individual={individual} />
                     </Route>
-                    <Route path={metadataUrl.replace(":", "\\:")}>
-                        <IndividualMetadata individual={individual} />
+                    <Route path={ontologiesUrl.replace(":", "\\:")}>
+                        <IndividualOntologies individual={individual} />
                     </Route>
                     <Route path={phenopacketsUrl.replace(":", "\\:")}>
                         <IndividualPhenopackets individual={individual} />

--- a/src/components/explorer/ExplorerIndividualContent.js
+++ b/src/components/explorer/ExplorerIndividualContent.js
@@ -1,14 +1,11 @@
-import React, {Component} from "react";
-import {connect} from "react-redux";
-import {Redirect, Route, Switch} from "react-router-dom";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Redirect, Route, Switch, useHistory, useLocation, useParams, useRouteMatch } from "react-router-dom";
 
-import PropTypes from "prop-types";
-import ReactRouterPropTypes from "react-router-prop-types";
+import { Layout, Menu, Skeleton } from "antd";
 
-import {Layout, Menu, Skeleton} from "antd";
-
+import { fetchDatasetResourcesIfNecessary } from "../../modules/datasets/actions";
 import { fetchIndividualIfNecessary } from "../../modules/metadata/actions";
-import { individualPropTypesShape } from "../../propTypes";
 import { LAYOUT_CONTENT_STYLE } from "../../styles/layoutContent";
 import { matchingMenuKeys, renderMenuItem } from "../../utils/menu";
 import { urlPath } from "../../utils/url";
@@ -33,147 +30,120 @@ const MENU_STYLE = {
     marginTop: "-12px",
 };
 
-
-class ExplorerIndividualContent extends Component {
-    constructor(props) {
-        super(props);
-
-        this.fetchIndividualData = this.fetchIndividualData.bind(this);
-
-        this.state = {
-            backUrl: null,
-        };
+const headerTitle = (individual) => {
+    if (!individual) {
+        return null;
     }
-
-    fetchIndividualData() {
-        const individualID = this.props.match.params.individual || null;
-        if (!individualID || !this.props.metadataService) return;
-        this.props.fetchIndividualIfNecessary(individualID);
-    }
-
-    // noinspection JSCheckFunctionSignatures
-    componentDidUpdate(prevProps) {
-        if (!prevProps.metadataService && this.props.metadataService) {
-            // We loaded metadata service, so we can load individual data now
-            this.fetchIndividualData();
-        }
-    }
-
-    componentDidMount() {
-        const { location } = this.props;
-        const { backUrl } = location.state || {};
-        if (backUrl) this.setState({ backUrl });
-        this.fetchIndividualData();
-    }
-
-    render() {
-        // TODO: Disease content - highlight what was found in search results?
-
-        const individualID = this.props.match.params.individual || null;
-        const individualInfo = this.props.individuals[individualID] || {};
-        const individual = individualInfo.data;
-
-        const individualUrl = this.props.match.url;
-
-        const overviewUrl = `${individualUrl}/overview`;
-        const phenotypicFeaturesUrl = `${individualUrl}/phenotypic-features`;
-        const biosamplesUrl = `${individualUrl}/biosamples`;
-        const experimentsUrl = `${individualUrl}/experiments`;
-        const variantsUrl = `${individualUrl}/variants`;
-        const genesUrl = `${individualUrl}/genes`;
-        const diseasesUrl = `${individualUrl}/diseases`;
-        const metadataUrl = `${individualUrl}/metadata`;
-        const tracksUrl = `${individualUrl}/tracks`;
-        const phenopacketsUrl = `${individualUrl}/phenopackets`;
-
-        const individualMenu = [
-            {url: overviewUrl, style: {marginLeft: "4px"}, text: "Overview"},
-            {url: phenotypicFeaturesUrl, text: "Phenotypic Features"},
-            {url: biosamplesUrl, text: "Biosamples"},
-            {url: experimentsUrl, text: "Experiments"},
-            {url: tracksUrl, text: "Tracks"},
-            {url: variantsUrl, text: "Variants"},
-            {url: genesUrl, text: "Genes"},
-            {url: diseasesUrl, text: "Diseases"},
-            {url: metadataUrl, text: "Metadata"},
-            {url: phenopacketsUrl, text: "Phenopackets JSON"},
-        ];
-
-        const selectedKeys = matchingMenuKeys(individualMenu, urlPath(BENTO_URL));
-
-        const headerTitle = (individual) => {
-            if (!individual) {
-                return null;
-            }
-            const mainId = individual.id;
-            const alternateIds = individual.alternate_ids ?? [];
-            return alternateIds.length ? `${mainId} (${alternateIds.join(", ")})` : mainId;
-        };
-
-        return <>
-            <SitePageHeader title={headerTitle(individual) || "Loading..."}
-                            withTabBar={true}
-                            onBack={this.state.backUrl
-                                ? (() => this.props.history.push(this.state.backUrl)) : undefined}
-                            footer={
-                                <Menu mode="horizontal" style={MENU_STYLE} selectedKeys={selectedKeys}>
-                                    {individualMenu.map(renderMenuItem)}
-                                </Menu>
-                            } />
-            <Layout>
-                <Layout.Content style={LAYOUT_CONTENT_STYLE}>
-                    {(individual && !individualInfo.isFetching) ? <Switch>
-                        <Route path={overviewUrl.replace(":", "\\:")}>
-                            <IndividualOverview individual={individual} />
-                        </Route>
-                        <Route path={phenotypicFeaturesUrl.replace(":", "\\:")}>
-                            <IndividualPhenotypicFeatures individual={individual} />
-                        </Route>
-                        <Route path={biosamplesUrl.replace(":", "\\:")}>
-                            <IndividualBiosamples individual={individual} experimentsUrl={experimentsUrl} />
-                        </Route>
-                        <Route path={experimentsUrl.replace(":", "\\:")}>
-                            <IndividualExperiments individual={individual} />
-                        </Route>
-                        <Route path={tracksUrl.replace(":", "\\:")}>
-                            <IndividualTracks individual={individual} />
-                        </Route>
-                        <Route path={variantsUrl.replace(":", "\\:")}>
-                            <IndividualVariants individual={individual} tracksUrl={tracksUrl}/>
-                        </Route>
-                        <Route path={genesUrl.replace(":", "\\:")}>
-                            <IndividualGenes individual={individual} tracksUrl={tracksUrl} />
-                        </Route>
-                        <Route path={diseasesUrl.replace(":", "\\:")}>
-                            <IndividualDiseases individual={individual} />
-                        </Route>
-                        <Route path={metadataUrl.replace(":", "\\:")}>
-                            <IndividualMetadata individual={individual} />
-                        </Route>
-                        <Route path={phenopacketsUrl.replace(":", "\\:")}>
-                            <IndividualPhenopackets individual={individual} />
-                        </Route>
-                        <Redirect to={overviewUrl.replace(":", "\\:")} />
-                    </Switch> : <Skeleton loading={true} />}
-                </Layout.Content>
-            </Layout>
-        </>;
-    }
-}
-
-ExplorerIndividualContent.propTypes = {
-    metadataService: PropTypes.object,  // TODO
-    individuals: PropTypes.objectOf(individualPropTypesShape),
-
-    fetchIndividualIfNecessary: PropTypes.func,
-
-    location: ReactRouterPropTypes.location.isRequired,
-    match: ReactRouterPropTypes.match.isRequired,
+    const mainId = individual.id;
+    const alternateIds = individual.alternate_ids ?? [];
+    return alternateIds.length ? `${mainId} (${alternateIds.join(", ")})` : mainId;
 };
 
-const mapStateToProps = state => ({
-    metadataService: state.services.metadataService,
-    individuals: state.individuals.itemsByID,
-});
+const ExplorerIndividualContent = () => {
+    const dispatch = useDispatch();
 
-export default connect(mapStateToProps, {fetchIndividualIfNecessary})(ExplorerIndividualContent);
+    const location = useLocation();
+    const history = useHistory();
+    const { individual: individualID } = useParams();
+    const { url: individualUrl } = useRouteMatch();
+
+    const backUrl = location.state?.backUrl;
+
+    const metadataService = useSelector((state) => state.services.metadataService);
+    const individuals = useSelector((state) => state.individuals.itemsByID);
+
+    useEffect(() => {
+        if (metadataService && individualID) {
+            // If we've loaded the metadata service, and we have an individual selected (or the individual ID changed),
+            // we should load individual data.
+            dispatch(fetchIndividualIfNecessary(individualID));
+        }
+    }, [dispatch, metadataService, individualID]);
+
+    const { isFetching: individualIsFetching, data: individual } = individuals[individualID] ?? {};
+
+    useEffect(() => {
+        // TODO: when individual belongs to a single dataset, use that instead
+        if (individual) {
+            individual.phenopackets.map((p) => dispatch(fetchDatasetResourcesIfNecessary(p.dataset)));
+        }
+    }, [dispatch, individual]);
+
+    const overviewUrl = `${individualUrl}/overview`;
+    const phenotypicFeaturesUrl = `${individualUrl}/phenotypic-features`;
+    const biosamplesUrl = `${individualUrl}/biosamples`;
+    const experimentsUrl = `${individualUrl}/experiments`;
+    const variantsUrl = `${individualUrl}/variants`;
+    const genesUrl = `${individualUrl}/genes`;
+    const diseasesUrl = `${individualUrl}/diseases`;
+    const metadataUrl = `${individualUrl}/metadata`;
+    const tracksUrl = `${individualUrl}/tracks`;
+    const phenopacketsUrl = `${individualUrl}/phenopackets`;
+
+    const individualMenu = [
+        {url: overviewUrl, style: {marginLeft: "4px"}, text: "Overview"},
+        {url: phenotypicFeaturesUrl, text: "Phenotypic Features"},
+        {url: biosamplesUrl, text: "Biosamples"},
+        {url: experimentsUrl, text: "Experiments"},
+        {url: tracksUrl, text: "Tracks"},
+        {url: variantsUrl, text: "Variants"},
+        {url: genesUrl, text: "Genes"},
+        {url: diseasesUrl, text: "Diseases"},
+        {url: metadataUrl, text: "Metadata"},
+        {url: phenopacketsUrl, text: "Phenopackets JSON"},
+    ];
+
+    const selectedKeys = matchingMenuKeys(individualMenu, urlPath(BENTO_URL));
+
+    return <>
+        <SitePageHeader
+            title={headerTitle(individual) || "Loading..."}
+            withTabBar={true}
+            onBack={backUrl ? (() => history.push(backUrl)) : undefined}
+            footer={
+                <Menu mode="horizontal" style={MENU_STYLE} selectedKeys={selectedKeys}>
+                    {individualMenu.map(renderMenuItem)}
+                </Menu>
+            }
+        />
+        <Layout>
+            <Layout.Content style={LAYOUT_CONTENT_STYLE}>
+                {(individual && !individualIsFetching) ? <Switch>
+                    <Route path={overviewUrl.replace(":", "\\:")}>
+                        <IndividualOverview individual={individual} />
+                    </Route>
+                    <Route path={phenotypicFeaturesUrl.replace(":", "\\:")}>
+                        <IndividualPhenotypicFeatures individual={individual} />
+                    </Route>
+                    <Route path={biosamplesUrl.replace(":", "\\:")}>
+                        <IndividualBiosamples individual={individual} experimentsUrl={experimentsUrl} />
+                    </Route>
+                    <Route path={experimentsUrl.replace(":", "\\:")}>
+                        <IndividualExperiments individual={individual} />
+                    </Route>
+                    <Route path={tracksUrl.replace(":", "\\:")}>
+                        <IndividualTracks individual={individual} />
+                    </Route>
+                    <Route path={variantsUrl.replace(":", "\\:")}>
+                        <IndividualVariants individual={individual} tracksUrl={tracksUrl}/>
+                    </Route>
+                    <Route path={genesUrl.replace(":", "\\:")}>
+                        <IndividualGenes individual={individual} tracksUrl={tracksUrl} />
+                    </Route>
+                    <Route path={diseasesUrl.replace(":", "\\:")}>
+                        <IndividualDiseases individual={individual} />
+                    </Route>
+                    <Route path={metadataUrl.replace(":", "\\:")}>
+                        <IndividualMetadata individual={individual} />
+                    </Route>
+                    <Route path={phenopacketsUrl.replace(":", "\\:")}>
+                        <IndividualPhenopackets individual={individual} />
+                    </Route>
+                    <Redirect to={overviewUrl.replace(":", "\\:")} />
+                </Switch> : <Skeleton loading={true} />}
+            </Layout.Content>
+        </Layout>
+    </>;
+};
+
+export default ExplorerIndividualContent;

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -192,7 +192,6 @@ const IndividualBiosamples = ({individual, experimentsUrl}) => {
     const match = useRouteMatch();
 
     const handleBiosampleClick = useCallback((bID) => {
-        console.log(match);
         if (!bID) {
             history.replace(match.url);
             return;
@@ -201,26 +200,21 @@ const IndividualBiosamples = ({individual, experimentsUrl}) => {
     }, [history, match]);
 
     const handleExperimentClick = useCallback((eid) => {
-        const hashLink = experimentsUrl + "#" + eid;
-        history.push(hashLink);
+        history.push(`${experimentsUrl}/${eid}`);
     }, [experimentsUrl, history]);
+
+    const biosamplesNode = (
+        <Biosamples
+            individual={individual}
+            handleBiosampleClick={handleBiosampleClick}
+            handleExperimentClick={handleExperimentClick}
+        />
+    );
 
     return (
         <Switch>
-            <Route path={`${match.path}/:selectedBiosample`}>
-                <Biosamples
-                    individual={individual}
-                    handleBiosampleClick={handleBiosampleClick}
-                    handleExperimentClick={handleExperimentClick}
-                />
-            </Route>
-            <Route path={match.path} exact={true}>
-                <Biosamples
-                    individual={individual}
-                    handleBiosampleClick={handleBiosampleClick}
-                    handleExperimentClick={handleExperimentClick}
-                />
-            </Route>
+            <Route path={`${match.path}/:selectedBiosample`}>{biosamplesNode}</Route>
+            <Route path={match.path} exact={true}>{biosamplesNode}</Route>
         </Switch>
     );
 };

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -5,7 +5,7 @@ import { Route, Switch, useHistory, useRouteMatch, useParams } from "react-route
 import { Button, Descriptions, Table } from "antd";
 
 import { EM_DASH } from "../../constants";
-import { useDeduplicatedIndividualBiosamples } from "./utils";
+import { useDeduplicatedIndividualBiosamples, useIndividualResources } from "./utils";
 import {
     biosamplePropTypesShape,
     experimentPropTypesShape,
@@ -21,18 +21,19 @@ import "./explorer.css";
 // TODO: Only show biosamples from the relevant dataset, if specified;
 //  highlight those found in search results, if specified
 
-const BiosampleProcedure = ({ individual, procedure }) => (
+const BiosampleProcedure = ({ resourcesTuple, procedure }) => (
     <div>
-        <strong>Code:</strong>{" "}<OntologyTerm individual={individual} term={procedure.code} />
+        <strong>Code:</strong>{" "}<OntologyTerm resourcesTuple={resourcesTuple} term={procedure.code} />
         {procedure.body_site ? (
             <div>
-                <strong>Body Site:</strong>{" "}<OntologyTerm individual={individual} term={procedure.body_site} />
+                <strong>Body Site:</strong>{" "}
+                <OntologyTerm resourcesTuple={resourcesTuple} term={procedure.body_site} />
             </div>
         ) : null}
     </div>
 );
 BiosampleProcedure.propTypes = {
-    individual: individualPropTypesShape.isRequired,
+    resourcesTuple: PropTypes.array,
     procedure: PropTypes.shape({
         code: ontologyShape.isRequired,
         body_site: ontologyShape,
@@ -60,19 +61,20 @@ ExperimentsClickList.propTypes = {
 };
 
 const BiosampleDetail = ({ individual, biosample, handleExperimentClick }) => {
+    const resourcesTuple = useIndividualResources(individual);
     return (
         <Descriptions bordered={true} column={1} size="small" style={{maxWidth: 800}}>
             <Descriptions.Item label="ID">
                 {biosample.id}
             </Descriptions.Item>
             <Descriptions.Item label="Sampled Tissue">
-                <OntologyTerm individual={individual} term={biosample.sampled_tissue} />
+                <OntologyTerm resourcesTuple={resourcesTuple} term={biosample.sampled_tissue} />
             </Descriptions.Item>
             <Descriptions.Item label="Procedure">
-                <BiosampleProcedure individual={individual} procedure={biosample.procedure} />
+                <BiosampleProcedure resourcesTuple={resourcesTuple} procedure={biosample.procedure} />
             </Descriptions.Item>
             <Descriptions.Item label="Histological Diagnosis">
-                <OntologyTerm individual={individual} term={biosample.histological_diagnosis} />
+                <OntologyTerm resourcesTuple={resourcesTuple} term={biosample.histological_diagnosis} />
             </Descriptions.Item>
             <Descriptions.Item label="Ind. Age At Collection">
                 {biosample.individual_age_at_collection
@@ -125,6 +127,7 @@ const Biosamples = ({ individual, handleBiosampleClick, handleExperimentClick })
     }, []);
 
     const biosamples = useDeduplicatedIndividualBiosamples(individual);
+    const resourcesTuple = useIndividualResources(individual);
 
     const columns = useMemo(
         () => [
@@ -136,7 +139,7 @@ const Biosamples = ({ individual, handleBiosampleClick, handleExperimentClick })
             {
                 title: "Sampled Tissue",
                 dataIndex: "sampled_tissue",
-                render: tissue => <OntologyTerm individual={individual} term={tissue} />,
+                render: tissue => <OntologyTerm resourcesTuple={resourcesTuple} term={tissue} />,
             },
             {
                 title: "Experiments",
@@ -146,7 +149,7 @@ const Biosamples = ({ individual, handleBiosampleClick, handleExperimentClick })
                 ),
             },
         ],
-        [individual, handleExperimentClick],
+        [resourcesTuple, handleExperimentClick],
     );
 
     const onExpand = useCallback(

--- a/src/components/explorer/IndividualDiseases.js
+++ b/src/components/explorer/IndividualDiseases.js
@@ -4,7 +4,7 @@ import { Table } from "antd";
 
 import { individualPropTypesShape } from "../../propTypes";
 import { EM_DASH } from "../../constants";
-import { ontologyTermSorter } from "./utils";
+import { ontologyTermSorter, useIndividualResources } from "./utils";
 
 import OntologyTerm from "./OntologyTerm";
 
@@ -13,6 +13,7 @@ import OntologyTerm from "./OntologyTerm";
 
 const IndividualDiseases = ({ individual }) => {
     const diseases = individual.phenopackets.flatMap(p => p.diseases);
+    const resourcesTuple = useIndividualResources(individual);
 
     const columns = useMemo(() => [
         {
@@ -24,7 +25,7 @@ const IndividualDiseases = ({ individual }) => {
         {
             title: "term",
             dataIndex: "term",
-            render: (term) => <OntologyTerm individual={individual} term={term} />,
+            render: (term) => <OntologyTerm resourcesTuple={resourcesTuple} term={term} />,
             sorter: ontologyTermSorter("term"),
         },
         {
@@ -41,21 +42,21 @@ const IndividualDiseases = ({ individual }) => {
                             ? <div>{disease.onset.start.age} - {disease.onset.end.age}</div>
                             // Onset age label only
                             : disease.onset.label
-                                ? <OntologyTerm individual={individual} term={disease.onset} />
+                                ? <OntologyTerm resourcesTuple={resourcesTuple} term={disease.onset} />
                                 : EM_DASH
                     : EM_DASH,
         },
         {
             title: "Extra Properties",
             key: "extra_properties",
-            render: (_, individual) =>
-                (Object.keys(individual.extra_properties ?? {}).length)
+            render: (_, disease) =>
+                (Object.keys(disease.extra_properties ?? {}).length)
                     ? <div>
-                        <pre>{JSON.stringify(individual.extra_properties, null, 2)}</pre>
+                        <pre>{JSON.stringify(disease.extra_properties, null, 2)}</pre>
                     </div>
                     : EM_DASH,
         },
-    ], [individual]);
+    ], [resourcesTuple]);
 
     return (
         <Table

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Route, Switch, useHistory, useParams, useRouteMatch } from "react-router-dom";
 import PropTypes from "prop-types";
 
-import { Button, Descriptions, Popover, Table, Typography } from "antd";
+import { Button, Descriptions, Icon, Popover, Table, Typography } from "antd";
 
 import { EM_DASH } from "../../constants";
 import { experimentPropTypesShape, experimentResultPropTypesShape, individualPropTypesShape } from "../../propTypes";
@@ -129,7 +129,7 @@ const ExperimentDetail = ({ experiment, resourcesTuple }) => {
 
     return (
         <div className="experiment_and_results">
-            <Typography.Title level={4}>{experimentType} - Details</Typography.Title>
+            <Typography.Title level={4}><Icon type="profile" /> Details</Typography.Title>
             <Descriptions layout="horizontal" bordered={true} column={2} size="small" style={{ maxWidth: 1200 }}>
                 <Descriptions.Item span={2} label="ID">
                     <span style={{ fontFamily: "monospace" }}>{id}</span>
@@ -176,8 +176,10 @@ const ExperimentDetail = ({ experiment, resourcesTuple }) => {
                     <JsonView inputJson={extraProperties} />
                 </Descriptions.Item>
             </Descriptions>
-            <Typography.Title level={4}>{experimentType} - Results</Typography.Title>
-            <Table
+            <Typography.Title level={4}>
+                <Icon type="file-text" /> {sortedExperimentResults.length ? 'Results' : 'No experiment results'}
+            </Typography.Title>
+            {sortedExperimentResults.length ? <Table
                 bordered={true}
                 size="small"
                 pagination={false}
@@ -185,7 +187,7 @@ const ExperimentDetail = ({ experiment, resourcesTuple }) => {
                 rowKey="id"
                 dataSource={sortedExperimentResults}
                 style={{ maxWidth: 1200, backgroundColor: "white" }}
-            />
+            /> : null}
         </div>
     );
 };

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -10,7 +10,7 @@ import { experimentPropTypesShape, experimentResultPropTypesShape, individualPro
 import { getFileDownloadUrlsFromDrs } from "../../modules/drs/actions";
 import { guessFileType } from "../../utils/guessFileType";
 
-import { useDeduplicatedIndividualBiosamples } from "./utils";
+import { useDeduplicatedIndividualBiosamples, useIndividualResources } from "./utils";
 
 import JsonView from "./JsonView";
 import OntologyTerm from "./OntologyTerm";
@@ -104,7 +104,7 @@ const EXPERIMENT_RESULTS_COLUMNS = [
     },
 ];
 
-const ExperimentDetail = ({ individual, experiment }) => {
+const ExperimentDetail = ({ experiment, resourcesTuple }) => {
     const {
         id,
         experiment_type: experimentType,
@@ -140,7 +140,10 @@ const ExperimentDetail = ({ individual, experiment }) => {
                     experiment_ontology is accidentally an array in Katsu, so this takes the first item
                     and falls back to just the field (if we fix this in the future)
                     */}
-                    <OntologyTerm individual={individual} term={experimentOntology?.[0] ?? experimentOntology} />
+                    <OntologyTerm
+                        resourcesTuple={resourcesTuple}
+                        term={experimentOntology?.[0] ?? experimentOntology}
+                    />
                 </Descriptions.Item>
                 <Descriptions.Item span={1} label="Molecule">
                     {molecule}
@@ -150,7 +153,7 @@ const ExperimentDetail = ({ individual, experiment }) => {
                     molecule_ontology is accidentally an array in Katsu, so this takes the first item
                     and falls back to just the field (if we fix this in the future)
                     */}
-                    <OntologyTerm individual={individual} term={moleculeOntology?.[0] ?? moleculeOntology} />
+                    <OntologyTerm resourcesTuple={resourcesTuple} term={moleculeOntology?.[0] ?? moleculeOntology} />
                 </Descriptions.Item>
                 <Descriptions.Item label="Study Type">{studyType}</Descriptions.Item>
                 <Descriptions.Item label="Extraction Protocol">{extractionProtocol}</Descriptions.Item>
@@ -187,8 +190,8 @@ const ExperimentDetail = ({ individual, experiment }) => {
     );
 };
 ExperimentDetail.propTypes = {
-    individual: individualPropTypesShape,
     experiment: experimentPropTypesShape,
+    resourcesTuple: PropTypes.array,
 };
 
 const Experiments = ({ individual, handleExperimentClick }) => {
@@ -218,6 +221,7 @@ const Experiments = ({ individual, handleExperimentClick }) => {
         () => biosamplesData.flatMap((b) => b?.experiments ?? []),
         [biosamplesData],
     );
+    const resourcesTuple = useIndividualResources(individual);
 
     useEffect(() => {
         // retrieve any download urls if experiments data changes
@@ -243,7 +247,7 @@ const Experiments = ({ individual, handleExperimentClick }) => {
             {
                 title: "Molecule",
                 dataIndex: "molecule_ontology",
-                render: (mo) => <OntologyTerm individual={individual} term={mo?.[0] ?? mo} />,
+                render: (mo) => <OntologyTerm resourcesTuple={resourcesTuple} term={mo?.[0] ?? mo} />,
             },
             {
                 title: "Experiment Results",
@@ -251,7 +255,7 @@ const Experiments = ({ individual, handleExperimentClick }) => {
                 render: (exp) => <span>{exp.experiment_results.length ?? 0} files</span>,
             },
         ],
-        [individual, handleExperimentClick],
+        [resourcesTuple, handleExperimentClick],
     );
 
     const onExpand = useCallback(
@@ -263,12 +267,9 @@ const Experiments = ({ individual, handleExperimentClick }) => {
 
     const expandedRowRender = useCallback(
         (experiment) => (
-            <ExperimentDetail
-                individual={individual}
-                experiment={experiment}
-            />
+            <ExperimentDetail experiment={experiment} resourcesTuple={resourcesTuple} />
         ),
-        [handleExperimentClick],
+        [resourcesTuple],
     );
 
     return (

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -252,7 +252,8 @@ const Experiments = ({ individual, handleExperimentClick }) => {
             {
                 title: "Experiment Results",
                 key: "experiment_results",
-                render: (exp) => <span>{exp.experiment_results.length ?? 0} files</span>,
+                // experiment_results can be undefined if no experiment results exist
+                render: (exp) => <span>{exp.experiment_results?.length ?? 0} files</span>,
             },
         ],
         [resourcesTuple, handleExperimentClick],

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -177,7 +177,7 @@ const ExperimentDetail = ({ experiment, resourcesTuple }) => {
                 </Descriptions.Item>
             </Descriptions>
             <Typography.Title level={4}>
-                <Icon type="file-text" /> {sortedExperimentResults.length ? 'Results' : 'No experiment results'}
+                <Icon type="file-text" /> {sortedExperimentResults.length ? "Results" : "No experiment results"}
             </Typography.Title>
             {sortedExperimentResults.length ? <Table
                 bordered={true}

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import { Button, Descriptions, Popover, Table, Typography } from "antd";
 
 import { EM_DASH } from "../../constants";
-import { experimentPropTypesShape, individualPropTypesShape } from "../../propTypes";
+import { experimentPropTypesShape, experimentResultPropTypesShape, individualPropTypesShape } from "../../propTypes";
 import { getFileDownloadUrlsFromDrs } from "../../modules/drs/actions";
 import { guessFileType } from "../../utils/guessFileType";
 
@@ -16,10 +16,10 @@ import JsonView from "./JsonView";
 import OntologyTerm from "./OntologyTerm";
 import DownloadButton from "../DownloadButton";
 
-const ExperimentResultDownloadButton = ({ resultFile }) => {
+const ExperimentResultDownloadButton = ({ result }) => {
     const downloadUrls = useSelector((state) => state.drs.downloadUrlsByFilename);
 
-    const url = downloadUrls[resultFile.filename]?.url;
+    const url = downloadUrls[result.filename]?.url;
     return url ? (
         <DownloadButton type="link" uri={url}>{""}</DownloadButton>
     ) : (
@@ -27,9 +27,7 @@ const ExperimentResultDownloadButton = ({ resultFile }) => {
     );
 };
 ExperimentResultDownloadButton.propTypes = {
-    resultFile: PropTypes.shape({
-        filename: PropTypes.string,
-    }),
+    result: experimentResultPropTypesShape,
 };
 
 const EXPERIMENT_RESULTS_COLUMNS = [
@@ -53,7 +51,7 @@ const EXPERIMENT_RESULTS_COLUMNS = [
         title: "Download",
         key: "download",
         align: "center",
-        render: (_, result) => <ExperimentResultDownloadButton resultFile={result} />,
+        render: (_, result) => <ExperimentResultDownloadButton result={result} />,
     },
     {
         key: "other_details",
@@ -286,7 +284,11 @@ const Experiments = ({ individual, handleExperimentClick }) => {
             rowKey="id"
         />
     );
-}
+};
+Experiments.propTypes = {
+    individual: individualPropTypesShape,
+    handleExperimentClick: PropTypes.func,
+};
 
 const IndividualExperiments = ({ individual }) => {
     const history = useHistory();

--- a/src/components/explorer/IndividualOntologies.js
+++ b/src/components/explorer/IndividualOntologies.js
@@ -1,9 +1,9 @@
 import React from "react";
 
-import {Table} from "antd";
+import { Table } from "antd";
 
-import {individualPropTypesShape} from "../../propTypes";
-import {useResources} from "./utils";
+import { individualPropTypesShape } from "../../propTypes";
+import { useIndividualResources } from "./utils";
 
 
 // TODO: Only show diseases from the relevant dataset, if specified;
@@ -48,8 +48,8 @@ const METADATA_COLUMNS = [
     },
 ];
 
-const IndividualMetadata = ({individual}) => {
-    const resources = useResources(individual);
+const IndividualOntologies = ({individual}) => {
+    const [resources, isFetching] = useIndividualResources(individual);
 
     return (
         <Table
@@ -59,12 +59,13 @@ const IndividualMetadata = ({individual}) => {
             columns={METADATA_COLUMNS}
             rowKey="id"
             dataSource={resources}
+            loading={isFetching}
         />
     );
 };
 
-IndividualMetadata.propTypes = {
+IndividualOntologies.propTypes = {
     individual: individualPropTypesShape,
 };
 
-export default IndividualMetadata;
+export default IndividualOntologies;

--- a/src/components/explorer/IndividualOverview.js
+++ b/src/components/explorer/IndividualOverview.js
@@ -5,25 +5,32 @@ import { Descriptions } from "antd";
 
 import { EM_DASH } from "../../constants";
 import { individualPropTypesShape } from "../../propTypes";
+import { useIndividualResources } from "./utils";
 import OntologyTerm from "./OntologyTerm";
 
-const IndividualOverview = ({individual}) => individual ?
-    <Descriptions layout="vertical" bordered={true} size="middle">
-        <Descriptions.Item label="Date of Birth">{individual.date_of_birth || EM_DASH}</Descriptions.Item>
-        <Descriptions.Item label="Sex">{individual.sex || "UNKNOWN_SEX"}</Descriptions.Item>
-        <Descriptions.Item label="Age">{getAge(individual)}</Descriptions.Item>
-        <Descriptions.Item label="Ethnicity">{individual.ethnicity || "UNKNOWN_ETHNICITY"}</Descriptions.Item>
-        <Descriptions.Item label="Karyotypic Sex">{individual.karyotypic_sex || "UNKNOWN_KARYOTYPE"}</Descriptions.Item>
-        <Descriptions.Item label="Taxonomy">
-            <OntologyTerm
-                individual={individual}
-                term={individual.taxonomy}
-                renderLabel={label => (<em>{label}</em>)}
-            />
-        </Descriptions.Item>
-        <Descriptions.Item label="Extra Properties">{
-            (individual.hasOwnProperty("extra_properties") && Object.keys(individual.extra_properties).length)
-                ?  <div>
+const IndividualOverview = ({individual}) => {
+    const resourcesTuple = useIndividualResources(individual);
+
+    if (!individual) return <div />;
+    return (
+        <Descriptions layout="vertical" bordered={true} size="middle">
+            <Descriptions.Item label="Date of Birth">{individual.date_of_birth || EM_DASH}</Descriptions.Item>
+            <Descriptions.Item label="Sex">{individual.sex || "UNKNOWN_SEX"}</Descriptions.Item>
+            <Descriptions.Item label="Age">{getAge(individual)}</Descriptions.Item>
+            <Descriptions.Item label="Ethnicity">{individual.ethnicity || "UNKNOWN_ETHNICITY"}</Descriptions.Item>
+            <Descriptions.Item label="Karyotypic Sex">{
+                individual.karyotypic_sex || "UNKNOWN_KARYOTYPE"}
+            </Descriptions.Item>
+            <Descriptions.Item label="Taxonomy">
+                <OntologyTerm
+                    resourcesTuple={resourcesTuple}
+                    term={individual.taxonomy}
+                    renderLabel={label => (<em>{label}</em>)}
+                />
+            </Descriptions.Item>
+            <Descriptions.Item label="Extra Properties">{
+                (individual.hasOwnProperty("extra_properties") && Object.keys(individual.extra_properties).length)
+                    ?  <div>
                     <pre>
                           <ReactJson src={individual.extra_properties}
                                      displayDataTypes={false}
@@ -32,10 +39,12 @@ const IndividualOverview = ({individual}) => individual ?
                                      enableClipboard={false}
                           />
                     </pre>
-                   </div>
-                : EM_DASH
-        }</Descriptions.Item>
-    </Descriptions> : <div />;
+                    </div>
+                    : EM_DASH
+            }</Descriptions.Item>
+        </Descriptions>
+    );
+};
 
 IndividualOverview.propTypes = {
     individual: individualPropTypesShape,

--- a/src/components/explorer/IndividualPhenotypicFeatures.js
+++ b/src/components/explorer/IndividualPhenotypicFeatures.js
@@ -5,8 +5,11 @@ import { Icon, Table } from "antd";
 import { EM_DASH } from "../../constants";
 import { individualPropTypesShape } from "../../propTypes";
 import OntologyTerm from "./OntologyTerm";
+import { useIndividualResources } from "./utils";
 
 const IndividualPhenotypicFeatures = ({ individual }) => {
+    const resourcesTuple = useIndividualResources(individual);
+
     const columns = useMemo(() => [
         {
             title: "Feature",
@@ -20,7 +23,7 @@ const IndividualPhenotypicFeatures = ({ individual }) => {
                         </span>
                     </h4>
                 ) : <>
-                    <OntologyTerm individual={individual} term={type} />{" "}
+                    <OntologyTerm resourcesTuple={resourcesTuple} term={type} />{" "}
                     {negated ? (
                         <span style={{ color: "#CC3333" }}>
                             (<span style={{ fontWeight: "bold" }}>Excluded:</span>{" "}
@@ -63,7 +66,7 @@ const IndividualPhenotypicFeatures = ({ individual }) => {
             },
         },
 
-    ], [individual]);
+    ], [resourcesTuple]);
 
     const data = useMemo(() => {
         const phenopackets = (individual?.phenopackets ?? []);

--- a/src/components/explorer/OntologyTerm.js
+++ b/src/components/explorer/OntologyTerm.js
@@ -1,17 +1,17 @@
 import React, { memo, useEffect } from "react";
 import PropTypes from "prop-types";
 
-import { Icon } from "antd";
+import { Button, Icon } from "antd";
 
 import { EM_DASH } from "../../constants";
-import { individualPropTypesShape, ontologyShape } from "../../propTypes";
+import { ontologyShape } from "../../propTypes";
 import { id } from "../../utils/misc";
 
 import { useResourcesByNamespacePrefix } from "./utils";
 
-const OntologyTerm = memo(({ individual, term, renderLabel }) => {
+const OntologyTerm = memo(({ resourcesTuple, term, renderLabel }) => {
     // TODO: perf: might be slow to generate this over and over
-    const resourcesByNamespacePrefix = useResourcesByNamespacePrefix(individual);
+    const [resourcesByNamespacePrefix, isFetchingResources] = useResourcesByNamespacePrefix(resourcesTuple);
 
     if (!term) {
         return (
@@ -43,22 +43,30 @@ const OntologyTerm = memo(({ individual, term, renderLabel }) => {
         if (termResource?.iri_prefix && !termResource.iri_prefix.includes("example.org")) {
             defLink = `${termResource.iri_prefix}${namespaceID}`;
         }  // If resource doesn't exist / isn't linkable, don't include a link
-    }  // Otherwise, malformed ID - render without a link
+    }  // Otherwise, malformed ID - render a disabled link
 
     return (
         <span>
             {renderLabel(term.label)} (ID: {term.id}){" "}
-            {defLink && (
-                <a href={defLink} target="_blank" rel="noopener noreferrer">
+            <span style={{cursor: (!defLink) ? (isFetchingResources ? "wait" : "not-allowed") : "pointer"}}>
+                <Button
+                    type="link"
+                    size="small"
+                    disabled={!defLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={defLink ?? "#"}
+                    style={{ padding: 0 }}
+                >
                     <Icon type="link" />
-                </a>
-            )}
+                </Button>
+            </span>
         </span>
     );
 });
 
 OntologyTerm.propTypes = {
-    individual: individualPropTypesShape,
+    resourcesTuple: PropTypes.array,
     term: ontologyShape.isRequired,
     renderLabel: PropTypes.func,
 };

--- a/src/components/explorer/explorer.css
+++ b/src/components/explorer/explorer.css
@@ -1,11 +1,3 @@
-/* css snippet to help align the antd spinner in the parent row */
-.ant-spin-nested-loading,
-.ant-spin-nested-loading > div:first-child,
-.ant-spin-spinning,
-.ant-spin-container {
-  display: inline !important;
-}
-
 .ant-table-row.ant-table-row-level-0 {
   vertical-align: top !important;
 }
@@ -19,8 +11,9 @@
 
 /* Variants tab */
 
-.variantDescriptions .ant-descriptions-item-label{
+.variantDescriptions .ant-descriptions-item-label {
   vertical-align: top;
+  width: 200px;
 }
 
 /* Biosamples and Experiments tabs */

--- a/src/components/explorer/explorer.css
+++ b/src/components/explorer/explorer.css
@@ -46,66 +46,16 @@
   padding: 8px 16px !important;
 }
 
-.ant-descriptions-item-no-label {
-  display: none;
+.ant-table-expanded-row .ant-descriptions-bordered table {
+  border-collapse: collapse;  /* Fixes borders not showing in descriptions nested inside tables */
 }
-
-.ant-descriptions-item-label.ant-descriptions-item-colon {
-  width: 200px;
-  padding: 8px 16px !important;
-}
-
-/* selector for nested descriptions */
-.ant-descriptions-view .ant-descriptions-view {
-  border: 0;
-  box-shadow: 0 0 0 1px #e8e8e8;
-}
-
 .ant-table-expanded-row .ant-descriptions-item-content {
-  background-color: white;
+  background-color: white;  /* Fixes no background on item content for descriptions nested inside tables */
 }
 
-.ant-descriptions-view .ant-descriptions-view .ant-descriptions-item-content {
-  padding: 8px 16px;
-  border-spacing: 0;
-  border: 0;
-  border-top: 0;
-  border-bottom: 0;
+.experiment_and_results {
+  margin: 8px 16px;
 }
-
-.experiment_summary {
-  display: flex;
-  margin-bottom: 25px;
-  gap: 12px;
-}
-
-/* box shadow instead of borders for automatic border collapse on adjacent items */
-.experiment_summary > :last-child > * {
-  border: 0;
-  box-shadow: 0 0 0 1px #e8e8e8;
-}
-
-.experiment_summary > :first-child > * {
-  border: 0;
-  box-shadow: 0 0 0 1px #e8e8e8;
-}
-
-.experiment-titles {
-  padding: 0 0 8px 17px;
-}
-
-.other-details .ant-descriptions-item-label {
-  padding: 0 10px !important;
-}
-
-.other-details .ant-descriptions-item-content {
-  padding: 0 10px !important;
-}
-
-.other-details-click {
-  color: #1990ff;
-}
-
-.experiment_and_results .ant-table-content {
-  display: inline-block;
+.experiment_and_results h4:not(:first-of-type) {
+  margin-top: 16px;
 }

--- a/src/components/explorer/searchResultsTables/ExperimentsTable.js
+++ b/src/components/explorer/searchResultsTables/ExperimentsTable.js
@@ -14,8 +14,7 @@ const ExperimentRender = React.memo(({ experimentId, individual }) => {
         <>
             <Link
                 to={{
-                    pathname: `/data/explorer/individuals/${individual.id}/experiments`,
-                    hash: "#" + experimentId,
+                    pathname: `/data/explorer/individuals/${individual.id}/experiments/${experimentId}`,
                     state: { backUrl: location.pathname },
                 }}
             >

--- a/src/modules/datasets/actions.js
+++ b/src/modules/datasets/actions.js
@@ -53,6 +53,7 @@ const fetchDatasetResources = networkAction((datasetID) => (dispatch, getState) 
     err: "Error fetching dataset resources",
 }));
 export const fetchDatasetResourcesIfNecessary = (datasetID) => (dispatch, getState) => {
-    if (getState().datasetResources.itemsByID[datasetID]?.isFetching) return;
+    const datasetResources = getState().datasetResources.itemsByID[datasetID];
+    if (datasetResources?.isFetching || datasetResources?.data) return;
     return dispatch(fetchDatasetResources(datasetID));
 };

--- a/src/modules/datasets/actions.js
+++ b/src/modules/datasets/actions.js
@@ -3,7 +3,11 @@ import {getDataServices} from "../services/utils";
 
 export const FETCHING_DATASETS_DATA_TYPES = createFlowActionTypes("FETCHING_DATASETS_DATA_TYPES");
 export const FETCH_DATASET_DATA_TYPES_SUMMARY = createNetworkActionTypes("FETCH_DATASET_DATA_TYPES_SUMMARY");
+
 export const FETCH_DATASET_SUMMARY = createNetworkActionTypes("FETCH_DATASET_SUMMARY");
+export const FETCHING_ALL_DATASET_SUMMARIES = createFlowActionTypes("FETCHING_ALL_DATASET_SUMMARIES");
+
+export const FETCH_DATASET_RESOURCES = createNetworkActionTypes("FETCH_DATASET_RESOURCES");
 
 const fetchDatasetDataTypesSummary = networkAction((serviceInfo, datasetID) => ({
     types: FETCH_DATASET_DATA_TYPES_SUMMARY,
@@ -12,7 +16,7 @@ const fetchDatasetDataTypesSummary = networkAction((serviceInfo, datasetID) => (
 }));
 
 export const fetchDatasetDataTypesSummariesIfPossible = (datasetID) => async (dispatch, getState) => {
-    if (getState().datasetDataTypes.itemsById?.[datasetID]?.isFetching) return;
+    if (getState().datasetDataTypes.itemsByID?.[datasetID]?.isFetching) return;
     await Promise.all(
         getDataServices(getState()).map(serviceInfo => dispatch(fetchDatasetDataTypesSummary(serviceInfo, datasetID))),
     );
@@ -34,8 +38,21 @@ const fetchDatasetSummary = networkAction((serviceInfo, datasetID) => ({
 }));
 
 export const fetchDatasetSummariesIfPossible = (datasetID) => async (dispatch, getState) => {
-    if (getState().datasetSummaries.isFetching) return;
+    if (getState().datasetSummaries.isFetchingAll) return;
+    dispatch(beginFlow(FETCHING_ALL_DATASET_SUMMARIES));
     await Promise.all(
         getDataServices(getState()).map(serviceInfo => dispatch(fetchDatasetSummary(serviceInfo, datasetID))),
     );
+    dispatch(endFlow(FETCHING_ALL_DATASET_SUMMARIES));
+};
+
+const fetchDatasetResources = networkAction((datasetID) => (dispatch, getState) => ({
+    types: FETCH_DATASET_RESOURCES,
+    params: {datasetID},
+    url: `${getState().services.metadataService.url}/api/datasets/${datasetID}/resources`,
+    err: "Error fetching dataset resources",
+}));
+export const fetchDatasetResourcesIfNecessary = (datasetID) => (dispatch, getState) => {
+    if (getState().datasetResources.itemsByID[datasetID]?.isFetching) return;
+    return dispatch(fetchDatasetResources(datasetID));
 };

--- a/src/modules/datasets/reducers.js
+++ b/src/modules/datasets/reducers.js
@@ -1,8 +1,13 @@
-import {FETCHING_DATASETS_DATA_TYPES, FETCH_DATASET_DATA_TYPES_SUMMARY, FETCH_DATASET_SUMMARY} from "./actions";
+import {
+    FETCHING_DATASETS_DATA_TYPES,
+    FETCH_DATASET_DATA_TYPES_SUMMARY,
+    FETCH_DATASET_SUMMARY,
+    FETCHING_ALL_DATASET_SUMMARIES, FETCH_DATASET_RESOURCES,
+} from "./actions";
 
 export const datasetDataTypes = (
     state = {
-        itemsById: {},
+        itemsByID: {},
         isFetchingAll: false,
     },
     action,
@@ -16,10 +21,10 @@ export const datasetDataTypes = (
             const {datasetID} = action;
             return {
                 ...state,
-                itemsById: {
-                    ...state.itemsById,
+                itemsByID: {
+                    ...state.itemsByID,
                     [datasetID]: {
-                        itemsById: state.itemsById[datasetID]?.itemsById ?? {},
+                        itemsByID: state.itemsByID[datasetID]?.itemsByID ?? {},
                         isFetching: true,
                     },
                 },
@@ -30,11 +35,11 @@ export const datasetDataTypes = (
             const itemsByID = Object.fromEntries(action.data.map(d => [d.id, d]));
             return {
                 ...state,
-                itemsById: {
-                    ...state.itemsById,
+                itemsByID: {
+                    ...state.itemsByID,
                     [datasetID]: {
-                        itemsById: {
-                            ...state.itemsById[datasetID].itemsById,
+                        itemsByID: {
+                            ...state.itemsByID[datasetID].itemsByID,
                             ...itemsByID,
                         },
                     },
@@ -46,10 +51,10 @@ export const datasetDataTypes = (
             const {datasetID} = action;
             return {
                 ...state,
-                itemsById: {
-                    ...state.itemsById,
+                itemsByID: {
+                    ...state.itemsByID,
                     [datasetID]: {
-                        ...state.itemsById[datasetID],
+                        ...state.itemsByID[datasetID],
                         isFetching: false,
                     },
                 },
@@ -61,43 +66,55 @@ export const datasetDataTypes = (
 };
 
 
+const datasetItemSet = (oldState, datasetID, key, value) => ({
+    ...oldState,
+    itemsByID: {
+        ...oldState.itemsByID,
+        [datasetID]: {
+            ...(oldState.itemsByID[datasetID] ?? {}),
+            [key]: value,
+        },
+    },
+});
+
+
 export const datasetSummaries = (
     state = {
-        itemsById: {},
+        isFetchingAll: false,
+        itemsByID: {},
     },
     action,
 ) => {
     switch (action.type) {
-        case FETCH_DATASET_SUMMARY.REQUEST:{
-            const {datasetID} = action;
-            return {
-                ...state,
-                itemsById: {
-                    ...state.itemsById,
-                    [datasetID]: {
-                        ...(state.itemsById[datasetID] ?? {}),
-                    },
-                },
-            };
-        }
-        case FETCH_DATASET_SUMMARY.RECEIVE:{
-            const {datasetID} = action;
-            return {
-                ...state,
-                itemsById: {
-                    ...state.itemsById,
-                    [datasetID]: {
-                        ...state.itemsById[datasetID],
-                        ...action.data,
-                    },
-                },
-            };
-        }
+        case FETCH_DATASET_SUMMARY.REQUEST:
+            return datasetItemSet(state, action.datasetID, "isFetching", true);
+        case FETCH_DATASET_SUMMARY.RECEIVE:
+            return datasetItemSet(state, action.datasetID, "data", action.data);
         case FETCH_DATASET_SUMMARY.FINISH:
-        case FETCH_DATASET_SUMMARY.ERROR:
-            return {
-                ...state,
-            };
+            return datasetItemSet(state, action.datasetID, "isFetching", false);
+        case FETCHING_ALL_DATASET_SUMMARIES.BEGIN:
+            return {...state, isFetchingAll: true};
+        case FETCHING_ALL_DATASET_SUMMARIES.END:
+        case FETCHING_ALL_DATASET_SUMMARIES.TERMINATE:
+            return {...state, isFetchingAll: false};
+        default:
+            return state;
+    }
+};
+
+export const datasetResources = (
+    state = {
+        itemsByID: {},
+    },
+    action,
+) => {
+    switch (action.type) {
+        case FETCH_DATASET_RESOURCES.REQUEST:
+            return datasetItemSet(state, action.datasetID, "isFetching", true);
+        case FETCH_DATASET_RESOURCES.RECEIVE:
+            return datasetItemSet(state, action.datasetID, "data", action.data);
+        case FETCH_DATASET_RESOURCES.FINISH:
+            return datasetItemSet(state, action.datasetID, "isFetching", false);
         default:
             return state;
     }

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -141,7 +141,7 @@ export const deleteProjectIfPossible = project => async (dispatch, getState) => 
 
 export const clearDatasetDataTypes = datasetId => async (dispatch, getState) => {
     // only clear data types which can yield counts - `queryable` is a proxy for this
-    const dataTypes = Object.values(getState().datasetDataTypes.itemsById[datasetId].itemsById)
+    const dataTypes = Object.values(getState().datasetDataTypes.itemsByID[datasetId].itemsByID)
         .filter(dt => dt.queryable);
     return await Promise.all(dataTypes.map(dt => dispatch(clearDatasetDataType(datasetId, dt.id))));
 };
@@ -307,4 +307,3 @@ export const fetchOverviewSummary = networkAction(() => (dispatch, getState) => 
     url: `${getState().services.metadataService.url}/api/overview`,
     err: "Error fetching overview summary metadata",
 }));
-

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -360,6 +360,8 @@ export const experimentPropTypesShape = PropTypes.shape({
         ]),
         data_output_type: PropTypes.oneOf(["Raw data", "Derived data"]),
         usage: PropTypes.string,
+        creation_date: PropTypes.string,
+        created_by: PropTypes.string,
     })),
 
     qc_flags: PropTypes.arrayOf(PropTypes.string),

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -281,6 +281,16 @@ export const phenotypicFeaturePropTypesShape = PropTypes.shape({
     updated: PropTypes.string,  // ISO datetime string
 });
 
+export const resourcePropTypesShape = PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    namespace_prefix: PropTypes.string,
+    url: PropTypes.string,
+    version: PropTypes.string,
+    iri_prefix: PropTypes.string,
+    extra_properties: PropTypes.object,
+});
+
 export const phenopacketPropTypesShape = PropTypes.shape({
     id: PropTypes.string.isRequired,
     subject: PropTypes.oneOfType([individualPropTypesShape, PropTypes.string]).isRequired,
@@ -291,19 +301,43 @@ export const phenopacketPropTypesShape = PropTypes.shape({
         created: PropTypes.string,
         created_by: PropTypes.string,
         submitted_by: PropTypes.string,
-        resources: PropTypes.arrayOf(PropTypes.shape({
-            id: PropTypes.string,
-            name: PropTypes.string,
-            namespace_prefix: PropTypes.string,
-            url: PropTypes.string,
-            version: PropTypes.string,
-            iri_prefix: PropTypes.string,
-            extra_properties: PropTypes.object,
-        })),
+        resources: PropTypes.arrayOf(resourcePropTypesShape),
         phenopacket_schema_version: PropTypes.string,
     }).isRequired,
     created: PropTypes.string,  // ISO datetime string
     updated: PropTypes.string,  // ISO datetime string
+});
+
+export const experimentResultPropTypesShape = PropTypes.shape({
+    identifier: PropTypes.string,
+    description: PropTypes.string,
+    filename: PropTypes.string,
+    file_format: PropTypes.oneOf([
+        "SAM",
+        "BAM",
+        "CRAM",
+        "BAI",
+        "CRAI",
+        "VCF",
+        "BCF",
+        "GVCF",
+        "BigWig",
+        "BigBed",
+        "FASTA",
+        "FASTQ",
+        "TAB",
+        "SRA",
+        "SRF",
+        "SFF",
+        "GFF",
+        "TABIX",
+        "UNKNOWN",
+        "OTHER",
+    ]),
+    data_output_type: PropTypes.oneOf(["Raw data", "Derived data"]),
+    usage: PropTypes.string,
+    creation_date: PropTypes.string,
+    created_by: PropTypes.string,
 });
 
 export const experimentPropTypesShape = PropTypes.shape({
@@ -332,37 +366,7 @@ export const experimentPropTypesShape = PropTypes.shape({
         model: PropTypes.string,
     }),
 
-    experiment_results: PropTypes.arrayOf(PropTypes.shape({
-        identifier: PropTypes.string,
-        description: PropTypes.string,
-        filename: PropTypes.string,
-        file_format: PropTypes.oneOf([
-            "SAM",
-            "BAM",
-            "CRAM",
-            "BAI",
-            "CRAI",
-            "VCF",
-            "BCF",
-            "GVCF",
-            "BigWig",
-            "BigBed",
-            "FASTA",
-            "FASTQ",
-            "TAB",
-            "SRA",
-            "SRF",
-            "SFF",
-            "GFF",
-            "TABIX",
-            "UNKNOWN",
-            "OTHER",
-        ]),
-        data_output_type: PropTypes.oneOf(["Raw data", "Derived data"]),
-        usage: PropTypes.string,
-        creation_date: PropTypes.string,
-        created_by: PropTypes.string,
-    })),
+    experiment_results: PropTypes.arrayOf(experimentResultPropTypesShape),
 
     qc_flags: PropTypes.arrayOf(PropTypes.string),
 

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -20,7 +20,7 @@ import {
     serviceDataTypes,
     serviceWorkflows,
 } from "./modules/services/reducers";
-import {datasetDataTypes, datasetSummaries} from "./modules/datasets/reducers";
+import {datasetDataTypes, datasetResources, datasetSummaries} from "./modules/datasets/reducers";
 import {runs} from "./modules/wes/reducers";
 
 const rootReducer = combineReducers({
@@ -60,6 +60,7 @@ const rootReducer = combineReducers({
     // Dataset module
     datasetDataTypes,
     datasetSummaries,
+    datasetResources,
 
     // WES module
     runs,


### PR DESCRIPTION
also includes
* dataset-based resource fetching to link ontologies correctly
* ontology links from biosample search results

requires the `releases/v13.1` branch of the main Bento repo, with Katsu 4.2.0!!