### PR TITLE
feat(explorer): use dataset resources for ontology displays

### DIFF
--- a/src/components/explorer/ExplorerIndividualContent.js
+++ b/src/components/explorer/ExplorerIndividualContent.js
@@ -4,11 +4,12 @@ import { Redirect, Route, Switch, useHistory, useLocation, useParams, useRouteMa
 
 import { Layout, Menu, Skeleton } from "antd";
 
-import { fetchDatasetResourcesIfNecessary } from "../../modules/datasets/actions";
+import { BENTO_URL } from "../../config";
 import { fetchIndividualIfNecessary } from "../../modules/metadata/actions";
 import { LAYOUT_CONTENT_STYLE } from "../../styles/layoutContent";
 import { matchingMenuKeys, renderMenuItem } from "../../utils/menu";
 import { urlPath } from "../../utils/url";
+import { useResources } from "./utils";
 
 import SitePageHeader from "../SitePageHeader";
 import IndividualOverview from "./IndividualOverview";
@@ -21,8 +22,6 @@ import IndividualVariants from "./IndividualVariants";
 import IndividualGenes from "./IndividualGenes";
 import IndividualTracks from "./IndividualTracks";
 import IndividualPhenopackets from "./IndividualPhenopackets";
-
-import { BENTO_URL } from "../../config";
 
 const MENU_STYLE = {
     marginLeft: "-24px",
@@ -62,12 +61,8 @@ const ExplorerIndividualContent = () => {
 
     const { isFetching: individualIsFetching, data: individual } = individuals[individualID] ?? {};
 
-    useEffect(() => {
-        // TODO: when individual belongs to a single dataset, use that instead
-        if (individual) {
-            individual.phenopackets.map((p) => dispatch(fetchDatasetResourcesIfNecessary(p.dataset)));
-        }
-    }, [dispatch, individual]);
+    // Trigger resource loading
+    useResources(individual);
 
     const overviewUrl = `${individualUrl}/overview`;
     const phenotypicFeaturesUrl = `${individualUrl}/phenotypic-features`;

--- a/src/components/explorer/ExplorerIndividualContent.js
+++ b/src/components/explorer/ExplorerIndividualContent.js
@@ -16,7 +16,7 @@ import IndividualPhenotypicFeatures from "./IndividualPhenotypicFeatures";
 import IndividualBiosamples from "./IndividualBiosamples";
 import IndividualExperiments from "./IndividualExperiments";
 import IndividualDiseases from "./IndividualDiseases";
-import IndividualMetadata from "./IndividualMetadata";
+import IndividualOntologies from "./IndividualOntologies";
 import IndividualVariants from "./IndividualVariants";
 import IndividualGenes from "./IndividualGenes";
 import IndividualTracks from "./IndividualTracks";
@@ -76,7 +76,7 @@ const ExplorerIndividualContent = () => {
     const variantsUrl = `${individualUrl}/variants`;
     const genesUrl = `${individualUrl}/genes`;
     const diseasesUrl = `${individualUrl}/diseases`;
-    const metadataUrl = `${individualUrl}/metadata`;
+    const ontologiesUrl = `${individualUrl}/ontologies`;
     const tracksUrl = `${individualUrl}/tracks`;
     const phenopacketsUrl = `${individualUrl}/phenopackets`;
 
@@ -89,7 +89,7 @@ const ExplorerIndividualContent = () => {
         {url: variantsUrl, text: "Variants"},
         {url: genesUrl, text: "Genes"},
         {url: diseasesUrl, text: "Diseases"},
-        {url: metadataUrl, text: "Metadata"},
+        {url: ontologiesUrl, text: "Ontologies"},
         {url: phenopacketsUrl, text: "Phenopackets JSON"},
     ];
 
@@ -133,8 +133,8 @@ const ExplorerIndividualContent = () => {
                     <Route path={diseasesUrl.replace(":", "\\:")}>
                         <IndividualDiseases individual={individual} />
                     </Route>
-                    <Route path={metadataUrl.replace(":", "\\:")}>
-                        <IndividualMetadata individual={individual} />
+                    <Route path={ontologiesUrl.replace(":", "\\:")}>
+                        <IndividualOntologies individual={individual} />
                     </Route>
                     <Route path={phenopacketsUrl.replace(":", "\\:")}>
                         <IndividualPhenopackets individual={individual} />

--- a/src/components/explorer/ExplorerIndividualContent.js
+++ b/src/components/explorer/ExplorerIndividualContent.js
@@ -9,7 +9,7 @@ import { fetchIndividualIfNecessary } from "../../modules/metadata/actions";
 import { LAYOUT_CONTENT_STYLE } from "../../styles/layoutContent";
 import { matchingMenuKeys, renderMenuItem } from "../../utils/menu";
 import { urlPath } from "../../utils/url";
-import { useResources } from "./utils";
+import { useIndividualResources } from "./utils";
 
 import SitePageHeader from "../SitePageHeader";
 import IndividualOverview from "./IndividualOverview";
@@ -62,7 +62,7 @@ const ExplorerIndividualContent = () => {
     const { isFetching: individualIsFetching, data: individual } = individuals[individualID] ?? {};
 
     // Trigger resource loading
-    useResources(individual);
+    useIndividualResources(individual);
 
     const overviewUrl = `${individualUrl}/overview`;
     const phenotypicFeaturesUrl = `${individualUrl}/phenotypic-features`;

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -5,7 +5,7 @@ import { Route, Switch, useHistory, useRouteMatch, useParams } from "react-route
 import { Button, Descriptions, Table } from "antd";
 
 import { EM_DASH } from "../../constants";
-import { useDeduplicatedIndividualBiosamples } from "./utils";
+import { useDeduplicatedIndividualBiosamples, useIndividualResources } from "./utils";
 import {
     biosamplePropTypesShape,
     experimentPropTypesShape,
@@ -21,18 +21,19 @@ import "./explorer.css";
 // TODO: Only show biosamples from the relevant dataset, if specified;
 //  highlight those found in search results, if specified
 
-const BiosampleProcedure = ({ individual, procedure }) => (
+const BiosampleProcedure = ({ resourcesTuple, procedure }) => (
     <div>
-        <strong>Code:</strong>{" "}<OntologyTerm individual={individual} term={procedure.code} />
+        <strong>Code:</strong>{" "}<OntologyTerm resourcesTuple={resourcesTuple} term={procedure.code} />
         {procedure.body_site ? (
             <div>
-                <strong>Body Site:</strong>{" "}<OntologyTerm individual={individual} term={procedure.body_site} />
+                <strong>Body Site:</strong>{" "}
+                <OntologyTerm resourcesTuple={resourcesTuple} term={procedure.body_site} />
             </div>
         ) : null}
     </div>
 );
 BiosampleProcedure.propTypes = {
-    individual: individualPropTypesShape.isRequired,
+    resourcesTuple: PropTypes.array,
     procedure: PropTypes.shape({
         code: ontologyShape.isRequired,
         body_site: ontologyShape,
@@ -60,19 +61,20 @@ ExperimentsClickList.propTypes = {
 };
 
 const BiosampleDetail = ({ individual, biosample, handleExperimentClick }) => {
+    const resourcesTuple = useIndividualResources(individual);
     return (
         <Descriptions bordered={true} column={1} size="small" style={{maxWidth: 800}}>
             <Descriptions.Item label="ID">
                 {biosample.id}
             </Descriptions.Item>
             <Descriptions.Item label="Sampled Tissue">
-                <OntologyTerm individual={individual} term={biosample.sampled_tissue} />
+                <OntologyTerm resourcesTuple={resourcesTuple} term={biosample.sampled_tissue} />
             </Descriptions.Item>
             <Descriptions.Item label="Procedure">
-                <BiosampleProcedure individual={individual} procedure={biosample.procedure} />
+                <BiosampleProcedure resourcesTuple={resourcesTuple} procedure={biosample.procedure} />
             </Descriptions.Item>
             <Descriptions.Item label="Histological Diagnosis">
-                <OntologyTerm individual={individual} term={biosample.histological_diagnosis} />
+                <OntologyTerm resourcesTuple={resourcesTuple} term={biosample.histological_diagnosis} />
             </Descriptions.Item>
             <Descriptions.Item label="Ind. Age At Collection">
                 {biosample.individual_age_at_collection
@@ -125,6 +127,7 @@ const Biosamples = ({ individual, handleBiosampleClick, handleExperimentClick })
     }, []);
 
     const biosamples = useDeduplicatedIndividualBiosamples(individual);
+    const resourcesTuple = useIndividualResources(individual);
 
     const columns = useMemo(
         () => [
@@ -136,7 +139,7 @@ const Biosamples = ({ individual, handleBiosampleClick, handleExperimentClick })
             {
                 title: "Sampled Tissue",
                 dataIndex: "sampled_tissue",
-                render: tissue => <OntologyTerm individual={individual} term={tissue} />,
+                render: tissue => <OntologyTerm resourcesTuple={resourcesTuple} term={tissue} />,
             },
             {
                 title: "Experiments",
@@ -146,7 +149,7 @@ const Biosamples = ({ individual, handleBiosampleClick, handleExperimentClick })
                 ),
             },
         ],
-        [individual, handleExperimentClick],
+        [resourcesTuple, handleExperimentClick],
     );
 
     const onExpand = useCallback(

--- a/src/components/explorer/IndividualDiseases.js
+++ b/src/components/explorer/IndividualDiseases.js
@@ -4,7 +4,7 @@ import { Table } from "antd";
 
 import { individualPropTypesShape } from "../../propTypes";
 import { EM_DASH } from "../../constants";
-import { ontologyTermSorter } from "./utils";
+import { ontologyTermSorter, useIndividualResources } from "./utils";
 
 import OntologyTerm from "./OntologyTerm";
 
@@ -13,6 +13,7 @@ import OntologyTerm from "./OntologyTerm";
 
 const IndividualDiseases = ({ individual }) => {
     const diseases = individual.phenopackets.flatMap(p => p.diseases);
+    const resourcesTuple = useIndividualResources(individual);
 
     const columns = useMemo(() => [
         {
@@ -24,7 +25,7 @@ const IndividualDiseases = ({ individual }) => {
         {
             title: "term",
             dataIndex: "term",
-            render: (term) => <OntologyTerm individual={individual} term={term} />,
+            render: (term) => <OntologyTerm resourcesTuple={resourcesTuple} term={term} />,
             sorter: ontologyTermSorter("term"),
         },
         {
@@ -41,21 +42,21 @@ const IndividualDiseases = ({ individual }) => {
                             ? <div>{disease.onset.start.age} - {disease.onset.end.age}</div>
                             // Onset age label only
                             : disease.onset.label
-                                ? <OntologyTerm individual={individual} term={disease.onset} />
+                                ? <OntologyTerm resourcesTuple={resourcesTuple} term={disease.onset} />
                                 : EM_DASH
                     : EM_DASH,
         },
         {
             title: "Extra Properties",
             key: "extra_properties",
-            render: (_, individual) =>
-                (Object.keys(individual.extra_properties ?? {}).length)
+            render: (_, disease) =>
+                (Object.keys(disease.extra_properties ?? {}).length)
                     ? <div>
-                        <pre>{JSON.stringify(individual.extra_properties, null, 2)}</pre>
+                        <pre>{JSON.stringify(disease.extra_properties, null, 2)}</pre>
                     </div>
                     : EM_DASH,
         },
-    ], [individual]);
+    ], [resourcesTuple]);
 
     return (
         <Table

--- a/src/components/explorer/IndividualExperiments.js
+++ b/src/components/explorer/IndividualExperiments.js
@@ -10,7 +10,7 @@ import { experimentPropTypesShape, experimentResultPropTypesShape, individualPro
 import { getFileDownloadUrlsFromDrs } from "../../modules/drs/actions";
 import { guessFileType } from "../../utils/guessFileType";
 
-import { useDeduplicatedIndividualBiosamples } from "./utils";
+import { useDeduplicatedIndividualBiosamples, useIndividualResources } from "./utils";
 
 import JsonView from "./JsonView";
 import OntologyTerm from "./OntologyTerm";
@@ -104,7 +104,7 @@ const EXPERIMENT_RESULTS_COLUMNS = [
     },
 ];
 
-const ExperimentDetail = ({ individual, experiment }) => {
+const ExperimentDetail = ({ experiment, resourcesTuple }) => {
     const {
         id,
         experiment_type: experimentType,
@@ -140,7 +140,10 @@ const ExperimentDetail = ({ individual, experiment }) => {
                     experiment_ontology is accidentally an array in Katsu, so this takes the first item
                     and falls back to just the field (if we fix this in the future)
                     */}
-                    <OntologyTerm individual={individual} term={experimentOntology?.[0] ?? experimentOntology} />
+                    <OntologyTerm
+                        resourcesTuple={resourcesTuple}
+                        term={experimentOntology?.[0] ?? experimentOntology}
+                    />
                 </Descriptions.Item>
                 <Descriptions.Item span={1} label="Molecule">
                     {molecule}
@@ -150,7 +153,7 @@ const ExperimentDetail = ({ individual, experiment }) => {
                     molecule_ontology is accidentally an array in Katsu, so this takes the first item
                     and falls back to just the field (if we fix this in the future)
                     */}
-                    <OntologyTerm individual={individual} term={moleculeOntology?.[0] ?? moleculeOntology} />
+                    <OntologyTerm resourcesTuple={resourcesTuple} term={moleculeOntology?.[0] ?? moleculeOntology} />
                 </Descriptions.Item>
                 <Descriptions.Item label="Study Type">{studyType}</Descriptions.Item>
                 <Descriptions.Item label="Extraction Protocol">{extractionProtocol}</Descriptions.Item>
@@ -187,8 +190,8 @@ const ExperimentDetail = ({ individual, experiment }) => {
     );
 };
 ExperimentDetail.propTypes = {
-    individual: individualPropTypesShape,
     experiment: experimentPropTypesShape,
+    resourcesTuple: PropTypes.array,
 };
 
 const Experiments = ({ individual, handleExperimentClick }) => {
@@ -218,6 +221,7 @@ const Experiments = ({ individual, handleExperimentClick }) => {
         () => biosamplesData.flatMap((b) => b?.experiments ?? []),
         [biosamplesData],
     );
+    const resourcesTuple = useIndividualResources(individual);
 
     useEffect(() => {
         // retrieve any download urls if experiments data changes
@@ -243,7 +247,7 @@ const Experiments = ({ individual, handleExperimentClick }) => {
             {
                 title: "Molecule",
                 dataIndex: "molecule_ontology",
-                render: (mo) => <OntologyTerm individual={individual} term={mo?.[0] ?? mo} />,
+                render: (mo) => <OntologyTerm resourcesTuple={resourcesTuple} term={mo?.[0] ?? mo} />,
             },
             {
                 title: "Experiment Results",
@@ -251,7 +255,7 @@ const Experiments = ({ individual, handleExperimentClick }) => {
                 render: (exp) => <span>{exp.experiment_results.length ?? 0} files</span>,
             },
         ],
-        [individual, handleExperimentClick],
+        [resourcesTuple, handleExperimentClick],
     );
 
     const onExpand = useCallback(
@@ -263,12 +267,9 @@ const Experiments = ({ individual, handleExperimentClick }) => {
 
     const expandedRowRender = useCallback(
         (experiment) => (
-            <ExperimentDetail
-                individual={individual}
-                experiment={experiment}
-            />
+            <ExperimentDetail experiment={experiment} resourcesTuple={resourcesTuple} />
         ),
-        [handleExperimentClick],
+        [resourcesTuple],
     );
 
     return (

--- a/src/components/explorer/IndividualOntologies.js
+++ b/src/components/explorer/IndividualOntologies.js
@@ -1,9 +1,9 @@
 import React from "react";
 
-import {Table} from "antd";
+import { Table } from "antd";
 
-import {individualPropTypesShape} from "../../propTypes";
-import {useResources} from "./utils";
+import { individualPropTypesShape } from "../../propTypes";
+import { useIndividualResources } from "./utils";
 
 
 // TODO: Only show diseases from the relevant dataset, if specified;
@@ -49,7 +49,7 @@ const METADATA_COLUMNS = [
 ];
 
 const IndividualOntologies = ({individual}) => {
-    const resources = useResources(individual);
+    const [resources, isFetching] = useIndividualResources(individual);
 
     return (
         <Table
@@ -59,6 +59,7 @@ const IndividualOntologies = ({individual}) => {
             columns={METADATA_COLUMNS}
             rowKey="id"
             dataSource={resources}
+            loading={isFetching}
         />
     );
 };

--- a/src/components/explorer/IndividualOntologies.js
+++ b/src/components/explorer/IndividualOntologies.js
@@ -48,7 +48,7 @@ const METADATA_COLUMNS = [
     },
 ];
 
-const IndividualMetadata = ({individual}) => {
+const IndividualOntologies = ({individual}) => {
     const resources = useResources(individual);
 
     return (
@@ -63,8 +63,8 @@ const IndividualMetadata = ({individual}) => {
     );
 };
 
-IndividualMetadata.propTypes = {
+IndividualOntologies.propTypes = {
     individual: individualPropTypesShape,
 };
 
-export default IndividualMetadata;
+export default IndividualOntologies;

--- a/src/components/explorer/IndividualOverview.js
+++ b/src/components/explorer/IndividualOverview.js
@@ -5,25 +5,30 @@ import { Descriptions } from "antd";
 
 import { EM_DASH } from "../../constants";
 import { individualPropTypesShape } from "../../propTypes";
+import { useIndividualResources } from "./utils";
 import OntologyTerm from "./OntologyTerm";
 
-const IndividualOverview = ({individual}) => individual ?
-    <Descriptions layout="vertical" bordered={true} size="middle">
-        <Descriptions.Item label="Date of Birth">{individual.date_of_birth || EM_DASH}</Descriptions.Item>
-        <Descriptions.Item label="Sex">{individual.sex || "UNKNOWN_SEX"}</Descriptions.Item>
-        <Descriptions.Item label="Age">{getAge(individual)}</Descriptions.Item>
-        <Descriptions.Item label="Ethnicity">{individual.ethnicity || "UNKNOWN_ETHNICITY"}</Descriptions.Item>
-        <Descriptions.Item label="Karyotypic Sex">{individual.karyotypic_sex || "UNKNOWN_KARYOTYPE"}</Descriptions.Item>
-        <Descriptions.Item label="Taxonomy">
-            <OntologyTerm
-                individual={individual}
-                term={individual.taxonomy}
-                renderLabel={label => (<em>{label}</em>)}
-            />
-        </Descriptions.Item>
-        <Descriptions.Item label="Extra Properties">{
-            (individual.hasOwnProperty("extra_properties") && Object.keys(individual.extra_properties).length)
-                ?  <div>
+const IndividualOverview = ({individual}) => {
+    const resourcesTuple = useIndividualResources(individual);
+
+    if (!individual) return <div />;
+    return (
+        <Descriptions layout="vertical" bordered={true} size="middle">
+            <Descriptions.Item label="Date of Birth">{individual.date_of_birth || EM_DASH}</Descriptions.Item>
+            <Descriptions.Item label="Sex">{individual.sex || "UNKNOWN_SEX"}</Descriptions.Item>
+            <Descriptions.Item label="Age">{getAge(individual)}</Descriptions.Item>
+            <Descriptions.Item label="Ethnicity">{individual.ethnicity || "UNKNOWN_ETHNICITY"}</Descriptions.Item>
+            <Descriptions.Item label="Karyotypic Sex">{individual.karyotypic_sex || "UNKNOWN_KARYOTYPE"}</Descriptions.Item>
+            <Descriptions.Item label="Taxonomy">
+                <OntologyTerm
+                    resourcesTuple={resourcesTuple}
+                    term={individual.taxonomy}
+                    renderLabel={label => (<em>{label}</em>)}
+                />
+            </Descriptions.Item>
+            <Descriptions.Item label="Extra Properties">{
+                (individual.hasOwnProperty("extra_properties") && Object.keys(individual.extra_properties).length)
+                    ?  <div>
                     <pre>
                           <ReactJson src={individual.extra_properties}
                                      displayDataTypes={false}
@@ -32,10 +37,12 @@ const IndividualOverview = ({individual}) => individual ?
                                      enableClipboard={false}
                           />
                     </pre>
-                   </div>
-                : EM_DASH
-        }</Descriptions.Item>
-    </Descriptions> : <div />;
+                    </div>
+                    : EM_DASH
+            }</Descriptions.Item>
+        </Descriptions>
+    );
+}
 
 IndividualOverview.propTypes = {
     individual: individualPropTypesShape,

--- a/src/components/explorer/IndividualOverview.js
+++ b/src/components/explorer/IndividualOverview.js
@@ -18,7 +18,9 @@ const IndividualOverview = ({individual}) => {
             <Descriptions.Item label="Sex">{individual.sex || "UNKNOWN_SEX"}</Descriptions.Item>
             <Descriptions.Item label="Age">{getAge(individual)}</Descriptions.Item>
             <Descriptions.Item label="Ethnicity">{individual.ethnicity || "UNKNOWN_ETHNICITY"}</Descriptions.Item>
-            <Descriptions.Item label="Karyotypic Sex">{individual.karyotypic_sex || "UNKNOWN_KARYOTYPE"}</Descriptions.Item>
+            <Descriptions.Item label="Karyotypic Sex">{
+                individual.karyotypic_sex || "UNKNOWN_KARYOTYPE"}
+            </Descriptions.Item>
             <Descriptions.Item label="Taxonomy">
                 <OntologyTerm
                     resourcesTuple={resourcesTuple}
@@ -42,7 +44,7 @@ const IndividualOverview = ({individual}) => {
             }</Descriptions.Item>
         </Descriptions>
     );
-}
+};
 
 IndividualOverview.propTypes = {
     individual: individualPropTypesShape,

--- a/src/components/explorer/IndividualPhenotypicFeatures.js
+++ b/src/components/explorer/IndividualPhenotypicFeatures.js
@@ -5,8 +5,11 @@ import { Icon, Table } from "antd";
 import { EM_DASH } from "../../constants";
 import { individualPropTypesShape } from "../../propTypes";
 import OntologyTerm from "./OntologyTerm";
+import { useIndividualResources } from "./utils";
 
 const IndividualPhenotypicFeatures = ({ individual }) => {
+    const resourcesTuple = useIndividualResources(individual);
+
     const columns = useMemo(() => [
         {
             title: "Feature",
@@ -20,7 +23,7 @@ const IndividualPhenotypicFeatures = ({ individual }) => {
                         </span>
                     </h4>
                 ) : <>
-                    <OntologyTerm individual={individual} term={type} />{" "}
+                    <OntologyTerm resourcesTuple={resourcesTuple} term={type} />{" "}
                     {negated ? (
                         <span style={{ color: "#CC3333" }}>
                             (<span style={{ fontWeight: "bold" }}>Excluded:</span>{" "}
@@ -63,7 +66,7 @@ const IndividualPhenotypicFeatures = ({ individual }) => {
             },
         },
 
-    ], [individual]);
+    ], [resourcesTuple]);
 
     const data = useMemo(() => {
         const phenopackets = (individual?.phenopackets ?? []);

--- a/src/components/explorer/OntologyTerm.js
+++ b/src/components/explorer/OntologyTerm.js
@@ -1,17 +1,17 @@
 import React, { memo, useEffect } from "react";
 import PropTypes from "prop-types";
 
-import { Icon } from "antd";
+import { Button, Icon } from "antd";
 
 import { EM_DASH } from "../../constants";
-import { individualPropTypesShape, ontologyShape } from "../../propTypes";
+import { ontologyShape } from "../../propTypes";
 import { id } from "../../utils/misc";
 
 import { useResourcesByNamespacePrefix } from "./utils";
 
-const OntologyTerm = memo(({ individual, term, renderLabel }) => {
+const OntologyTerm = memo(({ resourcesTuple, term, renderLabel }) => {
     // TODO: perf: might be slow to generate this over and over
-    const resourcesByNamespacePrefix = useResourcesByNamespacePrefix(individual);
+    const [resourcesByNamespacePrefix, isFetchingResources] = useResourcesByNamespacePrefix(resourcesTuple);
 
     if (!term) {
         return (
@@ -43,22 +43,30 @@ const OntologyTerm = memo(({ individual, term, renderLabel }) => {
         if (termResource?.iri_prefix && !termResource.iri_prefix.includes("example.org")) {
             defLink = `${termResource.iri_prefix}${namespaceID}`;
         }  // If resource doesn't exist / isn't linkable, don't include a link
-    }  // Otherwise, malformed ID - render without a link
+    }  // Otherwise, malformed ID - render a disabled link
 
     return (
         <span>
             {renderLabel(term.label)} (ID: {term.id}){" "}
-            {defLink && (
-                <a href={defLink} target="_blank" rel="noopener noreferrer">
+            <span style={{cursor: (!defLink) ? (isFetchingResources ? "wait" : "not-allowed") : "pointer"}}>
+                <Button
+                    type="link"
+                    size="small"
+                    disabled={!defLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={defLink ?? "#"}
+                    style={{ padding: 0 }}
+                >
                     <Icon type="link" />
-                </a>
-            )}
+                </Button>
+            </span>
         </span>
     );
 });
 
 OntologyTerm.propTypes = {
-    individual: individualPropTypesShape,
+    resourcesTuple: PropTypes.array,
     term: ontologyShape.isRequired,
     renderLabel: PropTypes.func,
 };

--- a/src/components/explorer/explorer.css
+++ b/src/components/explorer/explorer.css
@@ -1,11 +1,3 @@
-/* css snippet to help align the antd spinner in the parent row */
-.ant-spin-nested-loading,
-.ant-spin-nested-loading > div:first-child,
-.ant-spin-spinning,
-.ant-spin-container {
-  display: inline !important;
-}
-
 .ant-table-row.ant-table-row-level-0 {
   vertical-align: top !important;
 }

--- a/src/components/explorer/explorer.css
+++ b/src/components/explorer/explorer.css
@@ -19,8 +19,9 @@
 
 /* Variants tab */
 
-.variantDescriptions .ant-descriptions-item-label{
+.variantDescriptions .ant-descriptions-item-label {
   vertical-align: top;
+  width: 200px;
 }
 
 /* Biosamples and Experiments tabs */

--- a/src/components/explorer/searchResultsTables/BiosamplesTable.js
+++ b/src/components/explorer/searchResultsTables/BiosamplesTable.js
@@ -108,7 +108,9 @@ const BiosamplesTable = ({ data, datasetID }) => {
         {
             title: "Biosample",
             dataIndex: "biosample",
-            render: (biosample, { individual }) => <BiosampleIDCell biosample={biosample} individualId={individual.id} />,
+            render: (biosample, { individual }) => (
+                <BiosampleIDCell biosample={biosample} individualId={individual.id} />
+            ),
             sorter: (a, b) => a.biosample.localeCompare(b.biosample),
             defaultSortOrder: "ascend",
         },

--- a/src/components/explorer/searchResultsTables/BiosamplesTable.js
+++ b/src/components/explorer/searchResultsTables/BiosamplesTable.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useMemo} from "react";
 import PropTypes from "prop-types";
 import { useSortedColumns } from "../hooks/explorerHooks";
 import { useSelector } from "react-redux";
@@ -10,7 +10,7 @@ import OntologyTerm from "../OntologyTerm";
 
 import { ontologyShape } from "../../../propTypes";
 import { countNonNullElements } from "../../../utils/misc";
-import { ontologyTermSorter } from "../utils";
+import { ontologyTermSorter, useDatasetResources } from "../utils";
 
 const NO_EXPERIMENTS_VALUE = -Infinity;
 
@@ -97,59 +97,60 @@ const availableExperimentsSorter = (a, b) => {
     return highB - highA;
 };
 
-const SEARCH_RESULT_COLUMNS_BIOSAMPLE = [
-    {
-        title: "Biosample",
-        dataIndex: "biosample",
-        render: (biosample, { individual }) => <BiosampleIDCell biosample={biosample} individualId={individual.id} />,
-        sorter: (a, b) => a.biosample.localeCompare(b.biosample),
-        defaultSortOrder: "ascend",
-    },
-    {
-        title: "Individual",
-        dataIndex: "individual",
-        render: (individual) => <IndividualIDCell individual={individual} />,
-        sorter: (a, b) => a.individual.id.localeCompare(b.individual.id),
-        sortDirections: ["descend", "ascend", "descend"],
-    },
-    {
-        title: "Experiments",
-        dataIndex: "studyTypes",
-        render: (studyTypes) => <ExperimentsRender studiesType={studyTypes} />,
-        sorter: experimentsSorter,
-        sortDirections: ["descend", "ascend", "descend"],
-    },
-    {
-        title: "Sampled Tissue",
-        dataIndex: "sampledTissue",
-        // Can't pass individual here to OntologyTerm since it doesn't have a list of phenopackets
-        render: (sampledTissue) => <OntologyTerm term={sampledTissue} />,
-        sorter: ontologyTermSorter("sampledTissue"),
-        sortDirections: ["descend", "ascend", "descend"],
-    },
-    {
-        title: "Available Experiments",
-        dataIndex: "experimentTypes",
-        render: availableExperimentsRender,
-        sorter: availableExperimentsSorter,
-        sortDirections: ["descend", "ascend", "descend"],
-    },
-];
-
 const BiosamplesTable = ({ data, datasetID }) => {
+    const resourcesTuple = useDatasetResources(datasetID);
+
     const tableSortOrder = useSelector(
         (state) => state.explorer.tableSortOrderByDatasetID[datasetID]?.["biosamples"],
     );
 
+    const columns = useMemo(() => [
+        {
+            title: "Biosample",
+            dataIndex: "biosample",
+            render: (biosample, { individual }) => <BiosampleIDCell biosample={biosample} individualId={individual.id} />,
+            sorter: (a, b) => a.biosample.localeCompare(b.biosample),
+            defaultSortOrder: "ascend",
+        },
+        {
+            title: "Individual",
+            dataIndex: "individual",
+            render: (individual) => <IndividualIDCell individual={individual} />,
+            sorter: (a, b) => a.individual.id.localeCompare(b.individual.id),
+            sortDirections: ["descend", "ascend", "descend"],
+        },
+        {
+            title: "Experiments",
+            dataIndex: "studyTypes",
+            render: (studyTypes) => <ExperimentsRender studiesType={studyTypes} />,
+            sorter: experimentsSorter,
+            sortDirections: ["descend", "ascend", "descend"],
+        },
+        {
+            title: "Sampled Tissue",
+            dataIndex: "sampledTissue",
+            // Can't pass individual here to OntologyTerm since it doesn't have a list of phenopackets
+            render: (sampledTissue) => <OntologyTerm resourcesTuple={resourcesTuple} term={sampledTissue} />,
+            sorter: ontologyTermSorter("sampledTissue"),
+            sortDirections: ["descend", "ascend", "descend"],
+        },
+        {
+            title: "Available Experiments",
+            dataIndex: "experimentTypes",
+            render: availableExperimentsRender,
+            sorter: availableExperimentsSorter,
+            sortDirections: ["descend", "ascend", "descend"],
+        },
+    ], [resourcesTuple]);
+
     const { sortedData, columnsWithSortOrder } = useSortedColumns(
         data,
         tableSortOrder,
-        SEARCH_RESULT_COLUMNS_BIOSAMPLE,
+        columns,
     );
 
     return (
         <ExplorerSearchResultsTable
-            dataStructure={SEARCH_RESULT_COLUMNS_BIOSAMPLE}
             data={sortedData}
             sortColumnKey={tableSortOrder?.sortColumnKey}
             sortOrder={tableSortOrder?.sortOrder}

--- a/src/components/explorer/utils.js
+++ b/src/components/explorer/utils.js
@@ -22,7 +22,7 @@ export const useDatasetResources = (datasetIDOrDatasetIDs) => {
 
     const datasetIDs = useMemo(
         () => Array.isArray(datasetIDOrDatasetIDs) ? datasetIDOrDatasetIDs : [datasetIDOrDatasetIDs],
-    [datasetIDOrDatasetIDs],
+        [datasetIDOrDatasetIDs],
     );
 
     useEffect(() => {

--- a/src/components/explorer/utils.js
+++ b/src/components/explorer/utils.js
@@ -1,4 +1,6 @@
-import {useMemo} from "react";
+import { useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchDatasetResourcesIfNecessary } from "../../modules/datasets/actions";
 
 export const useDeduplicatedIndividualBiosamples = (individual) =>
     useMemo(
@@ -13,18 +15,32 @@ export const useDeduplicatedIndividualBiosamples = (individual) =>
     );
 
 
-export const useResources = (individual) =>
-    useMemo(
+export const useResources = (individual) => {
+    const dispatch = useDispatch();
+
+    // TODO: when individual belongs to a single dataset, use that instead
+    const individualDatasets = useMemo(
+        () => (individual?.phenopackets ?? []).map(p => p.dataset),
+        [individual]);
+
+    const datasetResources = useSelector((state) => state.datasetResources.itemsByID);
+
+    useEffect(() => {
+        individualDatasets.map((d) => dispatch(fetchDatasetResourcesIfNecessary(d)));
+    }, [dispatch, individualDatasets]);
+
+    return useMemo(
         () =>
             Object.values(
                 Object.fromEntries(
-                    (individual?.phenopackets ?? [])
-                        .flatMap(p => p.meta_data.resources ?? [])
+                    individualDatasets
+                        .flatMap(d => datasetResources[d]?.data ?? [])
                         .map(r => [r.id, r]),
                 ),
             ),
-        [individual],
+        [datasetResources, individualDatasets],
     );
+};
 
 
 export const useResourcesByNamespacePrefix = (individual) => {

--- a/src/modules/datasets/actions.js
+++ b/src/modules/datasets/actions.js
@@ -53,6 +53,7 @@ const fetchDatasetResources = networkAction((datasetID) => (dispatch, getState) 
     err: "Error fetching dataset resources",
 }));
 export const fetchDatasetResourcesIfNecessary = (datasetID) => (dispatch, getState) => {
-    if (getState().datasetResources.itemsByID[datasetID]?.isFetching) return;
+    const datasetResources = getState().datasetResources.itemsByID[datasetID];
+    if (datasetResources?.isFetching || datasetResources?.data) return;
     return dispatch(fetchDatasetResources(datasetID));
 };


### PR DESCRIPTION
This will link more resources, since before any additional resources on
the dataset were ignored. This now also means biosample ontology
terms in the search results table are linked up. Failed links are now shown
as a disabled link icon with an error-state cursor.