### PR TITLE
fix(propTypes): biosample sampled_tissue no longer required

### DIFF
--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -178,7 +178,7 @@ export const biosamplePropTypesShape = PropTypes.shape({
         updated: PropTypes.string,  // ISO datetime string
     }),
     description: PropTypes.string,
-    sampled_tissue: ontologyShape.isRequired,
+    sampled_tissue: ontologyShape,
     individual_age_at_collection: PropTypes.oneOfType([agePropTypesShape, ageRangePropTypesShape]),
     histological_diagnosis: ontologyShape,
     tumor_progression: ontologyShape,


### PR DESCRIPTION
Remove `isRequired` from biosample sampled_tissue prop types, no longer required in Phenopackets 2.0

Partial fix for Redmine [#2069](https://206.12.92.46/issues/2069).