### PR TITLE
fix biosample procedure props and rendering

### DIFF
--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -1,4 +1,4 @@
-import React, {Fragment, useCallback, useEffect, useMemo} from "react";
+import React, { Fragment, useCallback, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import { Route, Switch, useHistory, useRouteMatch, useParams } from "react-router-dom";
 
@@ -24,29 +24,36 @@ import { MeasurementsTable } from "./IndividualMeasurements";
 // TODO: Only show biosamples from the relevant dataset, if specified;
 //  highlight those found in search results, if specified
 
-const BiosampleProcedure = ({ procedure }) => (
-    <div>
-        <strong>Code:</strong>{" "}<OntologyTerm term={procedure.code} />
-        {procedure.body_site ? (
-            <div>
-                <strong>Body Site:</strong>{" "}
-                <OntologyTerm term={procedure.body_site} />
-            </div>
-        ) : null}
-        {procedure.performed ? (
-            <div>
-                <strong>Performed:</strong>{" "}
-                <TimeElement timeElement={procedure.performed} />
-            </div>
-        ) : null}
-    </div>
-);
+const BiosampleProcedure = ({ procedure }) => {
+    if (!procedure || !procedure.code) {
+        return EM_DASH;
+    }
+
+    return (
+        <div>
+            <strong>Code:</strong>{" "}<OntologyTerm term={procedure.code} />
+            {procedure.body_site ? (
+                <div>
+                    <strong>Body Site:</strong>{" "}
+                    <OntologyTerm term={procedure.body_site} />
+                </div>
+            ) : null}
+            {procedure.performed ? (
+                <div>
+                    <strong>Performed:</strong>{" "}
+                    <TimeElement timeElement={procedure.performed} />
+                </div>
+            ) : null}
+        </div>
+    );
+}
+    ;
 BiosampleProcedure.propTypes = {
     procedure: PropTypes.shape({
         code: ontologyShape.isRequired,
         body_site: ontologyShape,
         performed: PropTypes.object,
-    }).isRequired,
+    }),
 };
 
 const ExperimentsClickList = ({ experiments, handleExperimentClick }) => {
@@ -208,7 +215,7 @@ Biosamples.propTypes = {
     handleExperimentClick: PropTypes.func,
 };
 
-const IndividualBiosamples = ({individual, experimentsUrl}) => {
+const IndividualBiosamples = ({ individual, experimentsUrl }) => {
     const history = useHistory();
     const match = useRouteMatch();
 

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -25,7 +25,7 @@ import { MeasurementsTable } from "./IndividualMeasurements";
 //  highlight those found in search results, if specified
 
 const BiosampleProcedure = ({ procedure }) => {
-    if (!procedure || !procedure.code) {
+    if (!procedure) {
         return EM_DASH;
     }
 

--- a/src/components/explorer/IndividualBiosamples.js
+++ b/src/components/explorer/IndividualBiosamples.js
@@ -46,8 +46,7 @@ const BiosampleProcedure = ({ procedure }) => {
             ) : null}
         </div>
     );
-}
-    ;
+};
 BiosampleProcedure.propTypes = {
     procedure: PropTypes.shape({
         code: ontologyShape.isRequired,

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -176,7 +176,7 @@ export const biosamplePropTypesShape = PropTypes.shape({
         body_site: ontologyShape,
         created: PropTypes.string,  // ISO datetime string
         updated: PropTypes.string,  // ISO datetime string
-    }).isRequired,
+    }),
     description: PropTypes.string,
     sampled_tissue: ontologyShape.isRequired,
     individual_age_at_collection: PropTypes.oneOfType([agePropTypesShape, ageRangePropTypesShape]),


### PR DESCRIPTION
- Prop Type for `biosample.procedure` was mistakenly mandatory, now optional.
- BiosampleProcedure now returns an em dash if the `procedure` prop or its `code` is falsy