### PR TITLE
feat: provide link to biosample from genomic interpretations if applicable

### DIFF
--- a/src/components/explorer/IndividualInterpretations.js
+++ b/src/components/explorer/IndividualInterpretations.js
@@ -50,7 +50,7 @@ VariantInterpretation.propTypes = {
 };
 
 export const GenomicInterpretationDetails = ({ genomicInterpretation }) => {
-    const relatedType = genomicInterpretation?.extra_properties?.related_type ?? "unknown";
+    const relatedType = genomicInterpretation?.extra_properties?.__related_type ?? "unknown";
     const relatedLabel = relatedType[0].toUpperCase() + relatedType.slice(1).toLowerCase();
     const isBiosampleRelated = relatedType === "biosample";
 

--- a/src/components/explorer/IndividualInterpretations.js
+++ b/src/components/explorer/IndividualInterpretations.js
@@ -10,6 +10,7 @@ import OntologyTerm from "./OntologyTerm";
 import { Route, Switch, useHistory, useParams, useRouteMatch } from "react-router-dom/cjs/react-router-dom.min";
 import { GeneDescriptor } from "./IndividualGenes";
 import VariantDescriptor from "./IndividualVariants";
+import BiosampleIDCell from "./searchResultsTables/BiosampleIDCell";
 
 
 export const VariantInterpretation = ({ variationInterpretation }) => {
@@ -51,6 +52,7 @@ VariantInterpretation.propTypes = {
 export const GenomicInterpretationDetails = ({ genomicInterpretation }) => {
     const relatedType = genomicInterpretation?.extra_properties?.related_type ?? "unknown";
     const relatedLabel = relatedType[0].toUpperCase() + relatedType.slice(1).toLowerCase();
+    const isBiosampleRelated = relatedType === "biosample";
 
     const variantInterpretation = genomicInterpretation?.variant_interpretation;
     const geneDescriptor = genomicInterpretation?.gene_descriptor;
@@ -58,7 +60,10 @@ export const GenomicInterpretationDetails = ({ genomicInterpretation }) => {
     return (
         <Descriptions layout="horizontal" bordered={true} column={1} size="small">
             <Descriptions.Item label={`${relatedLabel} ID`}>
-                {genomicInterpretation.subject_or_biosample_id}
+                { isBiosampleRelated
+                    ? <BiosampleIDCell biosample={genomicInterpretation.subject_or_biosample_id}/>
+                    : genomicInterpretation.subject_or_biosample_id
+                }
             </Descriptions.Item>
             {variantInterpretation && <Descriptions.Item label={"Variant Interpretation"}>
                 <VariantInterpretation variationInterpretation={variantInterpretation} />


### PR DESCRIPTION
- If a `GenomicInterpretation` has a `subject_or_biosample_id` that is related to a biosample, we provide a link to the biosample
- Otherwise, if `subject_or_biosample_id` is related to a subject, we display the ID in plain text, since we are already on the individual's explorer page