### PR TITLE
refactor: unify dataset endpoints, drop _v2 suffix

### DIFF
--- a/src/components/ServiceContent.js
+++ b/src/components/ServiceContent.js
@@ -37,7 +37,7 @@ const ServiceContent = () => {
               <Spin spinning={isFetching}>
                 <Statistic
                   title="Datasets"
-                  value={isFetching ? EM_DASH : projects.flatMap((p) => p.datasets_v2).length}
+                  value={isFetching ? EM_DASH : projects.flatMap((p) => p.datasets).length}
                 />
               </Spin>
             </Col>

--- a/src/components/ServiceContent.js
+++ b/src/components/ServiceContent.js
@@ -35,10 +35,7 @@ const ServiceContent = () => {
             </Col>
             <Col md={12} lg={8} xl={3}>
               <Spin spinning={isFetching}>
-                <Statistic
-                  title="Datasets"
-                  value={isFetching ? EM_DASH : projects.flatMap((p) => p.datasets).length}
-                />
+                <Statistic title="Datasets" value={isFetching ? EM_DASH : projects.flatMap((p) => p.datasets).length} />
               </Spin>
             </Col>
           </Row>

--- a/src/components/explorer/ExplorerSearchContent.js
+++ b/src/components/explorer/ExplorerSearchContent.js
@@ -21,7 +21,7 @@ const ExplorerSearchContent = () => {
         // url: `/data/explorer/projects/${project.identifier}`,
         key: project.identifier,
         text: project.title,
-        children: project.datasets_v2.map((dataset) => ({
+        children: project.datasets.map((dataset) => ({
           url: `/data/explorer/search/${dataset.identifier}`,
           text: dataset.title,
         })),

--- a/src/components/manager/DatasetTreeSelect.js
+++ b/src/components/manager/DatasetTreeSelect.js
@@ -35,7 +35,7 @@ const DatasetTreeSelect = forwardRef(({ value, onChange, style, idFormat }, ref)
         selectable: false,
         key: p.identifier,
         value: p.identifier,
-        children: p.datasets_v2.map((d) => {
+        children: p.datasets.map((d) => {
           const key = idFormat === ID_FORMAT_PROJECT_DATASET ? `${p.identifier}:${d.identifier}` : d.identifier;
           return {
             title: d.title,

--- a/src/components/manager/access/GrantForm.tsx
+++ b/src/components/manager/access/GrantForm.tsx
@@ -315,7 +315,7 @@ const ResourceInput = ({ value, onChange }: ResourceInputProps) => {
 
     if (selectedProject) {
       options.push(
-        ...(selectedProject.datasets_v2 ?? []).map((d) => ({
+        ...(selectedProject.datasets ?? []).map((d) => ({
           value: d.identifier,
           label: d.title,
         })),

--- a/src/components/manager/projects/Project.js
+++ b/src/components/manager/projects/Project.js
@@ -69,7 +69,7 @@ const Project = ({
     (onCancelEdit || nop)();
   }, [editingForm, onCancelEdit]);
 
-  const datasets = value.datasets_v2 ?? [];
+  const datasets = value.datasets ?? [];
 
   return (
     <>

--- a/src/components/manager/projects/RoutedProject.js
+++ b/src/components/manager/projects/RoutedProject.js
@@ -40,7 +40,7 @@ const RoutedProject = () => {
 
   // Derive from live Redux state so the form reflects post-save data
   const datasetForEdit = selectedDataset
-    ? (project?.datasets_v2?.find((d) => d.identifier === selectedDataset.identifier) ?? selectedDataset)
+    ? (project?.datasets?.find((d) => d.identifier === selectedDataset.identifier) ?? selectedDataset)
     : selectedDataset;
 
   useEffect(() => {

--- a/src/modules/datasets/actions.js
+++ b/src/modules/datasets/actions.js
@@ -54,7 +54,7 @@ export const invalidateDatasetSummaries = (datasetID) => ({ type: INVALIDATE_DAT
 const fetchDatasetResources = networkAction((datasetID) => (_dispatch, getState) => ({
   types: FETCH_DATASET_RESOURCES,
   params: { datasetID },
-  url: `${getState().services.metadataService.url}/datasets_v2/${datasetID}/resources`,
+  url: `${getState().services.metadataService.url}/datasets/${datasetID}/resources`,
   err: "Error fetching dataset resources",
 }));
 export const fetchDatasetResourcesIfNecessary = (datasetID) => (dispatch, getState) => {

--- a/src/modules/datasets/actions.js
+++ b/src/modules/datasets/actions.js
@@ -10,16 +10,20 @@ export const INVALIDATE_DATASET_SUMMARIES = "INVALIDATE_DATASET_SUMMARIES";
 
 export const FETCH_DATASET_RESOURCES = createNetworkActionTypes("FETCH_DATASET_RESOURCES");
 
-const fetchDatasetDataTypesSummary = networkAction((serviceInfo, datasetID) => ({
+const fetchDatasetDataTypesSummary = networkAction((serviceInfo, datasetID, datasetsPath) => ({
   types: FETCH_DATASET_DATA_TYPES,
   params: { serviceInfo, datasetID },
-  url: `${serviceInfo.url}/datasets/${datasetID}/data-types`,
+  url: `${serviceInfo.url}/${datasetsPath}/${datasetID}/data-types`,
 }));
 
 export const fetchDatasetDataTypesIfPossible = (datasetID) => async (dispatch, getState) => {
   if (getState().datasetDataTypes.itemsByID?.[datasetID]?.isFetching) return;
+  const metadataUrl = getState().services.metadataService?.url;
   await Promise.all(
-    getDataServices(getState()).map((serviceInfo) => dispatch(fetchDatasetDataTypesSummary(serviceInfo, datasetID))),
+    getDataServices(getState()).map((serviceInfo) => {
+      const datasetsPath = serviceInfo.url === metadataUrl ? "api/datasets" : "datasets";
+      return dispatch(fetchDatasetDataTypesSummary(serviceInfo, datasetID, datasetsPath));
+    }),
   );
 };
 
@@ -33,18 +37,22 @@ export const fetchDatasetsDataTypes = () => async (dispatch, getState) => {
   dispatch(endFlow(FETCHING_DATASETS_DATA_TYPES));
 };
 
-const fetchServiceDatasetSummary = networkAction((serviceInfo, datasetID) => ({
+const fetchServiceDatasetSummary = networkAction((serviceInfo, datasetID, datasetsPath) => ({
   types: FETCH_SERVICE_DATASET_SUMMARY,
   params: { serviceInfo, datasetID },
-  url: `${serviceInfo.url}/datasets/${datasetID}/summary`,
+  url: `${serviceInfo.url}/${datasetsPath}/${datasetID}/summary`,
 }));
 
 export const fetchDatasetSummariesIfNeeded = (datasetID) => async (dispatch, getState) => {
   const existingSummaryState = getState().datasetSummaries.itemsByID[datasetID] ?? {};
   if (existingSummaryState.isFetching || (!existingSummaryState.isInvalid && existingSummaryState.hasAttempted)) return;
+  const metadataUrl = getState().services.metadataService?.url;
   dispatch(beginFlow(FETCHING_DATASET_SUMMARIES, { datasetID }));
   await Promise.all(
-    getDataServices(getState()).map((serviceInfo) => dispatch(fetchServiceDatasetSummary(serviceInfo, datasetID))),
+    getDataServices(getState()).map((serviceInfo) => {
+      const datasetsPath = serviceInfo.url === metadataUrl ? "api/datasets" : "datasets";
+      return dispatch(fetchServiceDatasetSummary(serviceInfo, datasetID, datasetsPath));
+    }),
   );
   dispatch(endFlow(FETCHING_DATASET_SUMMARIES, { datasetID }));
 };
@@ -54,7 +62,7 @@ export const invalidateDatasetSummaries = (datasetID) => ({ type: INVALIDATE_DAT
 const fetchDatasetResources = networkAction((datasetID) => (_dispatch, getState) => ({
   types: FETCH_DATASET_RESOURCES,
   params: { datasetID },
-  url: `${getState().services.metadataService.url}/datasets/${datasetID}/resources`,
+  url: `${getState().services.metadataService.url}/api/datasets/${datasetID}/resources`,
   err: "Error fetching dataset resources",
 }));
 export const fetchDatasetResourcesIfNecessary = (datasetID) => (dispatch, getState) => {

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -45,13 +45,10 @@ export const fetchDiscoverySchema = () => (dispatch, getState) => {
 
 export const clearDatasetDataType = networkAction((datasetId, dataTypeID) => (_dispatch, getState) => {
   const { service_base_url: serviceBaseUrl } = getState().serviceDataTypes.itemsByID[dataTypeID];
-  const metadataServiceUrl = getState().services.metadataService?.url ?? "";
-  const datasetsSegment =
-    metadataServiceUrl && serviceBaseUrl.startsWith(metadataServiceUrl) ? "datasets_v2" : "datasets";
   // noinspection JSUnusedGlobalSymbols
   return {
     types: DELETE_DATASET_DATA_TYPE,
-    url: `${serviceBaseUrl}${datasetsSegment}/${datasetId}/data-types/${dataTypeID}`,
+    url: `${serviceBaseUrl}datasets/${datasetId}/data-types/${dataTypeID}`,
     req: {
       method: "DELETE",
     },
@@ -149,7 +146,7 @@ export const deleteProjectIfPossible = (project) => async (dispatch, getState) =
 
   // Remove data without destroying project/datasets first
   try {
-    await Promise.all(project.datasets_v2.map((ds) => dispatch(clearDatasetDataTypes(ds.identifier))));
+    await Promise.all(project.datasets.map((ds) => dispatch(clearDatasetDataTypes(ds.identifier))));
     await dispatch(deleteProject(project));
   } catch (err) {
     console.error(err);

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -180,7 +180,7 @@ export const saveProjectIfPossible = networkAction((project) => (dispatch, getSt
 
 export const addProjectDataset = networkAction((project, dataset, onSuccess = nop) => (_dispatch, getState) => ({
   types: ADD_PROJECT_DATASET,
-  url: `${getState().services.metadataService.url}/api/datasets_v2`,
+  url: `${getState().services.metadataService.url}/api/datasets`,
   req: jsonRequest({ ...dataset, project: project.identifier }, "POST"),
   err: `Error adding dataset to project '${project.title}'`, // TODO: More user-friendly error
   // TODO: END ACTION?
@@ -192,7 +192,7 @@ export const addProjectDataset = networkAction((project, dataset, onSuccess = no
 
 export const saveProjectDataset = networkAction((dataset, onSuccess = nop) => (_dispatch, getState) => ({
   types: SAVE_PROJECT_DATASET,
-  url: `${getState().services.metadataService.url}/api/datasets_v2/${dataset.identifier}`,
+  url: `${getState().services.metadataService.url}/api/datasets/${dataset.identifier}`,
   // Filter out read-only props
   // TODO: PATCH
   req: jsonRequest(objectWithoutProps(dataset, ["identifier", "created", "updated"]), "PUT"),
@@ -206,7 +206,7 @@ export const saveProjectDataset = networkAction((dataset, onSuccess = nop) => (_
 export const deleteProjectDataset = networkAction((project, dataset) => (_dispatch, getState) => ({
   types: DELETE_PROJECT_DATASET,
   params: { project, dataset },
-  url: `${getState().services.metadataService.url}/api/datasets_v2/${dataset.identifier}`,
+  url: `${getState().services.metadataService.url}/api/datasets/${dataset.identifier}`,
   req: { method: "DELETE" },
   err: `Error deleting dataset '${dataset.title}'`,
 }));
@@ -229,7 +229,7 @@ export const deleteProjectDatasetIfPossible = (project, dataset) => async (dispa
 
 const addDatasetLinkedFieldSet = networkAction((dataset, linkedFieldSet, onSuccess) => (_dispatch, getState) => ({
   types: ADD_DATASET_LINKED_FIELD_SET,
-  url: `${getState().services.metadataService.url}/api/datasets_v2/${dataset.identifier}`,
+  url: `${getState().services.metadataService.url}/api/datasets/${dataset.identifier}`,
   req: jsonRequest({ linked_field_sets: [...(dataset.linked_field_sets ?? []), linkedFieldSet] }, "PATCH"),
   err: `Error adding linked field set '${linkedFieldSet.name}' to dataset '${dataset.title}'`,
   onSuccess: async () => {
@@ -253,7 +253,7 @@ export const addDatasetLinkedFieldSetIfPossible =
 const saveDatasetLinkedFieldSet = networkAction(
   (dataset, index, linkedFieldSet, onSuccess) => (_dispatch, getState) => ({
     types: SAVE_DATASET_LINKED_FIELD_SET,
-    url: `${getState().services.metadataService.url}/api/datasets_v2/${dataset.identifier}`,
+    url: `${getState().services.metadataService.url}/api/datasets/${dataset.identifier}`,
     req: jsonRequest(
       {
         linked_field_sets: dataset.linked_field_sets.map((l, i) => (i === index ? linkedFieldSet : l)),
@@ -284,7 +284,7 @@ export const saveDatasetLinkedFieldSetIfPossible =
 const deleteDatasetLinkedFieldSet = networkAction(
   (dataset, linkedFieldSet, linkedFieldSetIndex) => (_dispatch, getState) => ({
     types: DELETE_DATASET_LINKED_FIELD_SET,
-    url: `${getState().services.metadataService.url}/api/datasets_v2/${dataset.identifier}`,
+    url: `${getState().services.metadataService.url}/api/datasets/${dataset.identifier}`,
     req: jsonRequest(
       {
         linked_field_sets: dataset.linked_field_sets.filter((_, i) => i !== linkedFieldSetIndex),

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -45,10 +45,13 @@ export const fetchDiscoverySchema = () => (dispatch, getState) => {
 
 export const clearDatasetDataType = networkAction((datasetId, dataTypeID) => (_dispatch, getState) => {
   const { service_base_url: serviceBaseUrl } = getState().serviceDataTypes.itemsByID[dataTypeID];
+  const metadataServiceUrl = getState().services.metadataService?.url ?? "";
+  const datasetsPath =
+    metadataServiceUrl && serviceBaseUrl.startsWith(metadataServiceUrl) ? "api/datasets" : "datasets";
   // noinspection JSUnusedGlobalSymbols
   return {
     types: DELETE_DATASET_DATA_TYPE,
-    url: `${serviceBaseUrl}datasets/${datasetId}/data-types/${dataTypeID}`,
+    url: `${serviceBaseUrl}${datasetsPath}/${datasetId}/data-types/${dataTypeID}`,
     req: {
       method: "DELETE",
     },

--- a/src/modules/metadata/reducers.ts
+++ b/src/modules/metadata/reducers.ts
@@ -81,7 +81,7 @@ export const projects: Reducer<ProjectsState> = (
     case FETCH_PROJECTS.RECEIVE: {
       const projects = [...(action.data as Project[])].sort(projectSort);
       const datasets: ProjectScopedDatasetModel[] = projects.flatMap((p: Project) =>
-        (p.datasets_v2 ?? []).map((d: DatasetModel) => ({ ...d, project: p.identifier })),
+        (p.datasets ?? []).map((d: DatasetModel) => ({ ...d, project: p.identifier })),
       );
       return {
         ...state,
@@ -164,13 +164,13 @@ export const projects: Reducer<ProjectsState> = (
         ...state,
         isAddingDataset: false,
         items: state.items.map((p) =>
-          p.identifier === projectID ? { ...p, datasets_v2: [...(p.datasets_v2 ?? []), newDataset] } : p,
+          p.identifier === projectID ? { ...p, datasets: [...(p.datasets ?? []), newDataset] } : p,
         ),
         itemsByID: {
           ...state.itemsByID,
           [projectID]: {
             ...(state.itemsByID[projectID] || {}),
-            datasets_v2: [...(state.itemsByID[projectID]?.datasets_v2 ?? []), newDataset],
+            datasets: [...(state.itemsByID[projectID]?.datasets ?? []), newDataset],
           },
         },
         datasets: [...state.datasets, newDataset],
@@ -196,14 +196,14 @@ export const projects: Reducer<ProjectsState> = (
         ...state,
         items: state.items.map((p) =>
           p.identifier === deletedProject.identifier
-            ? { ...p, datasets_v2: (p.datasets_v2 ?? []).filter(deleteDataset) }
+            ? { ...p, datasets: (p.datasets ?? []).filter(deleteDataset) }
             : p,
         ),
         itemsByID: {
           ...state.itemsByID,
           [deletedProject.identifier]: {
             ...(state.itemsByID[deletedProject.identifier] || {}),
-            datasets_v2: ((state.itemsByID[deletedProject.identifier] || {}).datasets_v2 ?? []).filter(deleteDataset),
+            datasets: ((state.itemsByID[deletedProject.identifier] || {}).datasets ?? []).filter(deleteDataset),
           },
         },
         datasets: state.datasets.filter((d) => d.identifier !== deletedDataset.identifier),
@@ -233,14 +233,14 @@ export const projects: Reducer<ProjectsState> = (
         ...state,
         items: state.items.map((p) =>
           p.identifier === updatedDataset.project
-            ? { ...p, datasets_v2: (p.datasets_v2 ?? []).map(replaceDataset) }
+            ? { ...p, datasets: (p.datasets ?? []).map(replaceDataset) }
             : p,
         ),
         itemsByID: {
           ...state.itemsByID,
           [updatedDataset.project]: {
             ...(state.itemsByID[updatedDataset.project] || {}),
-            datasets_v2: ((state.itemsByID[updatedDataset.project] || {}).datasets_v2 ?? []).map(replaceDataset),
+            datasets: ((state.itemsByID[updatedDataset.project] || {}).datasets ?? []).map(replaceDataset),
           },
         },
       };

--- a/src/modules/metadata/reducers.ts
+++ b/src/modules/metadata/reducers.ts
@@ -195,9 +195,7 @@ export const projects: Reducer<ProjectsState> = (
       return {
         ...state,
         items: state.items.map((p) =>
-          p.identifier === deletedProject.identifier
-            ? { ...p, datasets: (p.datasets ?? []).filter(deleteDataset) }
-            : p,
+          p.identifier === deletedProject.identifier ? { ...p, datasets: (p.datasets ?? []).filter(deleteDataset) } : p,
         ),
         itemsByID: {
           ...state.itemsByID,
@@ -232,9 +230,7 @@ export const projects: Reducer<ProjectsState> = (
       return {
         ...state,
         items: state.items.map((p) =>
-          p.identifier === updatedDataset.project
-            ? { ...p, datasets: (p.datasets ?? []).map(replaceDataset) }
-            : p,
+          p.identifier === updatedDataset.project ? { ...p, datasets: (p.datasets ?? []).map(replaceDataset) } : p,
         ),
         itemsByID: {
           ...state.itemsByID,

--- a/src/modules/metadata/types.ts
+++ b/src/modules/metadata/types.ts
@@ -18,7 +18,7 @@ export type Project = {
   description: string;
 
   project_schemas?: ProjectJSONSchema[];
-  datasets_v2: DatasetModel[];
+  datasets: DatasetModel[];
 
   created: string; // ISO timestamp string
   updated: string; // ISO timestamp string


### PR DESCRIPTION
## Summary 
**Redmine ticket**: [2833](https://redmine.c3g-app.sd4h.ca/issues/2833)
- Migrated all dataset API calls from `_v2` endpoints (`/api/datasets_v2`, `/datasets_v2`) to unified `/api/datasets` and `/datasets` endpoints
- Renamed `datasets_v2` project field references to `datasets` across components, reducers, and types
- Simplified `clearDatasetDataType` URL logic — removed branching that selected `datasets_v2` vs `datasets` based on service URL, now always uses `datasets`

**Requires https://github.com/bento-platform/katsu/pull/704**