### PR TITLE
refact(manager): project JSON Schema form to ant4 + schema input

### DIFF
--- a/src/components/manager/projects/ProjectJsonSchema.js
+++ b/src/components/manager/projects/ProjectJsonSchema.js
@@ -1,18 +1,20 @@
 import React, { useCallback } from "react";
-import PropTypes from "prop-types";
-import { projectJsonSchemaTypesShape } from "../../../propTypes";
-import { Button, Card, Descriptions, Modal, Typography } from "antd";
-import ReactJson from "react-json-view";
 import { useDispatch } from "react-redux";
-import { deleteProjectJsonSchema } from "../../../modules/metadata/actions";
+import PropTypes from "prop-types";
+
+import { Button, Card, Descriptions, Modal, Typography } from "antd";
 import { DeleteOutlined } from "@ant-design/icons";
+import ReactJson from "react-json-view";
+
+import { deleteProjectJsonSchema } from "@/modules/metadata/actions";
+import { projectJsonSchemaTypesShape } from "@/propTypes";
 
 // Custom style based on Typography.Text in 'code' mode, with colors for dark backgrounds
 const CODE_STYLE = {
     "margin": "0 0.2em",
     "padding": "0.2em 0.4em 0.1em",
     "fontSize": "85%",
-    "fontFamily": "Liberation Mono",
+    "fontFamily": "monospace",
     "background": "rgba(0, 0, 0, 0.06)",
     "border": "1px solid",
     "borderColor": "white",

--- a/src/components/manager/projects/ProjectJsonSchemaForm.js
+++ b/src/components/manager/projects/ProjectJsonSchemaForm.js
@@ -38,7 +38,7 @@ const JsonSchemaInput = ({ value, onChange }) => {
                     // Validate against draft-07 meta schema
                     onChange(json);
                 } else {
-                    message.error("Selected file is an invalid JSON schema definition.").catch(console.error);
+                    message.error("Selected file is an invalid JSON schema definition.");
                 }
             };
             reader.readAsText(file);
@@ -100,6 +100,9 @@ const ProjectJsonSchemaForm = ({ form, schemaTypes, initialValues }) => {
                     ))}
                 </Select>
             </Form.Item>
