### PR TITLE
Fix dataset data-types summaries

### DIFF
--- a/src/modules/datasets/reducers.js
+++ b/src/modules/datasets/reducers.js
@@ -67,16 +67,12 @@ export const datasetDataTypes = (
 
 
 const datasetItemSet = (oldState, datasetID, key, value) => {
-    let newValue;
-    if ("boolean" === typeof value) {
-        // no need to spread a boolean
-        newValue = value;
-    } else {
-        newValue = {
-            ...(oldState.itemsByID[datasetID]?.[key] ?? {}),
-            ...value,
-        };
-    }
+    // If value is an object, spread with key's oldState
+    // Else, set key with value as is (boolean | string | undefined)
+    const newValue = "object" === typeof value ? {
+        ...(oldState.itemsByID[datasetID]?.[key] ?? {}),
+        ...value,
+    } : value;
     const newState = {
         ...oldState,
         itemsByID: {

--- a/src/modules/datasets/reducers.js
+++ b/src/modules/datasets/reducers.js
@@ -66,16 +66,29 @@ export const datasetDataTypes = (
 };
 
 
-const datasetItemSet = (oldState, datasetID, key, value) => ({
-    ...oldState,
-    itemsByID: {
-        ...oldState.itemsByID,
-        [datasetID]: {
-            ...(oldState.itemsByID[datasetID] ?? {}),
-            [key]: value,
+const datasetItemSet = (oldState, datasetID, key, value) => {
+    let newValue;
+    if ("boolean" === typeof value) {
+        // no need to spread a boolean
+        newValue = value;
+    } else {
+        newValue = {
+            ...(oldState.itemsByID[datasetID]?.[key] ?? {}),
+            ...value,
+        };
+    }
+    const newState = {
+        ...oldState,
+        itemsByID: {
+            ...oldState.itemsByID,
+            [datasetID]: {
+                ...(oldState.itemsByID[datasetID] ?? {}),
+                [key]: newValue,
+            },
         },
-    },
-});
+    };
+    return newState;
+};
 
 
 export const datasetSummaries = (


### PR DESCRIPTION
**Issue:** The `datasetSummaries` state was not updated properly, causing new state keys to erase old ones when it shouldn't. Katsu summaries would first be saved correctly, then the gohan summaries would erase the old state since it was not spread.

**Fix:** spread the new value with the oldstate if its an object.

