### PR TITLE
chore: remove onFocus data refresh

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -65,7 +65,6 @@ const App = () => {
   const signInWindow = useRef(null);
   const windowMessageHandler = useRef(null);
   const pingInterval = useRef(null);
-  const focusListener = useRef(undefined);
 
   const [signedOutModal, setSignedOutModal] = useState(false);
 
@@ -165,14 +164,6 @@ const App = () => {
   useEffect(() => {
     handleUserChange();
   }, [handleUserChange, idTokenContents]);
-
-  // TODO: Don't execute on focus if it's been checked recently
-  useEffect(() => {
-    if (focusListener.current === handleUserChange) return; // Same as before
-    if (focusListener.current) window.removeEventListener("focus", focusListener.current);
-    window.addEventListener("focus", handleUserChange);
-    focusListener.current = handleUserChange;
-  }, [focusListener, handleUserChange]);
 
   useEffect(() => {
     if (didPostLoadEffects) return;


### PR DESCRIPTION
this would refresh data when tabbing back to the focused window, but this is an ugly way of refreshing data and wasn't executed very well (would show loading indicators and whatnot). we don't have data change very frequently in bento, so user-refreshing should be good enough.