### PR TITLE
reference genomes tab:fix link to gff3 tbi file

### DIFF
--- a/src/components/ReferenceGenomesContent.js
+++ b/src/components/ReferenceGenomesContent.js
@@ -108,8 +108,8 @@ const ReferenceGenomesContent = () => {
               <>
                 <br />
                 <strong>GFF3.gz TBI:</strong>&nbsp;
-                <a target="_blank" rel="noopener noreferrer" href={genome.gff3_gz}>
-                  {genome.gff3_gz}
+                <a target="_blank" rel="noopener noreferrer" href={genome.gff3_gz_tbi}>
+                  {genome.gff3_gz_tbi}
                 </a>
               </>
             )}


### PR DESCRIPTION
Fix link to gff3 tbi index file (currently just repeats the link to the gff3 file). 