### PR TITLE
site footer: link bento logo to bento page

### DIFF
--- a/src/components/SiteFooter.js
+++ b/src/components/SiteFooter.js
@@ -21,7 +21,9 @@ const SiteFooter = React.memo(() => (
                     <p style={{ margin: 0, color: "rgba(0, 0, 0, 0.65)" }}>Powered by</p>
                 </div>
                 <div style={{ width: BENTO_LOGO_WIDTH }}>
-                    <img src={BentoLogo} alt="Bento logo" />
+                    <a href="https://bento-platform.github.io" target="_blank" rel="noreferrer">
+                        <img src={BentoLogo} alt="Bento logo" />
+                    </a>
                 </div>
             </div>
 


### PR DESCRIPTION
Give the "Powered by Bento" image a clickable link to https://bento-platform.github.io/. 

Pops out in a new page (`target="_blank"`) even though the other footer links don't do this. I'm happy to hear contrary suggestions. 

`rel="noreferrer"` now mostly voodoo, only necessary for a few very old browers which probably can't run Bento. 