### PR TITLE
fix datasetResources reducer

### DIFF
--- a/src/components/explorer/utils.js
+++ b/src/components/explorer/utils.js
@@ -100,7 +100,7 @@ export const useDatasetResources = (datasetIDOrDatasetIDs) => {
             const r = Object.values(
                 Object.fromEntries(
                     datasetIDs
-                        .flatMap(d => datasetResources[d]?.data ?? [])
+                        .flatMap(d => Object.values(datasetResources[d]?.data ?? []))
                         .map(r => [r.id, r]),
                 ),
             );

--- a/src/components/explorer/utils.js
+++ b/src/components/explorer/utils.js
@@ -100,7 +100,7 @@ export const useDatasetResources = (datasetIDOrDatasetIDs) => {
             const r = Object.values(
                 Object.fromEntries(
                     datasetIDs
-                        .flatMap(d => Object.values(datasetResources[d]?.data ?? []))
+                        .flatMap(d => datasetResources[d]?.data ?? [])
                         .map(r => [r.id, r]),
                 ),
             );

--- a/src/modules/datasets/reducers.js
+++ b/src/modules/datasets/reducers.js
@@ -68,8 +68,8 @@ export const datasetDataTypes = (
 
 const datasetItemSet = (oldState, datasetID, key, value) => {
     // If value is an object, spread with key's oldState
-    // Else, set key with value as is (boolean | string | undefined)
-    const newValue = "object" === typeof value ? {
+    // Else, set key with value as is (array | boolean | string | undefined)
+    const newValue = "object" === typeof value && !Array.isArray(value) ? {
         ...(oldState.itemsByID[datasetID]?.[key] ?? {}),
         ...value,
     } : value;


### PR DESCRIPTION
**Issue:** the `datasetResources` reducer did not properly handle array values, causing them to be spread in an object instead of an array in the state.