### PR TITLE
remove console error message for sampled_tissue id, label null

### DIFF
--- a/src/components/explorer/OntologyTerm.js
+++ b/src/components/explorer/OntologyTerm.js
@@ -27,6 +27,8 @@ const OntologyTerm = memo(({ term, renderLabel = id, br = false }) => {
 
   useEffect(() => {
     if (!term) return;
+    // Skip logging for the explicit missing case {id: null, label: null}
+    if (term.id === null && term.label === null) return;
     if (!term.id || !term.label) {
       console.error("Invalid term provided to OntologyTerm component:", term);
     }


### PR DESCRIPTION
Fix sampled_tissue ontology term console error. Remove the console error message for the {id: null, label: null} case.