### PR TITLE
Fixes/variants form submit

### DIFF
--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -71,7 +71,7 @@ const DiscoveryQueryBuilder = ({ activeDataset, dataTypeForms, requiredDataTypes
       if (action !== "remove") return;
       dispatch(removeDataTypeQueryForm(activeDataset, dataTypesByID[key]));
 
-      // remove this field from antd form
+      // remove this field from submitted form
       setForms((fs) => objectWithoutProp(fs, key));
     },
     [dispatch, activeDataset, dataTypesByID],

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -71,6 +71,12 @@ const DiscoveryQueryBuilder = ({ activeDataset, dataTypeForms, requiredDataTypes
     (key, action) => {
       if (action !== "remove") return;
       dispatch(removeDataTypeQueryForm(activeDataset, dataTypesByID[key]));
+
+      // remove this field from antd form
+      setForms((fs) => {
+        const { [key]: _, ...rest } = fs;
+        return rest;
+      });
     },
     [dispatch, activeDataset, dataTypesByID],
   );
@@ -85,7 +91,7 @@ const DiscoveryQueryBuilder = ({ activeDataset, dataTypeForms, requiredDataTypes
     try {
       await Promise.all(Object.values(forms).map((f) => f.validateFields()));
 
-      // force validation of variant fields
+      // force validation of variant fields, validateFields() has no effect
       if (forms["variant"]) {
         const variantFields = forms["variant"].getFieldValue("conditions");
         await Promise.all(variantFields.map((field) => conditionValidator(null, field)));

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -15,14 +15,13 @@ import { useDataTypes, useServices } from "@/modules/services/hooks";
 import { useAppDispatch, useAppSelector } from "@/store";
 import { nop } from "@/utils/misc";
 import { VARIANT_OPTIONAL_FIELDS } from "@/utils/search";
+import { objectWithoutProp } from "@/utils/misc";
 
 import DataTypeExplorationModal from "./DataTypeExplorationModal";
 import DiscoverySearchForm from "./DiscoverySearchForm";
 import { getSchemaTypeTransformer } from "./DiscoverySearchCondition";
 
 const conditionValidator = (rule, { field, fieldSchema, searchValue }) => {
-  console.log("running conditionValidator()");
-
   if (field === undefined) {
     return Promise.reject("A field must be specified for this search condition.");
   }
@@ -73,10 +72,7 @@ const DiscoveryQueryBuilder = ({ activeDataset, dataTypeForms, requiredDataTypes
       dispatch(removeDataTypeQueryForm(activeDataset, dataTypesByID[key]));
 
       // remove this field from antd form
-      setForms((fs) => {
-        const { [key]: _, ...rest } = fs;
-        return rest;
-      });
+      setForms((fs) => objectWithoutProp(fs, key));
     },
     [dispatch, activeDataset, dataTypesByID],
   );

--- a/src/components/discovery/DiscoveryQueryBuilder.js
+++ b/src/components/discovery/DiscoveryQueryBuilder.js
@@ -13,36 +13,11 @@ import {
 } from "@/modules/explorer/actions";
 import { useDataTypes, useServices } from "@/modules/services/hooks";
 import { useAppDispatch, useAppSelector } from "@/store";
-import { nop } from "@/utils/misc";
-import { VARIANT_OPTIONAL_FIELDS } from "@/utils/search";
-import { objectWithoutProp } from "@/utils/misc";
+import { nop, objectWithoutProp } from "@/utils/misc";
+import { conditionValidator } from "@/utils/search";
 
 import DataTypeExplorationModal from "./DataTypeExplorationModal";
 import DiscoverySearchForm from "./DiscoverySearchForm";
-import { getSchemaTypeTransformer } from "./DiscoverySearchCondition";
-
-const conditionValidator = (rule, { field, fieldSchema, searchValue }) => {
-  if (field === undefined) {
-    return Promise.reject("A field must be specified for this search condition.");
-  }
-
-  const transformedSearchValue = getSchemaTypeTransformer(fieldSchema.type)[1](searchValue);
-  const isEnum = fieldSchema.hasOwnProperty("enum");
-  const isString = fieldSchema.type === "string";
-
-  // noinspection JSCheckFunctionSignatures
-  if (
-    !VARIANT_OPTIONAL_FIELDS.includes(field) &&
-    (transformedSearchValue === null ||
-      (!isEnum && !transformedSearchValue) ||
-      (!isEnum && isString && !transformedSearchValue.trim()) || // Forbid whitespace-only free-text searches
-      (isEnum && !fieldSchema.enum.includes(transformedSearchValue)))
-  ) {
-    return Promise.reject(`This field must have a value: ${field}`);
-  }
-
-  return Promise.resolve();
-};
 
 const DiscoveryQueryBuilder = ({ activeDataset, dataTypeForms, requiredDataTypes, onSubmit, searchLoading }) => {
   const dispatch = useAppDispatch();
@@ -169,7 +144,6 @@ const DiscoveryQueryBuilder = ({ activeDataset, dataTypeForms, requiredDataTypes
               setFormRef={setFormRef}
               onChange={handleChange}
               handleVariantHiddenFieldChange={handleVariantHiddenFieldChange}
-              conditionValidator={conditionValidator}
             />
           ),
         };

--- a/src/components/discovery/DiscoverySearchCondition.js
+++ b/src/components/discovery/DiscoverySearchCondition.js
@@ -5,8 +5,14 @@ import { Button, Input, Select, Space } from "antd";
 import { CloseOutlined } from "@ant-design/icons";
 
 import SchemaTreeSelect from "../schema_trees/SchemaTreeSelect";
-import { constFn, id, nop } from "@/utils/misc";
-import { DEFAULT_SEARCH_PARAMETERS, OP_EQUALS, OPERATION_TEXT, UI_SUPPORTED_OPERATIONS } from "@/utils/search";
+import { nop } from "@/utils/misc";
+import {
+  DEFAULT_SEARCH_PARAMETERS,
+  OP_EQUALS,
+  OPERATION_TEXT,
+  UI_SUPPORTED_OPERATIONS,
+  getSchemaTypeTransformer,
+} from "@/utils/search";
 
 const BOOLEAN_OPTIONS = ["true", "false"];
 const NEGATE_SELECT_OPTIONS = [
@@ -29,23 +35,6 @@ const styles = {
   negationSelect: { width: `${NEGATION_WIDTH}px`, float: "left" },
   operationSelect: { width: `${OPERATION_WIDTH}px`, float: "left" },
   closeButton: { width: `${CLOSE_WIDTH}px` },
-};
-
-const toStringOrNull = (x) => (x === null ? null : x.toString());
-
-export const getSchemaTypeTransformer = (type) => {
-  switch (type) {
-    case "integer":
-      return [(s) => parseInt(s, 10), toStringOrNull];
-    case "number":
-      return [(s) => parseFloat(s), toStringOrNull];
-    case "boolean":
-      return [(s) => s === "true", toStringOrNull];
-    case "null":
-      return [constFn(null), constFn("null")];
-    default:
-      return [id, id];
-  }
 };
 
 const DEFAULT_FIELD_SCHEMA = {

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -43,6 +43,8 @@ const ADD_CONDITION_WRAPPER_COL = {
 
 const conditionLabel = (i) => `Condition ${i + 1}`;
 
+const CONDITION_RULES = [{ validator: conditionValidator }];
+
 const PhenopacketDropdownOption = ({ option: { path, ui_name: uiName }, getDataTypeFieldSchema }) => (
   <Tooltip title={getDataTypeFieldSchema(`[dataset item].${path}`).description} mouseEnterDelay={TOOLTIP_DELAY_SECONDS}>
     {uiName}
@@ -58,8 +60,6 @@ PhenopacketDropdownOption.propTypes = {
 
 const DiscoverySearchForm = ({ onChange, dataType, setFormRef, handleVariantHiddenFieldChange }) => {
   const [form] = Form.useForm();
-
-  const CONDITION_RULES = [{ validator: conditionValidator }];
 
   useEffect(() => {
     if (setFormRef) setFormRef(form);

--- a/src/components/discovery/DiscoverySearchForm.js
+++ b/src/components/discovery/DiscoverySearchForm.js
@@ -15,6 +15,7 @@ import {
   searchUiMappings,
   VARIANT_REQUIRED_FIELDS,
   VARIANT_OPTIONAL_FIELDS,
+  conditionValidator,
 } from "@/utils/search";
 
 import DiscoverySearchCondition from "./DiscoverySearchCondition";
@@ -55,13 +56,7 @@ PhenopacketDropdownOption.propTypes = {
   getDataTypeFieldSchema: PropTypes.func,
 };
 
-const DiscoverySearchForm = ({
-  onChange,
-  dataType,
-  setFormRef,
-  handleVariantHiddenFieldChange,
-  conditionValidator,
-}) => {
+const DiscoverySearchForm = ({ onChange, dataType, setFormRef, handleVariantHiddenFieldChange }) => {
   const [form] = Form.useForm();
 
   const CONDITION_RULES = [{ validator: conditionValidator }];
@@ -365,7 +360,6 @@ DiscoverySearchForm.propTypes = {
   dataType: PropTypes.object, // TODO: Shape?
   setFormRef: PropTypes.func,
   handleVariantHiddenFieldChange: PropTypes.func.isRequired,
-  conditionValidator: PropTypes.func,
 };
 
 export default DiscoverySearchForm;

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -41,7 +41,14 @@ export const DEFAULT_SEARCH_PARAMETERS = {
   queryable: "all",
 };
 
-const VARIANT_OPTIONAL_FIELDS = [
+export const VARIANT_REQUIRED_FIELDS = [
+  "[dataset item].assembly_id",
+  "[dataset item].chromosome",
+  "[dataset item].start",
+  "[dataset item].end", //always filled in UI but not required in spec
+];
+
+export const VARIANT_OPTIONAL_FIELDS = [
   "[dataset item].calls.[item].genotype_type",
   "[dataset item].alternative",
   "[dataset item].reference",


### PR DESCRIPTION
Fixes issues with search form validation, where users were permitted to launch searches with invalid form state. (Redmine [2415](https://redmine.c3g-app.sd4h.ca/issues/2415)). 

Some of the previous tricks for variants form validation  do not work as well in antd > 3, this is fixed by moving validation code to a parent component and invoking manually when needed. 

Also discovered and fixed this issue of uncertain age: data types are not removed from the submitted form when deleting data type tabs (when removing, e.g. the "Variants" search tab, the submitted form still has fields for variants). This can block form submission, and without giving any user feedback (because the tab is not rendered). 
