### PR TITLE
Features/handle fastapi errors

### DIFF
--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -139,7 +139,6 @@ const formatErrorMessage = (errorMessageIntro, errorDetail) => {
         : errorDetail;
 };
 
-
 export const beginFlow = (types) => async (dispatch) => await dispatch({ type: types.BEGIN });
 export const endFlow = (types) => async (dispatch) => await dispatch({ type: types.END });
 export const terminateFlow = (types) => async (dispatch) => await dispatch({ type: types.TERMINATE });

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -126,16 +126,16 @@ const handleNetworkErrorMessaging = (e, reduxErrDetail) => {
     if (e.cause && e.cause.length) {
         const errorDetails = e.cause.map((c) => c.message ?? "");
         errorDetails.forEach((ed) => {
-            message.error(formatErrorMessage(reduxErrDetail, ed))
+            message.error(formatErrorMessage(reduxErrDetail, ed));
         });
     } else {
-        message.error(formatErrorMessage(reduxErrDetail, e.message))
+        message.error(formatErrorMessage(reduxErrDetail, e.message));
     }
 };
 
 const formatErrorMessage = (errorMessageIntro, errorDetail) => {
-    return errorMessageIntro 
-        ? errorMessageIntro + (errorDetail ? `: ${errorDetail}` : "") 
+    return errorMessageIntro
+        ? errorMessageIntro + (errorDetail ? `: ${errorDetail}` : "")
         : errorDetail;
 };
 

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -125,7 +125,7 @@ const handleNetworkErrorMessaging = (e, reduxErrDetail) => {
 
     // prefer any cause messages to the top-level "message" string
     if (e.cause) {
-        const errorDetails = e.causes.map((c) => c.message ?? "");
+        const errorDetails = e.cause.map((c) => c.message ?? "");
         errorDetails.forEach((ed) => {
             message.error(errorMessageIntro + " " + ed);
         });

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -124,7 +124,7 @@ const handleNetworkErrorMessaging = (e, reduxErrDetail) => {
     const errorMessageIntro = reduxErrDetail ? reduxErrDetail : "";
 
     // prefer any cause messages to the top-level "message" string
-    if (e.cause) {
+    if (e.cause && e.cause.length) {
         const errorDetails = e.cause.map((c) => c.message ?? "");
         errorDetails.forEach((ed) => {
             message.error(errorMessageIntro + " " + ed);

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -121,18 +121,22 @@ export const networkAction =
 
 const handleNetworkErrorMessaging = (e, reduxErrDetail) => {
     console.error(e, reduxErrDetail);
-    const errorMessageIntro = reduxErrDetail ? reduxErrDetail : "";
 
     // prefer any cause messages to the top-level "message" string
     if (e.cause && e.cause.length) {
         const errorDetails = e.cause.map((c) => c.message ?? "");
         errorDetails.forEach((ed) => {
-            message.error(errorMessageIntro + " " + ed);
+            message.error(formatErrorMessage(reduxErrDetail, ed))
         });
     } else {
-        const errorDetail = e.message ?? "";
-        message.error(errorMessageIntro + " " + errorDetail);
+        message.error(formatErrorMessage(reduxErrDetail, e.message))
     }
+};
+
+const formatErrorMessage = (errorMessageIntro, errorDetail) => {
+    return errorMessageIntro 
+        ? errorMessageIntro + (errorDetail ? `: ${errorDetail}` : "") 
+        : errorDetail;
 };
 
 


### PR DESCRIPTION
Handle any `errors` array in the response from a service, preferring this to the top-level `message` field, and sending an antd message for each one. At the moment we generally expect the array to have only one element. 

Alternatively, we could join() all messages into a single error message, although since there's no spec for service error messages, joining them together with, say, periods or commas could lead to ugly errors in the future. 
