### PR TITLE
fix: update putDropBoxObject to invalidate drop box tree on a successful file upload

### DIFF
--- a/src/modules/dropBox/actions.js
+++ b/src/modules/dropBox/actions.js
@@ -24,7 +24,7 @@ export const invalidateDropBoxTree = basicAction(INVALIDATE_DROP_BOX_TREE);
 const dropBoxObjectPath = (getState, path) =>
   `${getState().services.dropBoxService.url}/objects/${path.replace(/^\//, "")}`;
 
-export const putDropBoxObject = networkAction((path, file) => async (_dispatch, getState) => ({
+export const putDropBoxObject = networkAction((path, file) => async (dispatch, getState) => ({
   types: PUT_DROP_BOX_OBJECT,
   url: dropBoxObjectPath(getState, path),
   req: {
@@ -33,6 +33,8 @@ export const putDropBoxObject = networkAction((path, file) => async (_dispatch, 
   },
   onSuccess: () => {
     message.success(`Successfully uploaded file to drop box path: ${path}`);
+    dispatch(invalidateDropBoxTree());
+    return dispatch(fetchDropBoxTree());
   },
   err: `Error uploading file to drop box path: ${path}`,
 }));


### PR DESCRIPTION
This PR addresses [Feature #2381](https://redmine.c3g-app.sd4h.ca/issues/2381) by automatically refreshing the UI after a file is uploaded via the Dropbox interface. Previously, users had to manually refresh the page to see the newly uploaded file. With this change, the file list updates immediately after a successful upload, improving usability and feedback.