### PR TITLE
tweak variant position regex & feedback

### DIFF
--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -8,7 +8,7 @@ const NULL_LOCUS = { chrom: null, start: null, end: null };
 // Position notation pattern
 //  - strip chr prefix, but allow any other types of chromosome - eventually this should instead autocomplete from the
 //    reference service.
-const POS_NOTATION_PATTERN = /(?:CHR|chr)?([\w.-]+):(\d+)-(\d+)$/;
+const POS_NOTATION_PATTERN = /^(?:CHR|chr)?([\w.-]+):(\d+)-(\d+)$/;
 
 const parsePosition = (value) => {
   const result = POS_NOTATION_PATTERN.exec(value);

--- a/src/components/discovery/LocusSearch.js
+++ b/src/components/discovery/LocusSearch.js
@@ -8,7 +8,7 @@ const NULL_LOCUS = { chrom: null, start: null, end: null };
 // Position notation pattern
 //  - strip chr prefix, but allow any other types of chromosome - eventually this should instead autocomplete from the
 //    reference service.
-const POS_NOTATION_PATTERN = /(?:CHR|chr)?([\w.-]+):(\d+)-(\d+)/;
+const POS_NOTATION_PATTERN = /(?:CHR|chr)?([\w.-]+):(\d+)-(\d+)$/;
 
 const parsePosition = (value) => {
   const result = POS_NOTATION_PATTERN.exec(value);
@@ -53,10 +53,6 @@ const LocusSearch = ({
   useEffect(() => {
     if (looksLikePositionNotation(inputValue)) {
       handlePositionNotation(inputValue);
-
-      // let user finish typing position before showing error
-      setLocusValidity(true);
-
       setAutoCompleteOptions([]);
     }
   }, [inputValue, handlePositionNotation, setLocusValidity]);


### PR DESCRIPTION
Fixes to variant search by position (Redmine #2470):
- reject non-matches (previously you could add extra cruft as long as the pattern could find chromosome, start and end values)
- provide user feedback right away about whether their position notation is correct. 