+            <Form.Item label="JSON Schema" name="jsonSchema" rules={[{ required: true }]}>
+                <JsonSchemaInput />
+            </Form.Item>
             <Form.Item
                 label={
                     <Tooltip title={
@@ -113,9 +116,6 @@ const ProjectJsonSchemaForm = ({ form, schemaTypes, initialValues }) => {
                 valuePropName="checked"
             >
                 <Checkbox />
-            </Form.Item>
-            <Form.Item label="JSON Schema" name="jsonSchema" rules={[{ required: true }]}>
-                <JsonSchemaInput />
             </Form.Item>
         </Form >
     );

--- a/src/components/manager/projects/ProjectJsonSchemaForm.js
+++ b/src/components/manager/projects/ProjectJsonSchemaForm.js
@@ -1,7 +1,6 @@
 import React, { useCallback } from "react";
 import PropTypes from "prop-types";
-import { Select, Checkbox, Tooltip, Button, message } from "antd";
-import { Form } from "@ant-design/compatible";
+import { Button, Checkbox, Form, Select, Tooltip, message } from "antd";
 import { useDropzone } from "react-dropzone";
 import ReactJson from "react-json-view";
 import Ajv from "ajv";
@@ -27,8 +26,7 @@ const getSchemaTypeOptions = (schemaTypes) => {
     }
 };
 
-const ProjectJsonSchemaForm = ({ style, schemaTypes, initialValues, setFileContent, fileContent, form }) => {
-
+const JsonSchemaInput = ({ value, onChange }) => {
     const onDrop = useCallback((files) => {
         files.forEach((file) => {
             const reader = new FileReader();
@@ -38,14 +36,14 @@ const ProjectJsonSchemaForm = ({ style, schemaTypes, initialValues, setFileConte
                 const json = JSON.parse(reader.result);
                 if (validateSchema(json)) {
                     // Validate against draft-07 meta schema
-                    setFileContent(json);
+                    onChange(json);
                 } else {
-                    message.error("Selected file is an invalid JSON schema definition.");
+                    message.error("Selected file is an invalid JSON schema definition.").catch(console.error);
                 }
             };
             reader.readAsText(file);
         });
-    }, []);
+    }, [onChange]);
 
     const { getRootProps, getInputProps } = useDropzone({
         onDrop,
@@ -56,101 +54,83 @@ const ProjectJsonSchemaForm = ({ style, schemaTypes, initialValues, setFileConte
     });
 
     return (
-        <Form style={style || {}}>
-            <Form.Item label={
-                <Tooltip title={
-                    <span>The data type on which this <ExtraPropertiesCode tooltip/> schema will be applied</span>
-                }>
-                    Schema Type
-                </Tooltip>
-            }>
-                {form.getFieldDecorator("schemaType", {
-                    initialValue: initialValues.schemaType,
-                    rules: [{ required: true }],
-                })(
-                    <Select>
-                        {getSchemaTypeOptions(schemaTypes).map((option) => (
-                            <Select.Option key={option.key} value={option.value}>
-                                {option.text}
-                            </Select.Option>
-                        ))}
-                    </Select>,
-                )}
+        <div>
+            <div {...getRootProps()} style={{
+                border: "2px dashed #bae7ff",
+                textAlign: "center",
+                cursor: "pointer",
+            }}>
+                <input {...getInputProps()} />
+                <p>Drag and drop a JSON Schema file here, or click to select files</p>
+            </div>
+            {value && (
+                <>
+                    <ReactJson src={value || {}} name={false} collapsed={true} />
+                    <Button key="cancel" onClick={() => onChange(null)}>Remove</Button>
+                </>
+            )}
+        </div>
+    );
+};
+JsonSchemaInput.propTypes = {
+    value: PropTypes.object,
+    onChange: PropTypes.func,
+};
+
+const ProjectJsonSchemaForm = ({ form, schemaTypes, initialValues }) => {
+    return (
+        <Form form={form}>
+            <Form.Item
+                label={
+                    <Tooltip title={
+                        <span>The data type on which this <ExtraPropertiesCode tooltip/> schema will be applied</span>
+                    }>
+                        Schema Type
+                    </Tooltip>
+                }
+                name="schemaType"
+                initialValue={initialValues.schemaType}
+                rules={[{ required: true }]}
+            >
+                <Select>
+                    {getSchemaTypeOptions(schemaTypes).map((option) => (
+                        <Select.Option key={option.key} value={option.value}>
+                            {option.text}
+                        </Select.Option>
+                    ))}
+                </Select>
             </Form.Item>
-            <Form.Item label={
-                <Tooltip title={
-                    <span>Check to make the <ExtraPropertiesCode tooltip/> field required</span>
-                }>
-                    <span>Required</span>
-                </Tooltip>
-            }>
-                {form.getFieldDecorator("required", {
-                    initialValue: initialValues.required,
-                    valuePropName: "checked",
-                })(
-                    <Checkbox />,
-                )}
+            <Form.Item
+                label={
+                    <Tooltip title={
+                        <span>Check to make the <ExtraPropertiesCode tooltip/> field required</span>
+                    }>
+                        <span>Required</span>
+                    </Tooltip>
+                }
+                name="required"
+                initialValue={initialValues.required}
+                valuePropName="checked"
+            >
+                <Checkbox />
             </Form.Item>
-            <Form.Item label="JSON Schema" extra={(fileContent &&
-                <Button key="cancel" onClick={() => setFileContent(null)}>Remove</Button>
-            )}>
-                {form.getFieldDecorator("jsonSchema", {
-                    initialValue: initialValues.jsonSchema,
-                    rules: [{ required: true }],
-                })(
-                    <>
-                        <div {...getRootProps()} style={{
-                            border: "2px dashed #bae7ff",
-                            textAlign: "center",
-                            cursor: "pointer",
-                        }}>
-                            <input {...getInputProps()} />
-                            <p>Drag and drop a JSON Schema file here, or click to select files</p>
-                        </div>
-                        {fileContent && <ReactJson src={fileContent || {}} name={false} collapsed={true} />}
-                    </>,
-                )}
+            <Form.Item label="JSON Schema" name="jsonSchema" rules={[{ required: true }]}>
+                <JsonSchemaInput />
             </Form.Item>
         </Form >
     );
 };
 
 const JSON_SCHEMA_FORM_SHAPE = PropTypes.shape({
-    schemaType: PropTypes.object,
-    required: PropTypes.object,
+    schemaType: PropTypes.string,
+    required: PropTypes.bool,
     jsonSchema: PropTypes.object,
 });
 
 ProjectJsonSchemaForm.propTypes = {
-    style: PropTypes.object,
+    form: PropTypes.object,  // FormInstance
     schemaTypes: PropTypes.objectOf(PropTypes.string).isRequired,
     initialValues: JSON_SCHEMA_FORM_SHAPE,
-    formValues: JSON_SCHEMA_FORM_SHAPE,
-    fileContent: PropTypes.object,
-
-    setFileContent: PropTypes.func,
 };
 
-export default Form.create({
-    name: "project_json_schema_form",
-    mapPropsToFields: (props) => {
-        const { formValues } = props;
-        return {
-            schemaType: Form.createFormField({
-                ...formValues.schemaType,
-                value: formValues.schemaType?.value,
-            }),
-            required: Form.createFormField({
-                ...formValues.required,
-                checked: formValues.required?.value,
-            }),
-            jsonSchema: Form.createFormField({
-                ...formValues.jsonSchema,
-                value: formValues.jsonSchema?.value,
-            }),
-        };
-    },
-    onFieldsChange: ({ onChange }, _, allFields) => {
-        onChange({ ...allFields });
-    },
-})(ProjectJsonSchemaForm);
+export default ProjectJsonSchemaForm;

--- a/src/components/manager/projects/ProjectJsonSchemaModal.js
+++ b/src/components/manager/projects/ProjectJsonSchemaModal.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 
@@ -8,7 +8,7 @@ import { PlusOutlined } from "@ant-design/icons";
 import { createProjectJsonSchemaIfPossible } from "@/modules/metadata/actions";
 import ProjectJsonSchemaForm from "./ProjectJsonSchemaForm";
 
-const ProjectJsonSchemaModal = ({projectId, open, onOk, onCancel}) => {
+const ProjectJsonSchemaModal = ({ projectId, open, onOk, onCancel }) => {
     const dispatch = useDispatch();
 
     const isFetchingExtraPropertiesSchemaTypes = useSelector((state) =>


### PR DESCRIPTION
instead of a bunch of state passing for the json schema input, this creates a custom Ant input component for the JSON schema data, which makes it a bit cleaner (in addition to the port to Ant 4).
