### PR TITLE
feat(authz): support editing grants via PUT /grants/:id

### DIFF
--- a/src/components/manager/access/GrantForm.tsx
+++ b/src/components/manager/access/GrantForm.tsx
@@ -462,8 +462,11 @@ const PermissionsInput = ({ id, value, onChange, currentResource, ...rest }: Per
   );
 
   useEffect(() => {
-    const filteredChecked = [...checked, ...checked.flatMap((s) => permissionsByID[s].gives)].filter((c) =>
-      permissionCompatibleWithResource(permissionsByID[c], currentResource),
+    // Don't filter while permissions haven't loaded: permissionsByID would be empty, causing all checked
+    // permissions to be filtered out and wiping the form field.
+    if (!permissions.length) return;
+    const filteredChecked = [...checked, ...checked.flatMap((s) => permissionsByID[s]?.gives ?? [])].filter(
+      (c) => permissionsByID[c] && permissionCompatibleWithResource(permissionsByID[c], currentResource),
     );
     if (newPermissionsDifferent(checked, filteredChecked)) {
       handleChange(filteredChecked);
@@ -596,32 +599,43 @@ const PermissionsInput = ({ id, value, onChange, currentResource, ...rest }: Per
   );
 };
 
-const GrantForm = ({ form }: { form: FormInstance<Grant> }) => {
+const GrantForm = ({ form, initialValues }: { form: FormInstance<Grant>; initialValues?: Partial<Grant> }) => {
   const homeIssuer = useOpenIdConfig().data?.issuer ?? "";
   const defaultSubject = useMemo<GrantSubject>(() => ({ iss: homeIssuer, sub: "" }), [homeIssuer]);
 
   const currentResource = Form.useWatch("resource", form);
 
+  const formInitialValues = useMemo(
+    () => ({
+      subject: defaultSubject,
+      resource: RESOURCE_EVERYTHING,
+      permissions: [],
+      expiry: null,
+      notes: "",
+      ...initialValues,
+    }),
+    [defaultSubject, initialValues],
+  );
+
   return (
-    <Form form={form} layout="vertical">
-      <Form.Item name="subject" label="Subject" initialValue={defaultSubject}>
+    <Form form={form} layout="vertical" initialValues={formInitialValues}>
+      <Form.Item name="subject" label="Subject">
         <SubjectInput />
       </Form.Item>
-      <Form.Item name="resource" label="Resource" initialValue={RESOURCE_EVERYTHING}>
+      <Form.Item name="resource" label="Resource">
         <ResourceInput />
       </Form.Item>
       <Form.Item
         name="permissions"
         label="Permissions"
-        initialValue={[]}
         rules={[{ type: "array", min: 1, message: "At least one permission must be specified" }]}
       >
         <PermissionsInput currentResource={currentResource ?? RESOURCE_EVERYTHING} />
       </Form.Item>
-      <Form.Item name="expiry" label="Expiry" initialValue={null}>
+      <Form.Item name="expiry" label="Expiry">
         <ExpiryInput />
       </Form.Item>
-      <Form.Item name="notes" label="Notes" initialValue="">
+      <Form.Item name="notes" label="Notes">
         <Input.TextArea />
       </Form.Item>
     </Form>

--- a/src/components/manager/access/GrantsTabContent.js
+++ b/src/components/manager/access/GrantsTabContent.js
@@ -113,7 +113,7 @@ const GrantsTabContent = () => {
 
   const isFetchingAllServices = useServices().isFetchingAll;
 
-  const { data: grants, isFetching: isFetchingGrants } = useGrants();
+  const { data: grants, itemsByID: grantsById, isFetching: isFetchingGrants } = useGrants();
 
   const {
     isFetching: isFetchingPermissions,
@@ -125,9 +125,16 @@ const GrantsTabContent = () => {
   const openCreateModal = useCallback(() => setCreateModalOpen(true), []);
   const closeCreateModal = useCallback(() => setCreateModalOpen(false), []);
 
-  const [editingGrant, setEditingGrant] = useState(null);
-  const openEditModal = useCallback((grant) => setEditingGrant(grant), []);
-  const closeEditModal = useCallback(() => setEditingGrant(null), []);
+  const [editingGrantId, setEditingGrantId] = useState(null);
+  const editingGrant = editingGrantId != null ? (grantsById[editingGrantId] ?? null) : null;
+  const openEditModal = useCallback((grantId) => setEditingGrantId(grantId), []);
+  const closeEditModal = useCallback(() => setEditingGrantId(null), []);
+
+  useEffect(() => {
+    if (editingGrantId != null && !grantsById[editingGrantId]) {
+      setEditingGrantId(null);
+    }
+  }, [editingGrantId, grantsById]);
 
   const [deleteModal, deleteModalContextHolder] = Modal.useModal();
 
@@ -149,7 +156,7 @@ const GrantsTabContent = () => {
                       icon={<EditOutlined />}
                       loading={pLoading}
                       disabled={!canEdit}
-                      onClick={() => openEditModal(grant)}
+                      onClick={() => openEditModal(grant.id)}
                     >
                       Edit
                     </Button>{" "}
@@ -201,7 +208,7 @@ const GrantsTabContent = () => {
         </ActionContainer>
       )}
       <GrantCreationModal open={createModalOpen} closeModal={closeCreateModal} />
-      <GrantEditModal grant={editingGrant} open={!!editingGrant} closeModal={closeEditModal} />
+      <GrantEditModal key={editingGrantId} grant={editingGrant} open={!!editingGrant} closeModal={closeEditModal} />
       <GrantsTable
         grants={grants}
         loading={isFetchingAllServices || isFetchingPermissions || isFetchingGrants}

--- a/src/components/manager/access/GrantsTabContent.js
+++ b/src/components/manager/access/GrantsTabContent.js
@@ -126,12 +126,12 @@ const GrantsTabContent = () => {
   const closeCreateModal = useCallback(() => setCreateModalOpen(false), []);
 
   const [editingGrantId, setEditingGrantId] = useState(null);
-  const editingGrant = editingGrantId != null ? (grantsById[editingGrantId] ?? null) : null;
+  const editingGrant = editingGrantId !== null ? (grantsById[editingGrantId] ?? null) : null;
   const openEditModal = useCallback((grantId) => setEditingGrantId(grantId), []);
   const closeEditModal = useCallback(() => setEditingGrantId(null), []);
 
   useEffect(() => {
-    if (editingGrantId != null && !grantsById[editingGrantId]) {
+    if (editingGrantId !== null && !grantsById[editingGrantId]) {
       setEditingGrantId(null);
     }
   }, [editingGrantId, grantsById]);

--- a/src/components/manager/access/GrantsTabContent.js
+++ b/src/components/manager/access/GrantsTabContent.js
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 
 import { Button, Form, Modal, Typography } from "antd";
-import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
 
 import { editPermissions, makeResourceKey } from "bento-auth-js";
 
 import ActionContainer from "@/components/manager/ActionContainer";
-import { createGrant, deleteGrant } from "@/modules/authz/actions";
+import { createGrant, deleteGrant, saveGrant } from "@/modules/authz/actions";
 import { useAuthzManagementPermissions, useGrants } from "@/modules/authz/hooks";
 import { useServices } from "@/modules/services/hooks";
 import { useAppDispatch } from "@/store";
@@ -15,6 +15,48 @@ import { useAppDispatch } from "@/store";
 import GrantForm from "./GrantForm";
 import GrantSummary from "./GrantSummary";
 import GrantsTable from "./GrantsTable";
+
+const GrantEditModal = ({ grant, open, closeModal }) => {
+  const dispatch = useAppDispatch();
+  const [form] = Form.useForm();
+  const [loading, setLoading] = useState(false);
+
+  const onOk = useCallback(() => {
+    setLoading(true);
+    form
+      .validateFields()
+      .then(async (values) => {
+        await dispatch(saveGrant({ ...values, id: grant.id }));
+        closeModal();
+      })
+      .catch((err) => {
+        console.error(err);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [dispatch, form, closeModal, grant]);
+
+  return (
+    <Modal
+      open={open}
+      width={720}
+      title={`Edit Grant ${grant?.id}`}
+      onCancel={closeModal}
+      onOk={onOk}
+      okText="Save"
+      okButtonProps={{ loading }}
+      destroyOnHidden={true}
+    >
+      <GrantForm form={form} initialValues={grant} />
+    </Modal>
+  );
+};
+GrantEditModal.propTypes = {
+  grant: PropTypes.object,
+  open: PropTypes.bool,
+  closeModal: PropTypes.func,
+};
 
 const GrantCreationModal = ({ open, closeModal }) => {
   const dispatch = useAppDispatch();
@@ -82,6 +124,11 @@ const GrantsTabContent = () => {
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const openCreateModal = useCallback(() => setCreateModalOpen(true), []);
   const closeCreateModal = useCallback(() => setCreateModalOpen(false), []);
+
+  const [editingGrant, setEditingGrant] = useState(null);
+  const openEditModal = useCallback((grant) => setEditingGrant(grant), []);
+  const closeEditModal = useCallback(() => setEditingGrant(null), []);
+
   const [deleteModal, deleteModalContextHolder] = Modal.useModal();
 
   const extraColumns = useMemo(
@@ -91,16 +138,21 @@ const GrantsTabContent = () => {
             {
               title: "Actions",
               key: "actions",
-              // TODO: hook up edit
               render: (grant) => {
                 const pObj = grantResourcePermissionsObjects[makeResourceKey(grant.resource)];
                 const pLoading = pObj.isFetching;
                 const canEdit = pObj.permissions.includes(editPermissions);
                 return (
                   <>
-                    {/*TODO: no edit grant right now; originally designed to be immutable but this should change*/}
-                    {/*<Button size="small" icon={<EditOutlined />} loading={pLoading} disabled={!canEdit}>*/}
-                    {/*    Edit</Button>{" "}*/}
+                    <Button
+                      size="small"
+                      icon={<EditOutlined />}
+                      loading={pLoading}
+                      disabled={!canEdit}
+                      onClick={() => openEditModal(grant)}
+                    >
+                      Edit
+                    </Button>{" "}
                     <Button
                       size="small"
                       danger={true}
@@ -135,7 +187,7 @@ const GrantsTabContent = () => {
             },
           ]
         : [],
-    [dispatch, grantResourcePermissionsObjects, hasAtLeastOneEditPermissionsGrant, deleteModal],
+    [dispatch, grantResourcePermissionsObjects, hasAtLeastOneEditPermissionsGrant, deleteModal, openEditModal],
   );
 
   return (
@@ -149,6 +201,7 @@ const GrantsTabContent = () => {
         </ActionContainer>
       )}
       <GrantCreationModal open={createModalOpen} closeModal={closeCreateModal} />
+      <GrantEditModal grant={editingGrant} open={!!editingGrant} closeModal={closeEditModal} />
       <GrantsTable
         grants={grants}
         loading={isFetchingAllServices || isFetchingPermissions || isFetchingGrants}

--- a/src/modules/authz/actions.js
+++ b/src/modules/authz/actions.js
@@ -46,6 +46,18 @@ export const createGrant = networkAction((grant) => (_dispatch, getState) => ({
   },
 }));
 
+export const SAVE_GRANT = createNetworkActionTypes("SAVE_GRANT");
+export const saveGrant = networkAction((grant) => (_dispatch, getState) => ({
+  types: SAVE_GRANT,
+  check: grantMutateCheck,
+  params: { grant },
+  req: jsonRequest(grant, "PUT"),
+  url: `${authzURL(getState())}/grants/${grant.id}`,
+  onSuccess: () => {
+    message.success(`Grant ${grant.id} saved successfully!`);
+  },
+}));
+
 export const DELETE_GRANT = createNetworkActionTypes("DELETE_GRANT");
 export const deleteGrant = networkAction(({ id: grantID }) => (_dispatch, getState) => ({
   types: DELETE_GRANT,

--- a/src/modules/authz/actions.js
+++ b/src/modules/authz/actions.js
@@ -41,6 +41,7 @@ export const createGrant = networkAction((grant) => (_dispatch, getState) => ({
   check: grantMutateCheck,
   req: jsonRequest(grant, "POST"),
   url: `${authzURL(getState())}/grants/`,
+  err: "Could not create grant",
   onSuccess: () => {
     message.success("Grant created successfully!");
   },
@@ -53,6 +54,7 @@ export const saveGrant = networkAction((grant) => (_dispatch, getState) => ({
   params: { grant },
   req: jsonRequest(grant, "PUT"),
   url: `${authzURL(getState())}/grants/${grant.id}`,
+  err: `Could not save grant ${grant.id}`,
   onSuccess: () => {
     message.success(`Grant ${grant.id} saved successfully!`);
   },
@@ -65,6 +67,7 @@ export const deleteGrant = networkAction(({ id: grantID }) => (_dispatch, getSta
   req: { method: "DELETE" },
   url: `${authzURL(getState())}/grants/${grantID}`,
   params: { grantID },
+  err: `Could not delete grant ${grantID}`,
   onSuccess: () => {
     message.success(`Grant ${grantID} deleted successfully!`);
   },

--- a/src/modules/authz/reducers.js
+++ b/src/modules/authz/reducers.js
@@ -8,6 +8,7 @@ import {
   FETCH_GROUPS,
   INVALIDATE_GRANTS,
   INVALIDATE_GROUPS,
+  SAVE_GRANT,
   SAVE_GROUP,
 } from "./actions";
 import { arrayToObjectByProperty, objectWithoutProp } from "@/utils/misc";
@@ -37,6 +38,7 @@ export const grants = (
     itemsByID: {},
     isFetching: false,
     isCreating: false,
+    isSaving: false,
     isDeleting: false,
     isInvalid: false,
   },
@@ -68,6 +70,22 @@ export const grants = (
       };
     case CREATE_GRANT.FINISH:
       return { ...state, isCreating: false };
+
+    case SAVE_GRANT.REQUEST: {
+      const grantID = action.grant.id;
+      return {
+        ...state,
+        isSaving: true,
+        // Optimistically update while we wait for the PUT response
+        data: state.data.map((g) => (g.id === grantID ? action.grant : g)),
+        itemsByID: { ...state.itemsByID, [grantID]: action.grant },
+      };
+    }
+    case SAVE_GRANT.ERROR:
+      // Revert by invalidating so a re-fetch picks up the true server state
+      return { ...state, isInvalid: true };
+    case SAVE_GRANT.FINISH:
+      return { ...state, isSaving: false };
 
     case DELETE_GRANT.REQUEST:
       return { ...state, isDeleting: true };

--- a/src/modules/authz/reducers.js
+++ b/src/modules/authz/reducers.js
@@ -36,6 +36,7 @@ export const grants = (
   state = {
     data: [],
     itemsByID: {},
+    oldItemsByID: {},
     isFetching: false,
     isCreating: false,
     isSaving: false,
@@ -78,14 +79,22 @@ export const grants = (
         isSaving: true,
         // Optimistically update while we wait for the PUT response
         data: state.data.map((g) => (g.id === grantID ? action.grant : g)),
+        oldItemsByID: { ...state.oldItemsByID, [grantID]: state.itemsByID[grantID] },
         itemsByID: { ...state.itemsByID, [grantID]: action.grant },
       };
     }
-    case SAVE_GRANT.ERROR:
-      // Revert by invalidating so a re-fetch picks up the true server state
-      return { ...state, isInvalid: true };
+    case SAVE_GRANT.ERROR: {
+      const grantID = action.grant.id;
+      const oldItem = state.oldItemsByID[grantID];
+      return {
+        ...state,
+        data: state.data.map((g) => (g.id === grantID ? oldItem : g)),
+        oldItemsByID: objectWithoutProp(state.oldItemsByID, grantID),
+        itemsByID: { ...state.itemsByID, [grantID]: oldItem },
+      };
+    }
     case SAVE_GRANT.FINISH:
-      return { ...state, isSaving: false };
+      return { ...state, isSaving: false, oldItemsByID: {} };
 
     case DELETE_GRANT.REQUEST:
       return { ...state, isDeleting: true };


### PR DESCRIPTION
## Summary

- Adds an Edit button to the grants table that opens a pre-filled edit modal
- Implements `saveGrant` action using `PUT /grants/:id` with optimistic UI update in the reducer
- Fixes a bug in `PermissionsInput` where permissions were wiped on first modal open because the `currentResource` effect ran before the permissions list loaded, filtering all IDs to an empty array

## Changes

- **`GrantsTabContent.js`**: Added `GrantEditModal` component, edit state, and wired up the Edit button (previously commented out)
- **`actions.js`**: Added `SAVE_GRANT` action types and `saveGrant` action creator
- **`reducers.js`**: Added `isSaving` state and `SAVE_GRANT` reducer cases with optimistic update; on error, invalidates grants to trigger a re-fetch
- **`GrantForm.tsx`**: Accepts an `initialValues` prop passed as form-level `initialValues` (higher priority than field-level) to correctly pre-fill the edit form on first open; fixed `PermissionsInput` resource-change effect to guard against empty `permissionsByID`