### PR TITLE
fix: project json schemas types query in a hook

### DIFF
--- a/src/components/manager/projects/ProjectJsonSchemaModal.js
+++ b/src/components/manager/projects/ProjectJsonSchemaModal.js
@@ -6,17 +6,15 @@ import { Button, Form, Modal } from "antd";
 import { PlusOutlined } from "@ant-design/icons";
 
 import { createProjectJsonSchema } from "@/modules/metadata/actions";
-import ProjectJsonSchemaForm from "./ProjectJsonSchemaForm";
 import { useProjectJsonSchemaTypes } from "@/modules/metadata/hooks";
+
+import ProjectJsonSchemaForm from "./ProjectJsonSchemaForm";
 
 const ProjectJsonSchemaModal = ({ projectId, open, onOk, onCancel }) => {
   const dispatch = useDispatch();
 
-  const {
-    isFetching: isFetchingExtraPropertiesSchemaTypes,
-    isCreating: isCreatingJsonSchema,
-    schemaTypes: extraPropertiesSchemaTypes,
-  } = useProjectJsonSchemaTypes();
+  const { isFetchingExtraPropertiesSchemaTypes, isCreatingJsonSchema, extraPropertiesSchemaTypes } =
+    useProjectJsonSchemaTypes();
 
   const [form] = Form.useForm();
 

--- a/src/components/manager/projects/ProjectJsonSchemaModal.js
+++ b/src/components/manager/projects/ProjectJsonSchemaModal.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 
 import { Button, Form, Modal } from "antd";
@@ -7,15 +7,16 @@ import { PlusOutlined } from "@ant-design/icons";
 
 import { createProjectJsonSchema } from "@/modules/metadata/actions";
 import ProjectJsonSchemaForm from "./ProjectJsonSchemaForm";
+import { useProjectJsonSchemaTypes } from "@/modules/metadata/hooks";
 
 const ProjectJsonSchemaModal = ({ projectId, open, onOk, onCancel }) => {
   const dispatch = useDispatch();
 
-  const isFetchingExtraPropertiesSchemaTypes = useSelector(
-    (state) => state.projects.isFetchingExtraPropertiesSchemaTypes,
-  );
-  const extraPropertiesSchemaTypes = useSelector((state) => state.projects.extraPropertiesSchemaTypes);
-  const isCreatingJsonSchema = useSelector((state) => state.projects.isCreatingJsonSchema);
+  const {
+    isFetching: isFetchingExtraPropertiesSchemaTypes,
+    isCreating: isCreatingJsonSchema,
+    schemaTypes: extraPropertiesSchemaTypes,
+  } = useProjectJsonSchemaTypes();
 
   const [form] = Form.useForm();
 

--- a/src/modules/metadata/hooks.js
+++ b/src/modules/metadata/hooks.js
@@ -40,9 +40,13 @@ export const useProjectJsonSchemaTypes = () => {
   useEffect(() => {
     dispatch(fetchExtraPropertiesSchemaTypes());
   }, [dispatch, metadataService]);
-  return useSelector((state) => ({
-    isFetching: state.projects.isFetchingExtraPropertiesSchemaTypes,
-    isCreating: state.projects.isCreatingJsonSchema,
-    schemaTypes: state.projects.extraPropertiesSchemaTypes,
-  }));
+  const { isFetchingExtraPropertiesSchemaTypes, isCreatingJsonSchema, extraPropertiesSchemaTypes } = useProjects();
+  return useMemo(
+    () => ({
+      isFetchingExtraPropertiesSchemaTypes,
+      isCreatingJsonSchema,
+      extraPropertiesSchemaTypes,
+    }),
+    [isFetchingExtraPropertiesSchemaTypes, isCreatingJsonSchema, extraPropertiesSchemaTypes],
+  );
 };

--- a/src/modules/metadata/hooks.js
+++ b/src/modules/metadata/hooks.js
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { makeProjectDatasetResource, makeProjectResource } from "bento-auth-js";
 import { useService } from "@/modules/services/hooks";
-import { fetchOverviewSummaryIfNeeded, fetchProjectsWithDatasets } from "./actions";
+import { fetchExtraPropertiesSchemaTypes, fetchOverviewSummaryIfNeeded, fetchProjectsWithDatasets } from "./actions";
 
 export const useProjects = () => {
   const dispatch = useDispatch();
@@ -32,4 +32,17 @@ export const useOverviewSummary = () => {
     dispatch(fetchOverviewSummaryIfNeeded()).catch((err) => console.error(err));
   }, [dispatch, metadataService]);
   return useSelector((state) => state.overviewSummary);
+};
+
+export const useProjectJsonSchemaTypes = () => {
+  const dispatch = useDispatch();
+  const metadataService = useService("metadata");
+  useEffect(() => {
+    dispatch(fetchExtraPropertiesSchemaTypes());
+  }, [dispatch, metadataService]);
+  return useSelector((state) => ({
+    isFetching: state.projects.isFetchingExtraPropertiesSchemaTypes,
+    isCreating: state.projects.isCreatingJsonSchema,
+    schemaTypes: state.projects.extraPropertiesSchemaTypes,
+  }));
 };

--- a/src/modules/user/actions.js
+++ b/src/modules/user/actions.js
@@ -1,13 +1,10 @@
 import { beginFlow, createFlowActionTypes, endFlow } from "@/utils/actions";
 import { nop } from "@/utils/misc";
 import { fetchDatasetsDataTypes } from "../datasets/actions";
-import { fetchExtraPropertiesSchemaTypes, fetchProjectsWithDatasets } from "../metadata/actions";
+import { fetchProjectsWithDatasets } from "../metadata/actions";
 import { fetchServicesWithMetadataAndDataTypesIfNeeded } from "../services/actions";
 
 export const FETCHING_USER_DEPENDENT_DATA = createFlowActionTypes("FETCHING_USER_DEPENDENT_DATA");
-
-export const fetchServiceDependentData = () => (dispatch) =>
-  Promise.all([fetchExtraPropertiesSchemaTypes].map((a) => dispatch(a())));
 
 export const fetchUserDependentData = (servicesCb) => async (dispatch, getState) => {
   const { idTokenContents, hasAttempted } = getState().auth;
@@ -27,7 +24,7 @@ export const fetchUserDependentData = (servicesCb) => async (dispatch, getState)
       // If we're newly authenticated as an owner, we run all actions that may have changed with authentication
       // (via the callback).
       // TODO: invalidate projects/datasets/other user-dependent data
-      await dispatch(fetchServicesWithMetadataAndDataTypesIfNeeded(() => dispatch(fetchServiceDependentData())));
+      await dispatch(fetchServicesWithMetadataAndDataTypesIfNeeded());
       await (servicesCb || nop)();
       await dispatch(fetchProjectsWithDatasets());
       await dispatch(fetchDatasetsDataTypes());


### PR DESCRIPTION
Removes `fetchServiceDependentData`, which was only used to fetch extra prop schema types, and replaces it with a hook.