### PR TITLE
fix: workflow boolean inputs default value

### DIFF
--- a/src/components/manager/RunSetupInputForm.js
+++ b/src/components/manager/RunSetupInputForm.js
@@ -165,12 +165,19 @@ const RunSetupInputForm = ({ initialValues, onSubmit, workflow, onBack, onChange
           .filter((i) => !i.hidden && !i.injected)
           .map((i) => {
             const [component, options] = getInputComponentAndOptions(i);
+
+            // Default to setting initialValue for boolean inputs to "false"
+            // so that the value is set when the form item is not interacted with
+            let initialValue = initialValues[i.id];
+            if (!initialValue && i.type === "boolean") {
+              initialValue = false;
+            }
             return (
               <Form.Item
                 key={i.id}
                 label={i.id}
                 name={i.id}
-                initialValue={initialValues[i.id]}
+                initialValue={initialValue}
                 rules={
                   // Default to requiring the field unless the "required" property is set on the input
                   // or the input is a boolean (i.e., checkbox), since booleans will always be present.


### PR DESCRIPTION
Workflow inputs of type "boolean" don't have their default value set correctly in the antd Form.
If the input's initial value is not present in the `initialValues` prop, the value defaults to `undefined`.

This bug causes errors when ingesting VCFs, "filter out references" can only be `false` by checking and unchecking the input.
, causing WES to reject the request due to a missing workflow input.
[Ticket](https://redmine.c3g-app.sd4h.ca/issues/2390)
