### PR TITLE
feat(datasets): French translation upload and provenance export

### DIFF
--- a/src/api/datasetTranslations.ts
+++ b/src/api/datasetTranslations.ts
@@ -27,6 +27,24 @@ export async function fetchTranslation(
   }
 }
 
+export async function deleteTranslation(
+  baseUrl: string,
+  datasetId: string,
+  lang: string,
+  authHeader: Record<string, string>,
+): Promise<{ ok: true } | { ok: false; status: number }> {
+  try {
+    const res = await fetch(translationsUrl(baseUrl, datasetId, lang), {
+      method: "DELETE",
+      headers: { Accept: "application/json", ...authHeader },
+    });
+    if (res.ok) return { ok: true };
+    return { ok: false, status: res.status };
+  } catch {
+    return { ok: false, status: 0 };
+  }
+}
+
 export async function upsertTranslation(
   baseUrl: string,
   datasetId: string,

--- a/src/api/datasetTranslations.ts
+++ b/src/api/datasetTranslations.ts
@@ -13,10 +13,11 @@ export async function fetchTranslation(
   baseUrl: string,
   datasetId: string,
   lang: string,
+  authHeader: Record<string, string>,
 ): Promise<{ exists: true; data: DatasetModelBase } | { exists: false } | { exists: null; error: string }> {
   try {
     const res = await fetch(translationsUrl(baseUrl, datasetId, lang), {
-      headers: { Accept: "application/json" },
+      headers: { Accept: "application/json", ...authHeader },
     });
     if (res.ok) return { exists: true, data: (await res.json()) as DatasetModelBase };
     if (res.status === 404) return { exists: false };
@@ -32,11 +33,12 @@ export async function upsertTranslation(
   lang: string,
   payload: DatasetModelBase,
   isEdit: boolean,
+  authHeader: Record<string, string>,
 ): Promise<TranslationApiResult> {
   try {
     const res = await fetch(translationsUrl(baseUrl, datasetId, isEdit ? lang : undefined), {
       method: isEdit ? "PUT" : "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeader },
       body: JSON.stringify({ ...payload, language: lang }),
     });
     if (res.ok) return { ok: true, data: (await res.json()) as DatasetModelBase };

--- a/src/api/datasetTranslations.ts
+++ b/src/api/datasetTranslations.ts
@@ -57,7 +57,7 @@ export async function upsertTranslation(
     const res = await fetch(translationsUrl(baseUrl, datasetId, isEdit ? lang : undefined), {
       method: isEdit ? "PUT" : "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeader },
-      body: JSON.stringify({ ...payload, language: lang }),
+      body: JSON.stringify(payload),
     });
     if (res.ok) return { ok: true, data: (await res.json()) as DatasetModelBase };
     if (res.status === 400) {

--- a/src/api/datasetTranslations.ts
+++ b/src/api/datasetTranslations.ts
@@ -1,0 +1,51 @@
+import type { DatasetModelBase } from "@/types/dataset";
+
+export type DRFErrors = Record<string, string[]>;
+
+export type TranslationApiResult =
+  | { ok: true; data: DatasetModelBase }
+  | { ok: false; status: number; drfErrors?: DRFErrors };
+
+const translationsUrl = (baseUrl: string, datasetId: string, lang?: string) =>
+  `${baseUrl}/api/datasets/${datasetId}/translations${lang ? `/${lang}` : ""}`;
+
+export async function fetchTranslation(
+  baseUrl: string,
+  datasetId: string,
+  lang: string,
+): Promise<{ exists: true; data: DatasetModelBase } | { exists: false } | { exists: null; error: string }> {
+  try {
+    const res = await fetch(translationsUrl(baseUrl, datasetId, lang), {
+      headers: { Accept: "application/json" },
+    });
+    if (res.ok) return { exists: true, data: (await res.json()) as DatasetModelBase };
+    if (res.status === 404) return { exists: false };
+    return { exists: null, error: `HTTP ${res.status}` };
+  } catch {
+    return { exists: null, error: "Network error" };
+  }
+}
+
+export async function upsertTranslation(
+  baseUrl: string,
+  datasetId: string,
+  lang: string,
+  payload: DatasetModelBase,
+  isEdit: boolean,
+): Promise<TranslationApiResult> {
+  try {
+    const res = await fetch(translationsUrl(baseUrl, datasetId, isEdit ? lang : undefined), {
+      method: isEdit ? "PUT" : "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ ...payload, language: lang }),
+    });
+    if (res.ok) return { ok: true, data: (await res.json()) as DatasetModelBase };
+    if (res.status === 400) {
+      const drfErrors = (await res.json()) as DRFErrors;
+      return { ok: false, status: 400, drfErrors };
+    }
+    return { ok: false, status: res.status };
+  } catch {
+    return { ok: false, status: 0 };
+  }
+}

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -3,12 +3,7 @@ import PropTypes from "prop-types";
 
 import { App, Button, Card, Col, Divider, Empty, Row, Typography } from "antd";
 
-import {
-  DeleteOutlined,
-  EditOutlined,
-  FileSearchOutlined,
-  PlusOutlined,
-} from "@ant-design/icons";
+import { DeleteOutlined, EditOutlined, FileSearchOutlined, PlusOutlined } from "@ant-design/icons";
 
 import {
   addDatasetLinkedFieldSetIfPossible,
@@ -18,7 +13,6 @@ import {
 
 import { fetchDatasetDataTypesIfPossible, fetchDatasetSummariesIfNeeded } from "@/modules/datasets/actions";
 
-import { nop } from "@/utils/misc";
 import LinkedFieldSetTable from "./linked_field_set/LinkedFieldSetTable";
 import LinkedFieldSetModal from "./linked_field_set/LinkedFieldSetModal";
 import { FORM_MODE_ADD, FORM_MODE_EDIT } from "@/constants";

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -221,7 +221,7 @@ const Dataset = ({ project, value }) => {
             style={{ marginRight: "8px" }}
             onClick={() => setProvenanceModalVisible(true)}
           >
-            Provenance
+            Edit/View Properties
           </Button>
           <Button danger={true} icon={<DeleteOutlined />} onClick={handleDelete}>
             Delete

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -221,7 +221,7 @@ const Dataset = ({ project, value }) => {
             style={{ marginRight: "8px" }}
             onClick={() => setProvenanceModalVisible(true)}
           >
-            Edit/View Properties
+            Dataset Properties
           </Button>
           <Button danger={true} icon={<DeleteOutlined />} onClick={handleDelete}>
             Delete

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -1,9 +1,17 @@
 import { useCallback, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 
-import { App, Button, Card, Col, Divider, Empty, Row, Typography } from "antd";
+import { App, Button, Card, Col, Divider, Dropdown, Empty, Row, Typography } from "antd";
 
-import { DeleteOutlined, EditOutlined, FileSearchOutlined, GlobalOutlined, PlusOutlined } from "@ant-design/icons";
+import {
+  DeleteOutlined,
+  DownloadOutlined,
+  DownOutlined,
+  EditOutlined,
+  FileSearchOutlined,
+  GlobalOutlined,
+  PlusOutlined,
+} from "@ant-design/icons";
 
 import {
   addDatasetLinkedFieldSetIfPossible,
@@ -22,7 +30,8 @@ import DatasetOverview from "./DatasetOverview";
 import DatasetDataTypes from "./DatasetDataTypes";
 import DatasetProvenanceModal from "./DatasetProvenanceModal";
 import DatasetTranslationModal from "./DatasetTranslationModal";
-import { useAppDispatch } from "@/store";
+import { fetchTranslation } from "@/api/datasetTranslations";
+import { useAppDispatch, useAppSelector } from "@/store";
 
 const DATASET_CARD_TABS = [
   { key: "overview", tab: "Overview" },
@@ -40,14 +49,16 @@ const DEFAULT_BIOSAMPLE_LFS = {
 };
 
 const Dataset = ({ mode, project, value, onEdit }) => {
-  const { modal } = App.useApp();
+  const { modal, message } = App.useApp();
   const dispatch = useAppDispatch();
+  const metadataUrl = useAppSelector((state) => state.services.metadataService?.url ?? "");
 
   const identifier = value?.identifier ?? null;
   const title = value?.title ?? "";
   const linkedFieldSets = value?.linked_field_sets ?? [];
   const [provenanceModalVisible, setProvenanceModalVisible] = useState(false);
   const [translationModalVisible, setTranslationModalVisible] = useState(false);
+  const [exportingFr, setExportingFr] = useState(false);
   const [fieldSetAdditionModalVisible, setFieldSetAdditionModalVisible] = useState(false);
   const [fieldSetEditModalVisible, setFieldSetEditModalVisible] = useState(false);
   const [selectedLinkedFieldSet, setSelectedLinkedFieldSet] = useState({ data: null, index: null });
@@ -111,6 +122,41 @@ const Dataset = ({ mode, project, value, onEdit }) => {
       },
     });
   }, [dispatch, modal, project, title, value]);
+
+  const downloadJson = useCallback((data, filename) => {
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, []);
+
+  const handleExport = useCallback(
+    async ({ key }) => {
+      if (key === "en") {
+        downloadJson(value, `${identifier}-en.json`);
+      } else if (key === "fr") {
+        setExportingFr(true);
+        const result = await fetchTranslation(metadataUrl, identifier, "fr");
+        setExportingFr(false);
+        if (result.exists === true) {
+          downloadJson(result.data, `${identifier}-fr.json`);
+        } else if (result.exists === false) {
+          message.warning("No French translation exists for this dataset.");
+        } else {
+          message.error(`Failed to fetch French translation: ${result.error}`);
+        }
+      }
+    },
+    [downloadJson, identifier, message, metadataUrl, value],
+  );
+
+  const exportMenuItems = [
+    { key: "en", label: "English (canonical)" },
+    { key: "fr", label: "French translation" },
+  ];
 
   const isPrivate = mode === "private";
   const defaultBiosampleLFSDisabled = linkedFieldSets.length !== 0;
@@ -234,6 +280,11 @@ const Dataset = ({ mode, project, value, onEdit }) => {
           >
             View Provenance
           </Button>
+          <Dropdown menu={{ items: exportMenuItems, onClick: handleExport }} trigger={["click"]} disabled={exportingFr}>
+            <Button icon={<DownloadOutlined />} loading={exportingFr} style={{ marginRight: "8px" }}>
+              Export <DownOutlined />
+            </Button>
+          </Dropdown>
           {isPrivate && (
             <>
               <Button

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -58,6 +58,7 @@ const Dataset = ({ mode, project, value, onEdit }) => {
   const linkedFieldSets = value?.linked_field_sets ?? [];
   const [provenanceModalVisible, setProvenanceModalVisible] = useState(false);
   const [translationModalVisible, setTranslationModalVisible] = useState(false);
+  const [frTranslationStatus, setFrTranslationStatus] = useState("loading"); // "loading" | "exists" | "missing" | "error"
   const [exportingFr, setExportingFr] = useState(false);
   const [fieldSetAdditionModalVisible, setFieldSetAdditionModalVisible] = useState(false);
   const [fieldSetEditModalVisible, setFieldSetEditModalVisible] = useState(false);
@@ -70,6 +71,20 @@ const Dataset = ({ mode, project, value, onEdit }) => {
       dispatch(fetchDatasetDataTypesIfPossible(identifier));
     }
   }, [dispatch, identifier]);
+
+  const checkFrTranslation = useCallback(() => {
+    if (!identifier || !metadataUrl) return;
+    setFrTranslationStatus("loading");
+    fetchTranslation(metadataUrl, identifier, "fr").then((result) => {
+      if (result.exists === true) setFrTranslationStatus("exists");
+      else if (result.exists === false) setFrTranslationStatus("missing");
+      else setFrTranslationStatus("error");
+    });
+  }, [identifier, metadataUrl]);
+
+  useEffect(() => {
+    checkFrTranslation();
+  }, [checkFrTranslation]);
 
   const handleFieldSetDeletion = useCallback(
     (fieldSet, index) => {
@@ -290,9 +305,10 @@ const Dataset = ({ mode, project, value, onEdit }) => {
               <Button
                 icon={<GlobalOutlined />}
                 style={{ marginRight: "8px" }}
+                loading={frTranslationStatus === "loading"}
                 onClick={() => setTranslationModalVisible(true)}
               >
-                French Translation
+                {frTranslationStatus === "exists" ? "Edit French Translation" : "Add French Translation"}
               </Button>
               <Button icon={<EditOutlined />} style={{ marginRight: "8px" }} onClick={() => (onEdit || nop)()}>
                 Edit
@@ -315,7 +331,10 @@ const Dataset = ({ mode, project, value, onEdit }) => {
         <DatasetTranslationModal
           dataset={value}
           open={translationModalVisible}
-          onClose={() => setTranslationModalVisible(false)}
+          onClose={() => {
+            setTranslationModalVisible(false);
+            checkFrTranslation();
+          }}
         />
       )}
       {isPrivate ? (

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -43,7 +43,7 @@ const DEFAULT_BIOSAMPLE_LFS = {
   },
 };
 
-const Dataset = ({ mode, project, value }) => {
+const Dataset = ({ project, value }) => {
   const { modal } = App.useApp();
   const dispatch = useAppDispatch();
 
@@ -116,37 +116,34 @@ const Dataset = ({ mode, project, value }) => {
     });
   }, [dispatch, modal, project, title, value]);
 
-  const isPrivate = mode === "private";
   const defaultBiosampleLFSDisabled = linkedFieldSets.length !== 0;
 
   const tabContents = {
-    overview: <DatasetOverview dataset={value} project={project} isPrivate={isPrivate} />,
-    data_types: <DatasetDataTypes dataset={value} project={project} isPrivate={isPrivate} />,
+    overview: <DatasetOverview dataset={value} />,
+    data_types: <DatasetDataTypes dataset={value} project={project} />,
     linked_field_sets: (
       <>
         <Typography.Title level={4} style={{ marginTop: 0 }}>
           Linked Field Sets
-          {isPrivate ? (
-            <div style={{ float: "right", display: "flex", flexDirection: "column", gap: "10px" }}>
-              <Button
-                icon={<PlusOutlined />}
-                style={{ verticalAlign: "top" }}
-                type="primary"
-                onClick={() => setFieldSetAdditionModalVisible(true)}
-              >
-                Add Linked Field Set
-              </Button>
-              <Button
-                icon={<PlusOutlined />}
-                style={{ verticalAlign: "top" }}
-                type="default"
-                disabled={defaultBiosampleLFSDisabled}
-                onClick={() => dispatch(addDatasetLinkedFieldSetIfPossible(value, DEFAULT_BIOSAMPLE_LFS))}
-              >
-                Default Biosample Field Set
-              </Button>
-            </div>
-          ) : null}
+          <div style={{ float: "right", display: "flex", flexDirection: "column", gap: "10px" }}>
+            <Button
+              icon={<PlusOutlined />}
+              style={{ verticalAlign: "top" }}
+              type="primary"
+              onClick={() => setFieldSetAdditionModalVisible(true)}
+            >
+              Add Linked Field Set
+            </Button>
+            <Button
+              icon={<PlusOutlined />}
+              style={{ verticalAlign: "top" }}
+              type="default"
+              disabled={defaultBiosampleLFSDisabled}
+              onClick={() => dispatch(addDatasetLinkedFieldSetIfPossible(value, DEFAULT_BIOSAMPLE_LFS))}
+            >
+              Default Biosample Field Set
+            </Button>
+          </div>
         </Typography.Title>
         <Typography.Paragraph style={{ maxWidth: "600px" }}>
           Linked Field Sets group common fields (i.e. fields that share the same &ldquo;value space&rdquo;) between
@@ -162,11 +159,9 @@ const Dataset = ({ mode, project, value }) => {
           <>
             <Divider />
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No Field Link Sets">
-              {isPrivate ? (
-                <Button icon={<PlusOutlined />} type="primary" onClick={() => setFieldSetAdditionModalVisible(true)}>
-                  Add Field Link Set
-                </Button>
-              ) : null}
+              <Button icon={<PlusOutlined />} type="primary" onClick={() => setFieldSetAdditionModalVisible(true)}>
+                Add Field Link Set
+              </Button>
             </Empty>
           </>
         ) : (
@@ -175,24 +170,20 @@ const Dataset = ({ mode, project, value }) => {
               <Col key={i} lg={24} xl={12}>
                 <Card
                   title={`${i + 1}. ${fieldSet.name}`}
-                  actions={
-                    isPrivate
-                      ? [
-                          <span
-                            key="edit"
-                            onClick={() => {
-                              setSelectedLinkedFieldSet({ data: fieldSet, index: i });
-                              setFieldSetEditModalVisible(true);
-                            }}
-                          >
-                            <EditOutlined style={{ width: "auto", display: "inline" }} /> Manage Fields
-                          </span>,
-                          <span key="delete" onClick={() => handleFieldSetDeletion(fieldSet, i)}>
-                            <DeleteOutlined style={{ width: "auto", display: "inline" }} /> Delete Set
-                          </span>,
-                        ]
-                      : []
-                  }
+                  actions={[
+                    <span
+                      key="edit"
+                      onClick={() => {
+                        setSelectedLinkedFieldSet({ data: fieldSet, index: i });
+                        setFieldSetEditModalVisible(true);
+                      }}
+                    >
+                      <EditOutlined style={{ width: "auto", display: "inline" }} /> Manage Fields
+                    </span>,
+                    <span key="delete" onClick={() => handleFieldSetDeletion(fieldSet, i)}>
+                      <DeleteOutlined style={{ width: "auto", display: "inline" }} /> Delete Set
+                    </span>,
+                  ]}
                 >
                   <LinkedFieldSetTable linkedFieldSet={fieldSet} />
                 </Card>
@@ -238,48 +229,39 @@ const Dataset = ({ mode, project, value }) => {
           >
             Provenance
           </Button>
-          {isPrivate && (
-            <Button danger={true} icon={<DeleteOutlined />} onClick={handleDelete}>
-              Delete
-            </Button>
-          )}
+          <Button danger={true} icon={<DeleteOutlined />} onClick={handleDelete}>
+            Delete
+          </Button>
         </>
       }
     >
       <DatasetProvenanceModal
         dataset={value}
         open={provenanceModalVisible}
-        isPrivate={isPrivate}
         onClose={() => setProvenanceModalVisible(false)}
       />
-      {isPrivate ? (
-        <>
-          <LinkedFieldSetModal
-            mode={FORM_MODE_ADD}
-            dataset={value}
-            open={fieldSetAdditionModalVisible}
-            onSubmit={() => setFieldSetAdditionModalVisible(false)}
-            onCancel={() => setFieldSetAdditionModalVisible(false)}
-          />
-
-          <LinkedFieldSetModal
-            mode={FORM_MODE_EDIT}
-            dataset={value}
-            open={fieldSetEditModalVisible}
-            linkedFieldSet={selectedLinkedFieldSet.data}
-            linkedFieldSetIndex={selectedLinkedFieldSet.index}
-            onSubmit={() => setFieldSetEditModalVisible(false)}
-            onCancel={() => setFieldSetEditModalVisible(false)}
-          />
-        </>
-      ) : null}
+      <LinkedFieldSetModal
+        mode={FORM_MODE_ADD}
+        dataset={value}
+        open={fieldSetAdditionModalVisible}
+        onSubmit={() => setFieldSetAdditionModalVisible(false)}
+        onCancel={() => setFieldSetAdditionModalVisible(false)}
+      />
+      <LinkedFieldSetModal
+        mode={FORM_MODE_EDIT}
+        dataset={value}
+        open={fieldSetEditModalVisible}
+        linkedFieldSet={selectedLinkedFieldSet.data}
+        linkedFieldSetIndex={selectedLinkedFieldSet.index}
+        onSubmit={() => setFieldSetEditModalVisible(false)}
+        onCancel={() => setFieldSetEditModalVisible(false)}
+      />
       {tabContents[selectedTab]}
     </Card>
   );
 };
 
 Dataset.propTypes = {
-  mode: PropTypes.string,
   project: PropTypes.object,
   value: PropTypes.shape({
     identifier: PropTypes.string,

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import { App, Button, Card, Col, Divider, Empty, Row, Typography } from "antd";
 
-import { DeleteOutlined, EditOutlined, FileSearchOutlined, PlusOutlined } from "@ant-design/icons";
+import { DeleteOutlined, EditOutlined, FileSearchOutlined, GlobalOutlined, PlusOutlined } from "@ant-design/icons";
 
 import {
   addDatasetLinkedFieldSetIfPossible,
@@ -21,6 +21,7 @@ import { FORM_MODE_ADD, FORM_MODE_EDIT } from "@/constants";
 import DatasetOverview from "./DatasetOverview";
 import DatasetDataTypes from "./DatasetDataTypes";
 import DatasetProvenanceModal from "./DatasetProvenanceModal";
+import DatasetTranslationModal from "./DatasetTranslationModal";
 import { useAppDispatch } from "@/store";
 
 const DATASET_CARD_TABS = [
@@ -46,6 +47,7 @@ const Dataset = ({ mode, project, value, onEdit }) => {
   const title = value?.title ?? "";
   const linkedFieldSets = value?.linked_field_sets ?? [];
   const [provenanceModalVisible, setProvenanceModalVisible] = useState(false);
+  const [translationModalVisible, setTranslationModalVisible] = useState(false);
   const [fieldSetAdditionModalVisible, setFieldSetAdditionModalVisible] = useState(false);
   const [fieldSetEditModalVisible, setFieldSetEditModalVisible] = useState(false);
   const [selectedLinkedFieldSet, setSelectedLinkedFieldSet] = useState({ data: null, index: null });
@@ -234,6 +236,13 @@ const Dataset = ({ mode, project, value, onEdit }) => {
           </Button>
           {isPrivate && (
             <>
+              <Button
+                icon={<GlobalOutlined />}
+                style={{ marginRight: "8px" }}
+                onClick={() => setTranslationModalVisible(true)}
+              >
+                French Translation
+              </Button>
               <Button icon={<EditOutlined />} style={{ marginRight: "8px" }} onClick={() => (onEdit || nop)()}>
                 Edit
               </Button>
@@ -251,6 +260,13 @@ const Dataset = ({ mode, project, value, onEdit }) => {
         open={provenanceModalVisible}
         onClose={() => setProvenanceModalVisible(false)}
       />
+      {isPrivate && value && (
+        <DatasetTranslationModal
+          dataset={value}
+          open={translationModalVisible}
+          onClose={() => setTranslationModalVisible(false)}
+        />
+      )}
       {isPrivate ? (
         <>
           <LinkedFieldSetModal

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -1,15 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 
-import { App, Button, Card, Col, Divider, Dropdown, Empty, Row, Typography } from "antd";
+import { App, Button, Card, Col, Divider, Empty, Row, Typography } from "antd";
 
 import {
   DeleteOutlined,
-  DownloadOutlined,
-  DownOutlined,
   EditOutlined,
   FileSearchOutlined,
-  GlobalOutlined,
   PlusOutlined,
 } from "@ant-design/icons";
 
@@ -29,12 +26,7 @@ import { FORM_MODE_ADD, FORM_MODE_EDIT } from "@/constants";
 import DatasetOverview from "./DatasetOverview";
 import DatasetDataTypes from "./DatasetDataTypes";
 import DatasetProvenanceModal from "./DatasetProvenanceModal";
-import DatasetTranslationModal from "./DatasetTranslationModal";
-import { useAuthorizationHeader } from "bento-auth-js";
-
-import { fetchTranslation } from "@/api/datasetTranslations";
-import { fetchProjectsWithDatasets } from "@/modules/metadata/actions";
-import { useAppDispatch, useAppSelector } from "@/store";
+import { useAppDispatch } from "@/store";
 
 const DATASET_CARD_TABS = [
   { key: "overview", tab: "Overview" },
@@ -52,19 +44,14 @@ const DEFAULT_BIOSAMPLE_LFS = {
 };
 
 const Dataset = ({ mode, project, value }) => {
-  const { modal, message } = App.useApp();
+  const { modal } = App.useApp();
   const dispatch = useAppDispatch();
-  const metadataUrl = useAppSelector((state) => state.services.metadataService?.url ?? "");
-  const authHeader = useAuthorizationHeader();
 
   const identifier = value?.identifier ?? null;
   const title = value?.title ?? "";
   const linkedFieldSets = value?.linked_field_sets ?? [];
-  const hasFrTranslation = (value?.translations ?? []).includes("fr");
 
   const [provenanceModalVisible, setProvenanceModalVisible] = useState(false);
-  const [translationModalVisible, setTranslationModalVisible] = useState(false);
-  const [exportingFr, setExportingFr] = useState(false);
   const [fieldSetAdditionModalVisible, setFieldSetAdditionModalVisible] = useState(false);
   const [fieldSetEditModalVisible, setFieldSetEditModalVisible] = useState(false);
   const [selectedLinkedFieldSet, setSelectedLinkedFieldSet] = useState({ data: null, index: null });
@@ -128,41 +115,6 @@ const Dataset = ({ mode, project, value }) => {
       },
     });
   }, [dispatch, modal, project, title, value]);
-
-  const downloadJson = useCallback((data, filename) => {
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
-  }, []);
-
-  const handleExport = useCallback(
-    async ({ key }) => {
-      if (key === "en") {
-        downloadJson(value, `${identifier}-en.json`);
-      } else if (key === "fr") {
-        setExportingFr(true);
-        const result = await fetchTranslation(metadataUrl, identifier, "fr", authHeader);
-        setExportingFr(false);
-        if (result.exists === true) {
-          downloadJson(result.data, `${identifier}-fr.json`);
-        } else if (result.exists === false) {
-          message.warning("No French translation exists for this dataset.");
-        } else {
-          message.error(`Failed to fetch French translation: ${result.error}`);
-        }
-      }
-    },
-    [authHeader, downloadJson, identifier, message, metadataUrl, value],
-  );
-
-  const exportMenuItems = [
-    { key: "en", label: "English (canonical)" },
-    ...(hasFrTranslation ? [{ key: "fr", label: "French translation" }] : []),
-  ];
 
   const isPrivate = mode === "private";
   const defaultBiosampleLFSDisabled = linkedFieldSets.length !== 0;
@@ -286,25 +238,10 @@ const Dataset = ({ mode, project, value }) => {
           >
             Provenance
           </Button>
-          <Dropdown menu={{ items: exportMenuItems, onClick: handleExport }} trigger={["click"]} disabled={exportingFr}>
-            <Button icon={<DownloadOutlined />} loading={exportingFr} style={{ marginRight: "8px" }}>
-              Export <DownOutlined />
-            </Button>
-          </Dropdown>
           {isPrivate && (
-            <>
-              <Button
-                icon={<GlobalOutlined />}
-                style={{ marginRight: "8px" }}
-                onClick={() => setTranslationModalVisible(true)}
-              >
-                {hasFrTranslation ? "Edit French Translation" : "Add French Translation"}
-              </Button>
-              <Button danger={true} icon={<DeleteOutlined />} onClick={handleDelete}>
-                Delete
-              </Button>
-              {/* TODO: Share button (vFuture) */}
-            </>
+            <Button danger={true} icon={<DeleteOutlined />} onClick={handleDelete}>
+              Delete
+            </Button>
           )}
         </>
       }
@@ -315,14 +252,6 @@ const Dataset = ({ mode, project, value }) => {
         isPrivate={isPrivate}
         onClose={() => setProvenanceModalVisible(false)}
       />
-      {isPrivate && value && (
-        <DatasetTranslationModal
-          dataset={value}
-          open={translationModalVisible}
-          onSave={() => dispatch(fetchProjectsWithDatasets())}
-          onClose={() => setTranslationModalVisible(false)}
-        />
-      )}
       {isPrivate ? (
         <>
           <LinkedFieldSetModal

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -33,6 +33,7 @@ import DatasetTranslationModal from "./DatasetTranslationModal";
 import { useAuthorizationHeader } from "bento-auth-js";
 
 import { fetchTranslation } from "@/api/datasetTranslations";
+import { fetchProjectsWithDatasets } from "@/modules/metadata/actions";
 import { useAppDispatch, useAppSelector } from "@/store";
 
 const DATASET_CARD_TABS = [
@@ -59,9 +60,10 @@ const Dataset = ({ mode, project, value, onEdit }) => {
   const identifier = value?.identifier ?? null;
   const title = value?.title ?? "";
   const linkedFieldSets = value?.linked_field_sets ?? [];
+  const hasFrTranslation = (value?.translations ?? []).includes("fr");
+
   const [provenanceModalVisible, setProvenanceModalVisible] = useState(false);
   const [translationModalVisible, setTranslationModalVisible] = useState(false);
-  const [frTranslationStatus, setFrTranslationStatus] = useState("loading"); // "loading" | "exists" | "missing" | "error"
   const [exportingFr, setExportingFr] = useState(false);
   const [fieldSetAdditionModalVisible, setFieldSetAdditionModalVisible] = useState(false);
   const [fieldSetEditModalVisible, setFieldSetEditModalVisible] = useState(false);
@@ -74,20 +76,6 @@ const Dataset = ({ mode, project, value, onEdit }) => {
       dispatch(fetchDatasetDataTypesIfPossible(identifier));
     }
   }, [dispatch, identifier]);
-
-  const checkFrTranslation = useCallback(() => {
-    if (!identifier || !metadataUrl) return;
-    setFrTranslationStatus("loading");
-    fetchTranslation(metadataUrl, identifier, "fr", authHeader).then((result) => {
-      if (result.exists === true) setFrTranslationStatus("exists");
-      else if (result.exists === false) setFrTranslationStatus("missing");
-      else setFrTranslationStatus("error");
-    });
-  }, [identifier, metadataUrl, authHeader]);
-
-  useEffect(() => {
-    checkFrTranslation();
-  }, [checkFrTranslation]);
 
   const handleFieldSetDeletion = useCallback(
     (fieldSet, index) => {
@@ -173,7 +161,7 @@ const Dataset = ({ mode, project, value, onEdit }) => {
 
   const exportMenuItems = [
     { key: "en", label: "English (canonical)" },
-    ...(frTranslationStatus === "exists" ? [{ key: "fr", label: "French translation" }] : []),
+    ...(hasFrTranslation ? [{ key: "fr", label: "French translation" }] : []),
   ];
 
   const isPrivate = mode === "private";
@@ -308,10 +296,9 @@ const Dataset = ({ mode, project, value, onEdit }) => {
               <Button
                 icon={<GlobalOutlined />}
                 style={{ marginRight: "8px" }}
-                loading={frTranslationStatus === "loading"}
                 onClick={() => setTranslationModalVisible(true)}
               >
-                {frTranslationStatus === "exists" ? "Edit French Translation" : "Add French Translation"}
+                {hasFrTranslation ? "Edit French Translation" : "Add French Translation"}
               </Button>
               <Button icon={<EditOutlined />} style={{ marginRight: "8px" }} onClick={() => (onEdit || nop)()}>
                 Edit
@@ -334,10 +321,8 @@ const Dataset = ({ mode, project, value, onEdit }) => {
         <DatasetTranslationModal
           dataset={value}
           open={translationModalVisible}
-          onClose={() => {
-            setTranslationModalVisible(false);
-            checkFrTranslation();
-          }}
+          onSave={() => dispatch(fetchProjectsWithDatasets())}
+          onClose={() => setTranslationModalVisible(false)}
         />
       )}
       {isPrivate ? (

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -51,7 +51,7 @@ const DEFAULT_BIOSAMPLE_LFS = {
   },
 };
 
-const Dataset = ({ mode, project, value, onEdit }) => {
+const Dataset = ({ mode, project, value }) => {
   const { modal, message } = App.useApp();
   const dispatch = useAppDispatch();
   const metadataUrl = useAppSelector((state) => state.services.metadataService?.url ?? "");
@@ -284,7 +284,7 @@ const Dataset = ({ mode, project, value, onEdit }) => {
             style={{ marginRight: "8px" }}
             onClick={() => setProvenanceModalVisible(true)}
           >
-            View Provenance
+            Provenance
           </Button>
           <Dropdown menu={{ items: exportMenuItems, onClick: handleExport }} trigger={["click"]} disabled={exportingFr}>
             <Button icon={<DownloadOutlined />} loading={exportingFr} style={{ marginRight: "8px" }}>
@@ -300,9 +300,6 @@ const Dataset = ({ mode, project, value, onEdit }) => {
               >
                 {hasFrTranslation ? "Edit French Translation" : "Add French Translation"}
               </Button>
-              <Button icon={<EditOutlined />} style={{ marginRight: "8px" }} onClick={() => (onEdit || nop)()}>
-                Edit
-              </Button>
               <Button danger={true} icon={<DeleteOutlined />} onClick={handleDelete}>
                 Delete
               </Button>
@@ -315,6 +312,7 @@ const Dataset = ({ mode, project, value, onEdit }) => {
       <DatasetProvenanceModal
         dataset={value}
         open={provenanceModalVisible}
+        isPrivate={isPrivate}
         onClose={() => setProvenanceModalVisible(false)}
       />
       {isPrivate && value && (
@@ -359,7 +357,6 @@ Dataset.propTypes = {
     title: PropTypes.string,
     linked_field_sets: PropTypes.array,
   }),
-  onEdit: PropTypes.func,
 };
 
 export default Dataset;

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -170,7 +170,7 @@ const Dataset = ({ mode, project, value, onEdit }) => {
 
   const exportMenuItems = [
     { key: "en", label: "English (canonical)" },
-    { key: "fr", label: "French translation" },
+    ...(frTranslationStatus === "exists" ? [{ key: "fr", label: "French translation" }] : []),
   ];
 
   const isPrivate = mode === "private";

--- a/src/components/datasets/Dataset.js
+++ b/src/components/datasets/Dataset.js
@@ -30,6 +30,8 @@ import DatasetOverview from "./DatasetOverview";
 import DatasetDataTypes from "./DatasetDataTypes";
 import DatasetProvenanceModal from "./DatasetProvenanceModal";
 import DatasetTranslationModal from "./DatasetTranslationModal";
+import { useAuthorizationHeader } from "bento-auth-js";
+
 import { fetchTranslation } from "@/api/datasetTranslations";
 import { useAppDispatch, useAppSelector } from "@/store";
 
@@ -52,6 +54,7 @@ const Dataset = ({ mode, project, value, onEdit }) => {
   const { modal, message } = App.useApp();
   const dispatch = useAppDispatch();
   const metadataUrl = useAppSelector((state) => state.services.metadataService?.url ?? "");
+  const authHeader = useAuthorizationHeader();
 
   const identifier = value?.identifier ?? null;
   const title = value?.title ?? "";
@@ -75,12 +78,12 @@ const Dataset = ({ mode, project, value, onEdit }) => {
   const checkFrTranslation = useCallback(() => {
     if (!identifier || !metadataUrl) return;
     setFrTranslationStatus("loading");
-    fetchTranslation(metadataUrl, identifier, "fr").then((result) => {
+    fetchTranslation(metadataUrl, identifier, "fr", authHeader).then((result) => {
       if (result.exists === true) setFrTranslationStatus("exists");
       else if (result.exists === false) setFrTranslationStatus("missing");
       else setFrTranslationStatus("error");
     });
-  }, [identifier, metadataUrl]);
+  }, [identifier, metadataUrl, authHeader]);
 
   useEffect(() => {
     checkFrTranslation();
@@ -154,7 +157,7 @@ const Dataset = ({ mode, project, value, onEdit }) => {
         downloadJson(value, `${identifier}-en.json`);
       } else if (key === "fr") {
         setExportingFr(true);
-        const result = await fetchTranslation(metadataUrl, identifier, "fr");
+        const result = await fetchTranslation(metadataUrl, identifier, "fr", authHeader);
         setExportingFr(false);
         if (result.exists === true) {
           downloadJson(result.data, `${identifier}-fr.json`);
@@ -165,7 +168,7 @@ const Dataset = ({ mode, project, value, onEdit }) => {
         }
       }
     },
-    [downloadJson, identifier, message, metadataUrl, value],
+    [authHeader, downloadJson, identifier, message, metadataUrl, value],
   );
 
   const exportMenuItems = [

--- a/src/components/datasets/DatasetDataTypes.js
+++ b/src/components/datasets/DatasetDataTypes.js
@@ -17,7 +17,7 @@ import DataTypeSummaryModal from "./datatype/DataTypeSummaryModal";
 
 const NA_TEXT = <span style={{ color: "#999", fontStyle: "italic" }}>N/A</span>;
 
-const DatasetDataTypes = memo(({ isPrivate, project, dataset }) => {
+const DatasetDataTypes = memo(({ project, dataset }) => {
   const dispatch = useAppDispatch();
   const datasetDataTypes = useDatasetDataTypesByID(dataset.identifier);
   const datasetDataTypeValues = useMemo(() => Object.values(datasetDataTypes.dataTypesByID), [datasetDataTypes]);
@@ -60,8 +60,7 @@ const DatasetDataTypes = memo(({ isPrivate, project, dataset }) => {
       {
         title: "Name",
         key: "label",
-        render: (dt) =>
-          isPrivate ? <a onClick={() => showDataTypeSummary(dt)}>{dt.label ?? NA_TEXT}</a> : (dt.label ?? NA_TEXT),
+        render: (dt) => <a onClick={() => showDataTypeSummary(dt)}>{dt.label ?? NA_TEXT}</a>,
         defaultSortOrder: "ascend",
         sorter: (a, b) => a.label.localeCompare(b.label),
       },
@@ -70,58 +69,54 @@ const DatasetDataTypes = memo(({ isPrivate, project, dataset }) => {
         dataIndex: "count",
         render: (c) => c ?? NA_TEXT,
       },
-      ...(isPrivate
-        ? [
-            {
-              title: "Actions",
-              key: "actions",
-              width: 240,
-              render: (dt) => {
-                const dtIngestionWorkflows = ingestionWorkflows.filter(
-                  (wf) => wf.data_type === dt.id || (wf.tags ?? []).includes(dt.id),
-                );
-                const dtIngestionWorkflowsByID = Object.fromEntries(dtIngestionWorkflows.map((wf) => [wf.id, wf]));
+      {
+        title: "Actions",
+        key: "actions",
+        width: 240,
+        render: (dt) => {
+          const dtIngestionWorkflows = ingestionWorkflows.filter(
+            (wf) => wf.data_type === dt.id || (wf.tags ?? []).includes(dt.id),
+          );
+          const dtIngestionWorkflowsByID = Object.fromEntries(dtIngestionWorkflows.map((wf) => [wf.id, wf]));
 
-                const ingestMenu = {
-                  onClick: (i) =>
-                    startIngestionFlow(dtIngestionWorkflowsByID[i.key], {
-                      // TODO: this requires that exactly this input is present, and may break in the future
-                      //  in a bit of a non-obvious way.
-                      project_dataset: `${project.identifier}:${dataset.identifier}`,
-                    }),
-                  items: dtIngestionWorkflows.map((wf) => ({ key: wf.id, label: wf.name })),
-                };
+          const ingestMenu = {
+            onClick: (i) =>
+              startIngestionFlow(dtIngestionWorkflowsByID[i.key], {
+                // TODO: this requires that exactly this input is present, and may break in the future
+                //  in a bit of a non-obvious way.
+                project_dataset: `${project.identifier}:${dataset.identifier}`,
+              }),
+            items: dtIngestionWorkflows.map((wf) => ({ key: wf.id, label: wf.name })),
+          };
 
-                const ingestDropdown = (
-                  <Dropdown menu={ingestMenu} trigger={["click"]}>
-                    <Button icon={<ImportOutlined />} style={{ width: "100%" }} disabled={!dtIngestionWorkflows.length}>
-                      Ingest <DownOutlined />
-                    </Button>
-                  </Dropdown>
-                );
+          const ingestDropdown = (
+            <Dropdown menu={ingestMenu} trigger={["click"]}>
+              <Button icon={<ImportOutlined />} style={{ width: "100%" }} disabled={!dtIngestionWorkflows.length}>
+                Ingest <DownOutlined />
+              </Button>
+            </Dropdown>
+          );
 
-                return (
-                  <Row gutter={10}>
-                    <Col span={13}>{ingestDropdown}</Col>
-                    <Col span={11}>
-                      <Button
-                        danger={true}
-                        icon={<DeleteOutlined />}
-                        disabled={!dt.count}
-                        onClick={() => handleClearDataType(dt)}
-                        style={{ width: "100%" }}
-                      >
-                        Clear
-                      </Button>
-                    </Col>
-                  </Row>
-                );
-              },
-            },
-          ]
-        : []),
+          return (
+            <Row gutter={10}>
+              <Col span={13}>{ingestDropdown}</Col>
+              <Col span={11}>
+                <Button
+                  danger={true}
+                  icon={<DeleteOutlined />}
+                  disabled={!dt.count}
+                  onClick={() => handleClearDataType(dt)}
+                  style={{ width: "100%" }}
+                >
+                  Clear
+                </Button>
+              </Col>
+            </Row>
+          );
+        },
+      },
     ],
-    [isPrivate, project, dataset, handleClearDataType, ingestionWorkflows, startIngestionFlow, showDataTypeSummary],
+    [project, dataset, handleClearDataType, ingestionWorkflows, startIngestionFlow, showDataTypeSummary],
   );
 
   const onDataTypeSummaryModalCancel = useCallback(() => setSelectedDataType(null), []);
@@ -154,7 +149,6 @@ const DatasetDataTypes = memo(({ isPrivate, project, dataset }) => {
 });
 
 DatasetDataTypes.propTypes = {
-  isPrivate: PropTypes.bool,
   project: projectPropTypesShape,
   dataset: datasetPropTypesShape,
 };

--- a/src/components/datasets/DatasetDataTypes.js
+++ b/src/components/datasets/DatasetDataTypes.js
@@ -1,6 +1,4 @@
 import { memo, useCallback, useMemo, useState } from "react";
-import PropTypes from "prop-types";
-
 import { Button, Col, Dropdown, Row, Table, Typography } from "antd";
 import { DeleteOutlined, DownOutlined, ImportOutlined } from "@ant-design/icons";
 

--- a/src/components/datasets/DatasetForm/helpers.ts
+++ b/src/components/datasets/DatasetForm/helpers.ts
@@ -146,7 +146,7 @@ export function prepareInitialValues(
   if (Array.isArray(result.funding_sources)) {
     result.funding_sources = (result.funding_sources as Record<string, unknown>[]).map((fs) => ({
       ...fs,
-      funder: fs.funder && typeof fs.funder === "object" ? (fs.funder as { name?: string }).name ?? "" : fs.funder,
+      funder: fs.funder && typeof fs.funder === "object" ? ((fs.funder as { name?: string }).name ?? "") : fs.funder,
     }));
   }
   if (

--- a/src/components/datasets/DatasetForm/helpers.ts
+++ b/src/components/datasets/DatasetForm/helpers.ts
@@ -144,10 +144,16 @@ export function prepareInitialValues(
     );
   }
   if (Array.isArray(result.funding_sources)) {
-    result.funding_sources = (result.funding_sources as Record<string, unknown>[]).map((fs) => ({
-      ...fs,
-      funder: fs.funder && typeof fs.funder === "object" ? ((fs.funder as { name?: string }).name ?? "") : fs.funder,
-    }));
+    result.funding_sources = (result.funding_sources as Record<string, unknown>[]).map((fs) => {
+      if ("url" in fs && "label" in fs) {
+        return { ...fs, _type: "link" };
+      }
+      return {
+        ...fs,
+        _type: "funding_source",
+        funder: fs.funder && typeof fs.funder === "object" ? ((fs.funder as { name?: string }).name ?? "") : fs.funder,
+      };
+    });
   }
   if (
     result.spatial_coverage !== null &&

--- a/src/components/datasets/DatasetForm/helpers.ts
+++ b/src/components/datasets/DatasetForm/helpers.ts
@@ -143,6 +143,12 @@ export function prepareInitialValues(
         : { type: "id" in (t as object) ? "ontology" : "string", ...(t as object) },
     );
   }
+  if (Array.isArray(result.funding_sources)) {
+    result.funding_sources = (result.funding_sources as Record<string, unknown>[]).map((fs) => ({
+      ...fs,
+      funder: fs.funder && typeof fs.funder === "object" ? (fs.funder as { name?: string }).name ?? "" : fs.funder,
+    }));
+  }
   if (
     result.spatial_coverage !== null &&
     result.spatial_coverage !== undefined &&

--- a/src/components/datasets/DatasetForm/index.tsx
+++ b/src/components/datasets/DatasetForm/index.tsx
@@ -108,8 +108,11 @@ const DatasetForm = ({ onSubmit, initialValues, form, readOnly, onValuesChange, 
       const discovery = values.discovery;
       delete values.discovery;
 
-      const cleaned = cleanFormValues(values) as Record<string, unknown>;
-      if (discovery !== null && discovery !== undefined) cleaned.discovery = discovery;
+      const cleaned = (cleanFormValues(values) ?? {}) as Record<string, unknown>;
+      for (const key of Object.keys(values)) {
+        if (!(key in cleaned)) cleaned[key] = null;
+      }
+      cleaned.discovery = discovery ?? null;
       const result = validateWithZod(cleaned);
 
       if (result.success) {

--- a/src/components/datasets/DatasetForm/tabs/PublicationsFundingTab.tsx
+++ b/src/components/datasets/DatasetForm/tabs/PublicationsFundingTab.tsx
@@ -8,6 +8,69 @@ import PublicationVenueFields from "../fields/PublicationVenueFields";
 const { TextArea } = Input;
 const { Text } = Typography;
 
+/** Matches the urlString check in dataset.ts — must start with http:// or https:// */
+const urlRules = [
+  { required: true, type: "url" as const },
+  { pattern: /^https?:\/\//i, message: "URL must start with http:// or https://" },
+];
+
+const FundingSourceCard = ({ name, remove, form }: { name: number; remove: () => void; form: FormInstance }) => {
+  const fsType = Form.useWatch(["funding_sources", name, "_type"], form);
+
+  return (
+    <Card size="small" style={{ marginBottom: 8 }}>
+      <Form.Item name={[name, "_type"]} hidden noStyle>
+        <Input />
+      </Form.Item>
+      {fsType === "link" ? (
+        <>
+          <Form.Item label="Label" name={[name, "label"]} rules={[{ required: true, min: 1 }]}>
+            <Input placeholder="Link label" />
+          </Form.Item>
+          <Form.Item label="URL" name={[name, "url"]} rules={urlRules}>
+            <Input placeholder="https://..." />
+          </Form.Item>
+        </>
+      ) : (
+        <>
+          <Form.Item label="Funder name" name={[name, "funder"]}>
+            <Input placeholder="Funding organization or person name" />
+          </Form.Item>
+          <Form.List name={[name, "grant_numbers"]}>
+            {(grantFields, { add: addGrant, remove: removeGrant }) => (
+              <>
+                <Text strong>Grant numbers</Text>
+                {grantFields.map(({ key: gKey, name: gName, ...gRest }) => (
+                  <Space key={gKey} align="baseline" style={{ display: "flex", marginBottom: 4 }}>
+                    <Form.Item {...gRest} name={gName}>
+                      <Input placeholder="Grant number" style={{ width: 300 }} />
+                    </Form.Item>
+                    <MinusCircleOutlined onClick={() => removeGrant(gName)} />
+                  </Space>
+                ))}
+                <Button
+                  type="dashed"
+                  onClick={() => addGrant()}
+                  icon={<PlusOutlined />}
+                  size="small"
+                  style={{ marginLeft: 8 }}
+                >
+                  Add grant number
+                </Button>
+              </>
+            )}
+          </Form.List>
+        </>
+      )}
+      <div style={{ marginTop: 8 }}>
+        <Button danger size="small" onClick={remove}>
+          Remove
+        </Button>
+      </div>
+    </Card>
+  );
+};
+
 const PublicationsFundingTab = ({ form }: { form: FormInstance }) => (
   <>
     <Card title="Publications" size="small" style={{ marginBottom: 8 }}>
@@ -19,7 +82,7 @@ const PublicationsFundingTab = ({ form }: { form: FormInstance }) => (
                 <Form.Item label="Title" name={[name, "title"]} rules={[{ required: true, min: 1 }]}>
                   <Input />
                 </Form.Item>
-                <Form.Item label="URL" name={[name, "url"]} rules={[{ required: true, type: "url" }]}>
+                <Form.Item label="URL" name={[name, "url"]} rules={urlRules}>
                   <Input placeholder="https://..." />
                 </Form.Item>
                 <Form.Item label="DOI" name={[name, "doi"]}>
@@ -125,44 +188,16 @@ const PublicationsFundingTab = ({ form }: { form: FormInstance }) => (
         {(fields, { add, remove }) => (
           <>
             {fields.map(({ key, name }) => (
-              <Card key={key} size="small" style={{ marginBottom: 8 }}>
-                <Form.Item label="Funder name" name={[name, "funder"]}>
-                  <Input placeholder="Funding organization or person name" />
-                </Form.Item>
-                <Form.List name={[name, "grant_numbers"]}>
-                  {(grantFields, { add: addGrant, remove: removeGrant }) => (
-                    <>
-                      <Text strong>Grant numbers</Text>
-                      {grantFields.map(({ key: gKey, name: gName, ...gRest }) => (
-                        <Space key={gKey} align="baseline" style={{ display: "flex", marginBottom: 4 }}>
-                          <Form.Item {...gRest} name={gName}>
-                            <Input placeholder="Grant number" style={{ width: 300 }} />
-                          </Form.Item>
-                          <MinusCircleOutlined onClick={() => removeGrant(gName)} />
-                        </Space>
-                      ))}
-                      <Button
-                        type="dashed"
-                        onClick={() => addGrant()}
-                        icon={<PlusOutlined />}
-                        size="small"
-                        style={{ marginLeft: 8 }}
-                      >
-                        Add grant number
-                      </Button>
-                    </>
-                  )}
-                </Form.List>
-                <div style={{ marginTop: 8 }}>
-                  <Button danger size="small" onClick={() => remove(name)}>
-                    Remove source
-                  </Button>
-                </div>
-              </Card>
+              <FundingSourceCard key={key} name={name} remove={() => remove(name)} form={form} />
             ))}
-            <Button type="dashed" onClick={() => add()} icon={<PlusOutlined />} style={{ marginLeft: 8 }}>
-              Add funding source
-            </Button>
+            <Space style={{ marginLeft: 8 }}>
+              <Button type="dashed" onClick={() => add({ _type: "funding_source" })} icon={<PlusOutlined />}>
+                Add funding source
+              </Button>
+              <Button type="dashed" onClick={() => add({ _type: "link" })} icon={<PlusOutlined />}>
+                Add link
+              </Button>
+            </Space>
           </>
         )}
       </Form.List>

--- a/src/components/datasets/DatasetOverview.js
+++ b/src/components/datasets/DatasetOverview.js
@@ -1,6 +1,4 @@
 import { Fragment, useMemo } from "react";
-import PropTypes from "prop-types";
-
 import { Col, Divider, Row, Spin, Statistic, Typography } from "antd";
 
 import { EM_DASH } from "@/constants";

--- a/src/components/datasets/DatasetOverview.js
+++ b/src/components/datasets/DatasetOverview.js
@@ -5,9 +5,9 @@ import { Col, Divider, Row, Spin, Statistic, Typography } from "antd";
 
 import { EM_DASH } from "@/constants";
 import { useDatasetDataTypesByID } from "@/modules/datasets/hooks";
-import { datasetPropTypesShape, projectPropTypesShape } from "@/propTypes";
+import { datasetPropTypesShape } from "@/propTypes";
 
-const DatasetOverview = ({ isPrivate, project, dataset }) => {
+const DatasetOverview = ({ dataset }) => {
   const { dataTypesByID, isFetchingDataTypes, hasAttemptedDataTypes } = useDatasetDataTypesByID(dataset.identifier);
 
   // Count data types which actually have data in them for showing in the overview
@@ -51,16 +51,11 @@ const DatasetOverview = ({ isPrivate, project, dataset }) => {
         </>
       ) : null}
       {(dataset.description ?? "").length > 0 || (dataset.contact_info ?? "").length > 0 ? <Divider /> : null}
-      <Row gutter={16} style={{ maxWidth: isPrivate ? "720px" : "1080px" }}>
-        {isPrivate ? null : (
-          <Col span={8}>
-            <Statistic title="Project" value={project.title ?? EM_DASH} />
-          </Col>
-        )}
-        <Col span={isPrivate ? 12 : 8}>
+      <Row gutter={16} style={{ maxWidth: "720px" }}>
+        <Col span={12}>
           <Statistic title="Created" value={new Date(Date.parse(dataset.created_at)).toLocaleString()} />
         </Col>
-        <Col span={isPrivate ? 12 : 8}>
+        <Col span={12}>
           <Spin spinning={isFetchingDataTypes}>
             <Statistic title="Data types" value={dataTypeDisplay} />
           </Spin>
@@ -71,8 +66,6 @@ const DatasetOverview = ({ isPrivate, project, dataset }) => {
 };
 
 DatasetOverview.propTypes = {
-  isPrivate: PropTypes.bool,
-  project: projectPropTypesShape,
   dataset: datasetPropTypesShape,
 };
 

--- a/src/components/datasets/DatasetProvenanceModal.tsx
+++ b/src/components/datasets/DatasetProvenanceModal.tsx
@@ -23,11 +23,10 @@ import { useAppDispatch, useAppSelector } from "@/store";
 interface DatasetProvenanceModalProps {
   dataset: (DatasetModel & { translations?: string[] }) | undefined;
   open: boolean;
-  isPrivate?: boolean;
   onClose: () => void;
 }
 
-const DatasetProvenanceModal = ({ dataset, open, isPrivate, onClose }: DatasetProvenanceModalProps) => {
+const DatasetProvenanceModal = ({ dataset, open, onClose }: DatasetProvenanceModalProps) => {
   const { message } = App.useApp();
   const dispatch = useAppDispatch();
   const metadataUrl = useAppSelector((state) => state.services.metadataService?.url ?? "");
@@ -201,18 +200,14 @@ const DatasetProvenanceModal = ({ dataset, open, isPrivate, onClose }: DatasetPr
             Export <DownOutlined />
           </Button>
         </Dropdown>
-        {isPrivate && (
-          <Button icon={<GlobalOutlined />} onClick={() => setTranslationModalOpen(true)}>
-            {hasFrTranslation ? "Edit French Translation" : "Add French Translation"}
-          </Button>
-        )}
+        <Button icon={<GlobalOutlined />} onClick={() => setTranslationModalOpen(true)}>
+          {hasFrTranslation ? "Edit French Translation" : "Add French Translation"}
+        </Button>
       </Space>
       <Space>
-        {isPrivate && (
-          <Button icon={<EditOutlined />} type="primary" onClick={enterEdit}>
-            Edit
-          </Button>
-        )}
+        <Button icon={<EditOutlined />} type="primary" onClick={enterEdit}>
+          Edit
+        </Button>
         <Button onClick={handleClose}>Close</Button>
       </Space>
     </Space>

--- a/src/components/datasets/DatasetProvenanceModal.tsx
+++ b/src/components/datasets/DatasetProvenanceModal.tsx
@@ -1,20 +1,227 @@
-import { Form, Modal } from "antd";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Alert, App, Button, Form, Modal, Space, Upload } from "antd";
+import { EditOutlined, PlusOutlined, SaveOutlined, UploadOutlined } from "@ant-design/icons";
 
-import type { DatasetModel } from "@/types/dataset";
+import type { DatasetModel, DatasetModelBase as DatasetModelBaseType } from "@/types/dataset";
+import { prepareInitialValues, validateWithZod } from "./DatasetForm/helpers";
+import { saveDraft, loadDraft, clearDraft, deserializeFormValues } from "@/utils/datasetDraftUtils";
+import { saveProjectDataset, fetchProjectsWithDatasets } from "@/modules/metadata/actions";
+import { useProjects } from "@/modules/metadata/hooks";
 import DatasetForm from "./DatasetForm";
+import { useAppDispatch } from "@/store";
 
 interface DatasetProvenanceModalProps {
   dataset: DatasetModel | undefined;
   open: boolean;
+  isPrivate?: boolean;
   onClose: () => void;
 }
 
-const DatasetProvenanceModal = ({ dataset, open, onClose }: DatasetProvenanceModalProps) => {
+const DatasetProvenanceModal = ({ dataset, open, isPrivate, onClose }: DatasetProvenanceModalProps) => {
+  const { message } = App.useApp();
+  const dispatch = useAppDispatch();
+  const { isSavingDataset } = useProjects();
+
   const [form] = Form.useForm();
+  const [editing, setEditing] = useState(false);
+  const [draftBanner, setDraftBanner] = useState<{ savedAt: string } | null>(null);
+  const [importErrors, setImportErrors] = useState<Array<{ path: string; message: string }>>([]);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const draftKey = `dataset-draft:edit:${dataset?.identifier}`;
+
+  useEffect(() => {
+    if (!open) {
+      setEditing(false);
+      setDraftBanner(null);
+      setImportErrors([]);
+    }
+  }, [open]);
+
+  const enterEdit = useCallback(() => {
+    const draft = loadDraft(draftKey);
+    setDraftBanner(draft ? { savedAt: draft.savedAt } : null);
+    setImportErrors([]);
+    setEditing(true);
+  }, [draftKey]);
+
+  const exitEdit = useCallback(() => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+      saveDraft(draftKey, form.getFieldsValue(true));
+    }
+    setDraftBanner(null);
+    setImportErrors([]);
+    form.resetFields();
+    setEditing(false);
+  }, [draftKey, form]);
+
+  const handleValuesChange = useCallback(
+    (_: unknown, allValues: unknown) => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(() => saveDraft(draftKey, allValues), 1000);
+    },
+    [draftKey],
+  );
+
+  const handleRestore = useCallback(() => {
+    const draft = loadDraft(draftKey);
+    if (!draft) return;
+    form.setFieldsValue(deserializeFormValues(draft.values));
+    setDraftBanner(null);
+  }, [draftKey, form]);
+
+  const handleDiscard = useCallback(() => {
+    clearDraft(draftKey);
+    setDraftBanner(null);
+  }, [draftKey]);
+
+  const handleDatasetSubmit = useCallback(
+    (values: DatasetModelBaseType) => {
+      if (!dataset) return;
+      const onSuccess = async () => {
+        if (debounceTimer.current) {
+          clearTimeout(debounceTimer.current);
+          debounceTimer.current = null;
+        }
+        clearDraft(draftKey);
+        form.resetFields();
+        await dispatch(fetchProjectsWithDatasets());
+        setEditing(false);
+      };
+      dispatch(saveProjectDataset({ ...dataset, ...values }, onSuccess));
+    },
+    [dataset, dispatch, draftKey, form],
+  );
+
+  const handleSubmit = useCallback(() => {
+    form.submit();
+  }, [form]);
+
+  const handleClose = useCallback(() => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
+    onClose();
+  }, [onClose]);
+
+  const handleJsonUpload = useCallback(
+    (file: File) => {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        try {
+          const parsed = JSON.parse(e.target?.result as string);
+          const result = validateWithZod(parsed);
+
+          const skippedFields = new Set(
+            result.success ? [] : result.errors.map((err) => err.path.split(".")[0]).filter(Boolean),
+          );
+
+          const cleaned = Object.fromEntries(Object.entries(parsed).filter(([k]) => !skippedFields.has(k)));
+          form.setFieldsValue(prepareInitialValues(cleaned));
+
+          if (skippedFields.size === 0) {
+            setImportErrors([]);
+            message.success("JSON imported — review the fields before saving.");
+          } else {
+            const skippedErrors = !result.success
+              ? result.errors.filter((err: { path: string }) => skippedFields.has(err.path.split(".")[0]))
+              : [];
+            setImportErrors(skippedErrors);
+            message.warning(`JSON imported — ${skippedFields.size} field(s) skipped due to invalid values.`);
+          }
+        } catch {
+          message.error("Invalid JSON file.");
+        }
+      };
+      reader.readAsText(file);
+      return false;
+    },
+    [form, message],
+  );
+
+  const viewFooter = (
+    <Space>
+      {isPrivate && (
+        <Button icon={<EditOutlined />} type="primary" onClick={enterEdit}>
+          Edit
+        </Button>
+      )}
+      <Button onClick={handleClose}>Close</Button>
+    </Space>
+  );
+
+  const editFooter = (
+    <Space>
+      <Upload key="import" accept=".json" showUploadList={false} beforeUpload={handleJsonUpload}>
+        <Button icon={<UploadOutlined />}>Import JSON</Button>
+      </Upload>
+      <Button onClick={exitEdit}>Cancel</Button>
+      <Button icon={<SaveOutlined />} type="primary" onClick={handleSubmit} loading={isSavingDataset}>
+        Save
+      </Button>
+    </Space>
+  );
 
   return (
-    <Modal title="Dataset Provenance" open={open} onCancel={onClose} footer={null} width={960} destroyOnClose>
-      {dataset && <DatasetForm form={form} initialValues={dataset} readOnly />}
+    <Modal
+      open={open}
+      width={editing ? 848 : 960}
+      title={editing ? `Edit Dataset "${dataset?.title ?? ""}"` : "Dataset Provenance"}
+      footer={editing ? editFooter : viewFooter}
+      onCancel={editing ? exitEdit : handleClose}
+      destroyOnClose
+    >
+      {editing && draftBanner && (
+        <Alert
+          type="warning"
+          showIcon
+          style={{ marginBottom: 16 }}
+          message="You have unsaved progress from this form"
+          description={`Last saved: ${new Date(draftBanner.savedAt).toLocaleString()}`}
+          action={
+            <Space>
+              <Button size="small" type="primary" onClick={handleRestore}>
+                Restore
+              </Button>
+              <Button size="small" onClick={handleDiscard}>
+                Discard
+              </Button>
+            </Space>
+          }
+        />
+      )}
+      {dataset && (
+        <DatasetForm
+          form={form}
+          initialValues={dataset}
+          readOnly={!editing}
+          onSubmit={handleDatasetSubmit}
+          onValuesChange={editing ? handleValuesChange : undefined}
+          open={open}
+        />
+      )}
+      {importErrors.length > 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          closable
+          onClose={() => setImportErrors([])}
+          style={{ marginTop: 16 }}
+          message="The following fields had invalid values and were not imported"
+          description={
+            <ul style={{ margin: 0, paddingLeft: 20 }}>
+              {importErrors.map((err, i) => (
+                <li key={i}>
+                  <strong>{err.path || "root"}</strong>: {err.message}
+                </li>
+              ))}
+            </ul>
+          }
+        />
+      )}
     </Modal>
   );
 };

--- a/src/components/datasets/DatasetProvenanceModal.tsx
+++ b/src/components/datasets/DatasetProvenanceModal.tsx
@@ -14,7 +14,7 @@ import type { DatasetModel, DatasetModelBase as DatasetModelBaseType } from "@/t
 import { prepareInitialValues, validateWithZod } from "./DatasetForm/helpers";
 import { saveDraft, loadDraft, clearDraft, deserializeFormValues } from "@/utils/datasetDraftUtils";
 import { fetchTranslation } from "@/api/datasetTranslations";
-import { saveProjectDataset, fetchProjectsWithDatasets } from "@/modules/metadata/actions";
+import { saveProjectDataset, refreshDataset } from "@/modules/metadata/actions";
 import { useProjects } from "@/modules/metadata/hooks";
 import DatasetForm from "./DatasetForm";
 import DatasetTranslationModal from "./DatasetTranslationModal";
@@ -42,13 +42,7 @@ const DatasetProvenanceModal = ({ dataset, open, onClose }: DatasetProvenanceMod
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const draftKey = `dataset-draft:edit:${dataset?.identifier}`;
-  const [hasFrOverride, setHasFrOverride] = useState<boolean | null>(null);
-  const hasFrTranslation = hasFrOverride ?? (dataset?.translations ?? []).includes("fr");
-
-  // Clear the optimistic override once the store delivers updated translations
-  useEffect(() => {
-    setHasFrOverride(null);
-  }, [dataset?.translations]);
+  const hasFrTranslation = (dataset?.translations ?? []).includes("fr");
 
   useEffect(() => {
     if (!open) {
@@ -107,7 +101,7 @@ const DatasetProvenanceModal = ({ dataset, open, onClose }: DatasetProvenanceMod
         }
         clearDraft(draftKey);
         form.resetFields();
-        await dispatch(fetchProjectsWithDatasets());
+        await dispatch(refreshDataset(dataset.identifier));
         setEditing(false);
       };
       dispatch(saveProjectDataset({ ...dataset, ...values }, onSuccess));
@@ -294,10 +288,7 @@ const DatasetProvenanceModal = ({ dataset, open, onClose }: DatasetProvenanceMod
         <DatasetTranslationModal
           dataset={dataset}
           open={translationModalOpen}
-          onSave={(hasFrNow) => {
-            setHasFrOverride(hasFrNow);
-            dispatch(fetchProjectsWithDatasets());
-          }}
+          onSave={() => dispatch(refreshDataset(dataset!.identifier))}
           onClose={() => setTranslationModalOpen(false)}
         />
       )}

--- a/src/components/datasets/DatasetProvenanceModal.tsx
+++ b/src/components/datasets/DatasetProvenanceModal.tsx
@@ -52,6 +52,12 @@ const DatasetProvenanceModal = ({ dataset, open, onClose }: DatasetProvenanceMod
     }
   }, [open]);
 
+  useEffect(() => {
+    if (!editing && dataset) {
+      form.setFieldsValue(prepareInitialValues(dataset));
+    }
+  }, [dataset, editing, form]);
+
   const enterEdit = useCallback(() => {
     const draft = loadDraft(draftKey);
     setDraftBanner(draft ? { savedAt: draft.savedAt } : null);
@@ -100,13 +106,12 @@ const DatasetProvenanceModal = ({ dataset, open, onClose }: DatasetProvenanceMod
           debounceTimer.current = null;
         }
         clearDraft(draftKey);
-        form.resetFields();
         await dispatch(refreshDataset(dataset.identifier));
         setEditing(false);
       };
       dispatch(saveProjectDataset({ ...dataset, ...values }, onSuccess));
     },
-    [dataset, dispatch, draftKey, form],
+    [dataset, dispatch, draftKey],
   );
 
   const handleSubmit = useCallback(() => {

--- a/src/components/datasets/DatasetProvenanceModal.tsx
+++ b/src/components/datasets/DatasetProvenanceModal.tsx
@@ -1,17 +1,27 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Alert, App, Button, Form, Modal, Space, Upload } from "antd";
-import { EditOutlined, PlusOutlined, SaveOutlined, UploadOutlined } from "@ant-design/icons";
+import { Alert, App, Button, Dropdown, Form, Modal, Space, Upload } from "antd";
+import {
+  DownloadOutlined,
+  DownOutlined,
+  EditOutlined,
+  GlobalOutlined,
+  SaveOutlined,
+  UploadOutlined,
+} from "@ant-design/icons";
+import { useAuthorizationHeader } from "bento-auth-js";
 
 import type { DatasetModel, DatasetModelBase as DatasetModelBaseType } from "@/types/dataset";
 import { prepareInitialValues, validateWithZod } from "./DatasetForm/helpers";
 import { saveDraft, loadDraft, clearDraft, deserializeFormValues } from "@/utils/datasetDraftUtils";
+import { fetchTranslation } from "@/api/datasetTranslations";
 import { saveProjectDataset, fetchProjectsWithDatasets } from "@/modules/metadata/actions";
 import { useProjects } from "@/modules/metadata/hooks";
 import DatasetForm from "./DatasetForm";
-import { useAppDispatch } from "@/store";
+import DatasetTranslationModal from "./DatasetTranslationModal";
+import { useAppDispatch, useAppSelector } from "@/store";
 
 interface DatasetProvenanceModalProps {
-  dataset: DatasetModel | undefined;
+  dataset: (DatasetModel & { translations?: string[] }) | undefined;
   open: boolean;
   isPrivate?: boolean;
   onClose: () => void;
@@ -20,15 +30,20 @@ interface DatasetProvenanceModalProps {
 const DatasetProvenanceModal = ({ dataset, open, isPrivate, onClose }: DatasetProvenanceModalProps) => {
   const { message } = App.useApp();
   const dispatch = useAppDispatch();
+  const metadataUrl = useAppSelector((state) => state.services.metadataService?.url ?? "");
+  const authHeader = useAuthorizationHeader();
   const { isSavingDataset } = useProjects();
 
   const [form] = Form.useForm();
   const [editing, setEditing] = useState(false);
   const [draftBanner, setDraftBanner] = useState<{ savedAt: string } | null>(null);
   const [importErrors, setImportErrors] = useState<Array<{ path: string; message: string }>>([]);
+  const [exportingFr, setExportingFr] = useState(false);
+  const [translationModalOpen, setTranslationModalOpen] = useState(false);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const draftKey = `dataset-draft:edit:${dataset?.identifier}`;
+  const hasFrTranslation = (dataset?.translations ?? []).includes("fr");
 
   useEffect(() => {
     if (!open) {
@@ -142,14 +157,64 @@ const DatasetProvenanceModal = ({ dataset, open, isPrivate, onClose }: DatasetPr
     [form, message],
   );
 
+  const downloadJson = useCallback((data: unknown, filename: string) => {
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, []);
+
+  const handleExport = useCallback(
+    async ({ key }: { key: string }) => {
+      if (!dataset) return;
+      if (key === "en") {
+        downloadJson(dataset, `${dataset.identifier}-en.json`);
+      } else if (key === "fr") {
+        setExportingFr(true);
+        const result = await fetchTranslation(metadataUrl, dataset.identifier, "fr", authHeader);
+        setExportingFr(false);
+        if (result.exists === true) {
+          downloadJson(result.data, `${dataset.identifier}-fr.json`);
+        } else if (result.exists === false) {
+          message.warning("No French translation exists for this dataset.");
+        } else {
+          message.error(`Failed to fetch French translation: ${result.error}`);
+        }
+      }
+    },
+    [authHeader, dataset, downloadJson, message, metadataUrl],
+  );
+
+  const exportMenuItems = [
+    { key: "en", label: "English (canonical)" },
+    ...(hasFrTranslation ? [{ key: "fr", label: "French translation" }] : []),
+  ];
+
   const viewFooter = (
-    <Space>
-      {isPrivate && (
-        <Button icon={<EditOutlined />} type="primary" onClick={enterEdit}>
-          Edit
-        </Button>
-      )}
-      <Button onClick={handleClose}>Close</Button>
+    <Space style={{ width: "100%", justifyContent: "space-between" }}>
+      <Space>
+        <Dropdown menu={{ items: exportMenuItems, onClick: handleExport }} trigger={["click"]} disabled={exportingFr}>
+          <Button icon={<DownloadOutlined />} loading={exportingFr}>
+            Export <DownOutlined />
+          </Button>
+        </Dropdown>
+        {isPrivate && (
+          <Button icon={<GlobalOutlined />} onClick={() => setTranslationModalOpen(true)}>
+            {hasFrTranslation ? "Edit French Translation" : "Add French Translation"}
+          </Button>
+        )}
+      </Space>
+      <Space>
+        {isPrivate && (
+          <Button icon={<EditOutlined />} type="primary" onClick={enterEdit}>
+            Edit
+          </Button>
+        )}
+        <Button onClick={handleClose}>Close</Button>
+      </Space>
     </Space>
   );
 
@@ -166,63 +231,73 @@ const DatasetProvenanceModal = ({ dataset, open, isPrivate, onClose }: DatasetPr
   );
 
   return (
-    <Modal
-      open={open}
-      width={editing ? 848 : 960}
-      title={editing ? `Edit Dataset "${dataset?.title ?? ""}"` : "Dataset Provenance"}
-      footer={editing ? editFooter : viewFooter}
-      onCancel={editing ? exitEdit : handleClose}
-      destroyOnClose
-    >
-      {editing && draftBanner && (
-        <Alert
-          type="warning"
-          showIcon
-          style={{ marginBottom: 16 }}
-          message="You have unsaved progress from this form"
-          description={`Last saved: ${new Date(draftBanner.savedAt).toLocaleString()}`}
-          action={
-            <Space>
-              <Button size="small" type="primary" onClick={handleRestore}>
-                Restore
-              </Button>
-              <Button size="small" onClick={handleDiscard}>
-                Discard
-              </Button>
-            </Space>
-          }
-        />
-      )}
+    <>
+      <Modal
+        open={open}
+        width={editing ? 848 : 960}
+        title={editing ? `Edit Dataset "${dataset?.title ?? ""}"` : "Dataset Provenance"}
+        footer={editing ? editFooter : viewFooter}
+        onCancel={editing ? exitEdit : handleClose}
+        destroyOnClose
+      >
+        {editing && draftBanner && (
+          <Alert
+            type="warning"
+            showIcon
+            style={{ marginBottom: 16 }}
+            message="You have unsaved progress from this form"
+            description={`Last saved: ${new Date(draftBanner.savedAt).toLocaleString()}`}
+            action={
+              <Space>
+                <Button size="small" type="primary" onClick={handleRestore}>
+                  Restore
+                </Button>
+                <Button size="small" onClick={handleDiscard}>
+                  Discard
+                </Button>
+              </Space>
+            }
+          />
+        )}
+        {dataset && (
+          <DatasetForm
+            form={form}
+            initialValues={dataset}
+            readOnly={!editing}
+            onSubmit={handleDatasetSubmit}
+            onValuesChange={editing ? handleValuesChange : undefined}
+            open={open}
+          />
+        )}
+        {importErrors.length > 0 && (
+          <Alert
+            type="warning"
+            showIcon
+            closable
+            onClose={() => setImportErrors([])}
+            style={{ marginTop: 16 }}
+            message="The following fields had invalid values and were not imported"
+            description={
+              <ul style={{ margin: 0, paddingLeft: 20 }}>
+                {importErrors.map((err, i) => (
+                  <li key={i}>
+                    <strong>{err.path || "root"}</strong>: {err.message}
+                  </li>
+                ))}
+              </ul>
+            }
+          />
+        )}
+      </Modal>
       {dataset && (
-        <DatasetForm
-          form={form}
-          initialValues={dataset}
-          readOnly={!editing}
-          onSubmit={handleDatasetSubmit}
-          onValuesChange={editing ? handleValuesChange : undefined}
-          open={open}
+        <DatasetTranslationModal
+          dataset={dataset}
+          open={translationModalOpen}
+          onSave={() => dispatch(fetchProjectsWithDatasets())}
+          onClose={() => setTranslationModalOpen(false)}
         />
       )}
-      {importErrors.length > 0 && (
-        <Alert
-          type="warning"
-          showIcon
-          closable
-          onClose={() => setImportErrors([])}
-          style={{ marginTop: 16 }}
-          message="The following fields had invalid values and were not imported"
-          description={
-            <ul style={{ margin: 0, paddingLeft: 20 }}>
-              {importErrors.map((err, i) => (
-                <li key={i}>
-                  <strong>{err.path || "root"}</strong>: {err.message}
-                </li>
-              ))}
-            </ul>
-          }
-        />
-      )}
-    </Modal>
+    </>
   );
 };
 

--- a/src/components/datasets/DatasetProvenanceModal.tsx
+++ b/src/components/datasets/DatasetProvenanceModal.tsx
@@ -42,7 +42,13 @@ const DatasetProvenanceModal = ({ dataset, open, onClose }: DatasetProvenanceMod
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const draftKey = `dataset-draft:edit:${dataset?.identifier}`;
-  const hasFrTranslation = (dataset?.translations ?? []).includes("fr");
+  const [hasFrOverride, setHasFrOverride] = useState<boolean | null>(null);
+  const hasFrTranslation = hasFrOverride ?? (dataset?.translations ?? []).includes("fr");
+
+  // Clear the optimistic override once the store delivers updated translations
+  useEffect(() => {
+    setHasFrOverride(null);
+  }, [dataset?.translations]);
 
   useEffect(() => {
     if (!open) {
@@ -288,7 +294,10 @@ const DatasetProvenanceModal = ({ dataset, open, onClose }: DatasetProvenanceMod
         <DatasetTranslationModal
           dataset={dataset}
           open={translationModalOpen}
-          onSave={() => dispatch(fetchProjectsWithDatasets())}
+          onSave={(hasFrNow) => {
+            setHasFrOverride(hasFrNow);
+            dispatch(fetchProjectsWithDatasets());
+          }}
           onClose={() => setTranslationModalOpen(false)}
         />
       )}

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -113,6 +113,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
   }, [authHeader, dataset.identifier, message, metadataUrl, onSave, onClose]);
 
   const handleCancel = useCallback(() => {
+    setUploadError(null);
     setDrfErrors(null);
     onClose();
   }, [onClose]);

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
-import { Alert, App, Button, Form, Modal, Space, Spin, Typography, Upload } from "antd";
-import { GlobalOutlined, SaveOutlined, UploadOutlined } from "@ant-design/icons";
+import { Alert, App, Button, Modal, Space, Spin, Typography, Upload } from "antd";
+import { GlobalOutlined, InboxOutlined } from "@ant-design/icons";
+import { useAuthorizationHeader } from "bento-auth-js";
 
-import DatasetForm from "./DatasetForm";
-import { prepareInitialValues, validateWithZod } from "./DatasetForm/helpers";
 import type { DRFErrors } from "@/api/datasetTranslations";
 import { fetchTranslation, upsertTranslation } from "@/api/datasetTranslations";
+import { validateWithZod } from "./DatasetForm/helpers";
 import type { DatasetModelBase } from "@/types/dataset";
 import { useAppSelector } from "@/store";
 
@@ -31,15 +31,13 @@ const DRFErrorList = ({ errors }: { errors: DRFErrors }) => (
 const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationModalProps) => {
   const { message } = App.useApp();
   const metadataUrl = useAppSelector((state) => state.services.metadataService?.url ?? "");
+  const authHeader = useAuthorizationHeader();
 
-  const [form] = Form.useForm();
   const [checking, setChecking] = useState(false);
   const [saving, setSaving] = useState(false);
   const [isEdit, setIsEdit] = useState(false);
-  const [initialValues, setInitialValues] = useState<Partial<DatasetModelBase> | undefined>(undefined);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [drfErrors, setDrfErrors] = useState<DRFErrors | null>(null);
-  const [importErrors, setImportErrors] = useState<Array<{ path: string; message: string }>>([]);
 
   useEffect(() => {
     if (!open || !metadataUrl || !dataset?.identifier) return;
@@ -48,88 +46,71 @@ const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationM
     setFetchError(null);
     setDrfErrors(null);
 
-    fetchTranslation(metadataUrl, dataset.identifier, LANG).then((result) => {
-      if (result.exists === true) {
-        setIsEdit(true);
-        setInitialValues({ ...result.data, language: LANG });
-      } else if (result.exists === false) {
-        setIsEdit(false);
-        // Pre-fill with canonical dataset data so the user has a starting point
-        setInitialValues({ ...(dataset as Partial<DatasetModelBase>), language: LANG });
-      } else {
-        setFetchError(result.error);
-      }
+    fetchTranslation(metadataUrl, dataset.identifier, LANG, authHeader).then((result) => {
+      if (result.exists === true) setIsEdit(true);
+      else if (result.exists === false) setIsEdit(false);
+      else setFetchError(result.error);
       setChecking(false);
     });
-  }, [open, metadataUrl, dataset]);
+  }, [open, metadataUrl, authHeader, dataset]);
 
-  const handleSubmit = useCallback(
-    async (validatedData: DatasetModelBase) => {
-      setSaving(true);
-      setDrfErrors(null);
-
-      const result = await upsertTranslation(metadataUrl, dataset.identifier, LANG, validatedData, isEdit);
-
-      if (result.ok) {
-        message.success(`${LANG_LABEL} translation ${isEdit ? "updated" : "added"} successfully.`);
-        form.resetFields();
-        onClose();
-      } else if (result.drfErrors) {
-        setDrfErrors(result.drfErrors);
-      } else {
-        message.error(`Unexpected error (HTTP ${result.status}). Please try again.`);
-      }
-
-      setSaving(false);
-    },
-    [metadataUrl, dataset.identifier, isEdit, form, onClose, message],
-  );
-
-  const handleJsonUpload = useCallback(
+  const handleUpload = useCallback(
     (file: File) => {
       const reader = new FileReader();
-      reader.onload = (e) => {
+      reader.onload = async (e) => {
+        let parsed: unknown;
         try {
-          const parsed = JSON.parse(e.target?.result as string);
-          const result = validateWithZod(parsed);
-
-          const allErrors = result.success ? [] : result.errors;
-          const skippedFields = new Set(allErrors.map((err) => err.path.split(".")[0]).filter(Boolean));
-
-          const cleaned = Object.fromEntries(Object.entries(parsed).filter(([k]) => !skippedFields.has(k)));
-          form.setFieldsValue(prepareInitialValues(cleaned));
-
-          if (skippedFields.size === 0) {
-            setImportErrors([]);
-            message.success("JSON imported — review the fields before saving.");
-          } else {
-            const skippedErrors = allErrors.filter((err) => skippedFields.has(err.path.split(".")[0]));
-            setImportErrors(skippedErrors);
-            message.warning(`JSON imported — ${skippedFields.size} field(s) skipped due to invalid values.`);
-          }
+          parsed = JSON.parse(e.target?.result as string);
         } catch {
           message.error("Invalid JSON file.");
+          return;
         }
+
+        const validation = validateWithZod(parsed);
+        if (!validation.success) {
+          message.error(`JSON validation failed: ${validation.errors[0]?.message ?? "unknown error"}`);
+          return;
+        }
+
+        setSaving(true);
+        setDrfErrors(null);
+
+        const result = await upsertTranslation(
+          metadataUrl,
+          dataset.identifier,
+          LANG,
+          validation.data as DatasetModelBase,
+          isEdit,
+          authHeader,
+        );
+
+        if (result.ok) {
+          message.success(`${LANG_LABEL} translation ${isEdit ? "updated" : "added"} successfully.`);
+          onClose();
+        } else if (result.drfErrors) {
+          setDrfErrors(result.drfErrors);
+        } else {
+          message.error(`Unexpected error (HTTP ${result.status}). Please try again.`);
+        }
+
+        setSaving(false);
       };
       reader.readAsText(file);
       return false;
     },
-    [form, message],
+    [authHeader, dataset.identifier, isEdit, message, metadataUrl, onClose],
   );
 
   const handleCancel = useCallback(() => {
-    form.resetFields();
     setDrfErrors(null);
     setFetchError(null);
-    setImportErrors([]);
-    setInitialValues(undefined);
     onClose();
-  }, [form, onClose]);
+  }, [onClose]);
 
   return (
     <Modal
       open={open}
-      width={848}
+      width={560}
       destroyOnClose
       title={
         <Space>
@@ -139,19 +120,7 @@ const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationM
           </span>
         </Space>
       }
-      footer={
-        checking || fetchError ? null : (
-          <Space>
-            <Upload accept=".json" showUploadList={false} beforeUpload={handleJsonUpload}>
-              <Button icon={<UploadOutlined />}>Import JSON</Button>
-            </Upload>
-            <Button onClick={handleCancel}>Cancel</Button>
-            <Button type="primary" icon={<SaveOutlined />} loading={saving} onClick={() => form.submit()}>
-              {isEdit ? "Update" : "Add"} Translation
-            </Button>
-          </Space>
-        )
-      }
+      footer={<Button onClick={handleCancel}>Close</Button>}
       onCancel={handleCancel}
     >
       {checking ? (
@@ -162,34 +131,30 @@ const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationM
           </Typography.Paragraph>
         </div>
       ) : fetchError ? (
-        <Alert
-          type="error"
-          showIcon
-          message="Could not load translation data"
-          description={fetchError}
-          action={
-            <Button size="small" onClick={handleCancel}>
-              Close
-            </Button>
-          }
-        />
+        <Alert type="error" showIcon message="Could not check for existing translation" description={fetchError} />
       ) : (
-        <>
+        <Space direction="vertical" style={{ width: "100%" }}>
           <Alert
             type={isEdit ? "info" : "warning"}
             showIcon
-            style={{ marginBottom: 16 }}
             message={
-              isEdit
-                ? `Editing existing ${LANG_LABEL} (${LANG}) translation`
-                : `Creating a new ${LANG_LABEL} (${LANG}) translation`
+              isEdit ? `Existing ${LANG_LABEL} translation will be replaced` : `No ${LANG_LABEL} translation yet`
             }
-            description={
-              isEdit
-                ? "The form is pre-filled with the current translation. Edit the fields you want to update."
-                : `The form is pre-filled with the canonical dataset. Translate text fields into ${LANG_LABEL}. The Language field is fixed to "${LANG}".`
-            }
+            description={`Upload a JSON file with the ${LANG_LABEL} dataset payload. The "language" field must be "${LANG}".`}
           />
+
+          <Upload.Dragger
+            accept=".json"
+            showUploadList={false}
+            beforeUpload={handleUpload}
+            disabled={saving}
+            style={{ padding: "8px 0" }}
+          >
+            <p className="ant-upload-drag-icon">
+              <InboxOutlined />
+            </p>
+            <p className="ant-upload-text">{saving ? "Uploading…" : "Click or drag a JSON file here"}</p>
+          </Upload.Dragger>
 
           {drfErrors && (
             <Alert
@@ -197,34 +162,11 @@ const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationM
               showIcon
               closable
               onClose={() => setDrfErrors(null)}
-              style={{ marginBottom: 16 }}
               message="The server rejected this translation"
               description={<DRFErrorList errors={drfErrors} />}
             />
           )}
-
-          <DatasetForm form={form} onSubmit={handleSubmit} initialValues={initialValues} open={open} />
-
-          {importErrors.length > 0 && (
-            <Alert
-              type="warning"
-              showIcon
-              closable
-              onClose={() => setImportErrors([])}
-              style={{ marginTop: 16 }}
-              message="The following fields had invalid values and were not imported"
-              description={
-                <ul style={{ margin: 0, paddingLeft: 20 }}>
-                  {importErrors.map((err, i) => (
-                    <li key={i}>
-                      <strong>{err.path || "root"}</strong>: {err.message}
-                    </li>
-                  ))}
-                </ul>
-              }
-            />
-          )}
-        </>
+        </Space>
       )}
     </Modal>
   );

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
-import { Alert, App, Button, Modal, Space, Spin, Typography, Upload } from "antd";
+import { useCallback, useState } from "react";
+import { Alert, App, Button, Modal, Space, Upload } from "antd";
 import { GlobalOutlined, InboxOutlined } from "@ant-design/icons";
 import { useAuthorizationHeader } from "bento-auth-js";
 
 import type { DRFErrors } from "@/api/datasetTranslations";
-import { fetchTranslation, upsertTranslation } from "@/api/datasetTranslations";
+import { upsertTranslation } from "@/api/datasetTranslations";
 import { validateWithZod } from "./DatasetForm/helpers";
 import type { DatasetModelBase } from "@/types/dataset";
 import { useAppSelector } from "@/store";
@@ -13,8 +13,9 @@ const LANG = "fr";
 const LANG_LABEL = "French";
 
 interface DatasetTranslationModalProps {
-  dataset: Record<string, unknown> & { identifier: string; title?: string };
+  dataset: Record<string, unknown> & { identifier: string; title?: string; translations?: string[] };
   open: boolean;
+  onSave?: () => void;
   onClose: () => void;
 }
 
@@ -28,31 +29,14 @@ const DRFErrorList = ({ errors }: { errors: DRFErrors }) => (
   </ul>
 );
 
-const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationModalProps) => {
+const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTranslationModalProps) => {
   const { message } = App.useApp();
   const metadataUrl = useAppSelector((state) => state.services.metadataService?.url ?? "");
   const authHeader = useAuthorizationHeader();
 
-  const [checking, setChecking] = useState(false);
+  const isEdit = (dataset.translations ?? []).includes(LANG);
   const [saving, setSaving] = useState(false);
-  const [isEdit, setIsEdit] = useState(false);
-  const [fetchError, setFetchError] = useState<string | null>(null);
   const [drfErrors, setDrfErrors] = useState<DRFErrors | null>(null);
-
-  useEffect(() => {
-    if (!open || !metadataUrl || !dataset?.identifier) return;
-
-    setChecking(true);
-    setFetchError(null);
-    setDrfErrors(null);
-
-    fetchTranslation(metadataUrl, dataset.identifier, LANG, authHeader).then((result) => {
-      if (result.exists === true) setIsEdit(true);
-      else if (result.exists === false) setIsEdit(false);
-      else setFetchError(result.error);
-      setChecking(false);
-    });
-  }, [open, metadataUrl, authHeader, dataset]);
 
   const handleUpload = useCallback(
     (file: File) => {
@@ -86,6 +70,7 @@ const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationM
 
         if (result.ok) {
           message.success(`${LANG_LABEL} translation ${isEdit ? "updated" : "added"} successfully.`);
+          onSave?.();
           onClose();
         } else if (result.drfErrors) {
           setDrfErrors(result.drfErrors);
@@ -98,12 +83,11 @@ const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationM
       reader.readAsText(file);
       return false;
     },
-    [authHeader, dataset.identifier, isEdit, message, metadataUrl, onClose],
+    [authHeader, dataset.identifier, dataset.translations, message, metadataUrl, onSave, onClose],
   );
 
   const handleCancel = useCallback(() => {
     setDrfErrors(null);
-    setFetchError(null);
     onClose();
   }, [onClose]);
 
@@ -123,51 +107,40 @@ const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationM
       footer={<Button onClick={handleCancel}>Close</Button>}
       onCancel={handleCancel}
     >
-      {checking ? (
-        <div style={{ textAlign: "center", padding: "48px 0" }}>
-          <Spin size="large" />
-          <Typography.Paragraph type="secondary" style={{ marginTop: 16 }}>
-            Checking for existing {LANG_LABEL} translation&hellip;
-          </Typography.Paragraph>
-        </div>
-      ) : fetchError ? (
-        <Alert type="error" showIcon message="Could not check for existing translation" description={fetchError} />
-      ) : (
-        <Space direction="vertical" style={{ width: "100%" }}>
+      <Space direction="vertical" style={{ width: "100%" }}>
+        <Alert
+          type={isEdit ? "info" : "warning"}
+          showIcon
+          message={
+            isEdit ? `Existing ${LANG_LABEL} translation will be replaced` : `No ${LANG_LABEL} translation yet`
+          }
+          description={`Upload a JSON file with the ${LANG_LABEL} dataset payload. The "language" field must be "${LANG}".`}
+        />
+
+        <Upload.Dragger
+          accept=".json"
+          showUploadList={false}
+          beforeUpload={handleUpload}
+          disabled={saving}
+          style={{ padding: "8px 0" }}
+        >
+          <p className="ant-upload-drag-icon">
+            <InboxOutlined />
+          </p>
+          <p className="ant-upload-text">{saving ? "Uploading…" : "Click or drag a JSON file here"}</p>
+        </Upload.Dragger>
+
+        {drfErrors && (
           <Alert
-            type={isEdit ? "info" : "warning"}
+            type="error"
             showIcon
-            message={
-              isEdit ? `Existing ${LANG_LABEL} translation will be replaced` : `No ${LANG_LABEL} translation yet`
-            }
-            description={`Upload a JSON file with the ${LANG_LABEL} dataset payload. The "language" field must be "${LANG}".`}
+            closable
+            onClose={() => setDrfErrors(null)}
+            message="The server rejected this translation"
+            description={<DRFErrorList errors={drfErrors} />}
           />
-
-          <Upload.Dragger
-            accept=".json"
-            showUploadList={false}
-            beforeUpload={handleUpload}
-            disabled={saving}
-            style={{ padding: "8px 0" }}
-          >
-            <p className="ant-upload-drag-icon">
-              <InboxOutlined />
-            </p>
-            <p className="ant-upload-text">{saving ? "Uploading…" : "Click or drag a JSON file here"}</p>
-          </Upload.Dragger>
-
-          {drfErrors && (
-            <Alert
-              type="error"
-              showIcon
-              closable
-              onClose={() => setDrfErrors(null)}
-              message="The server rejected this translation"
-              description={<DRFErrorList errors={drfErrors} />}
-            />
-          )}
-        </Space>
-      )}
+        )}
+      </Space>
     </Modal>
   );
 };

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useState } from "react";
+import { Alert, App, Button, Form, Modal, Space, Spin, Typography, Upload } from "antd";
+import { GlobalOutlined, SaveOutlined, UploadOutlined } from "@ant-design/icons";
+
+import DatasetForm from "./DatasetForm";
+import { prepareInitialValues, validateWithZod } from "./DatasetForm/helpers";
+import type { DRFErrors } from "@/api/datasetTranslations";
+import { fetchTranslation, upsertTranslation } from "@/api/datasetTranslations";
+import type { DatasetModelBase } from "@/types/dataset";
+import { useAppSelector } from "@/store";
+
+const LANG = "fr";
+const LANG_LABEL = "French";
+
+interface DatasetTranslationModalProps {
+  dataset: Record<string, unknown> & { identifier: string; title?: string };
+  open: boolean;
+  onClose: () => void;
+}
+
+const DRFErrorList = ({ errors }: { errors: DRFErrors }) => (
+  <ul style={{ margin: 0, paddingLeft: 20 }}>
+    {Object.entries(errors).map(([field, messages]) => (
+      <li key={field}>
+        <strong>{field === "non_field_errors" ? "General" : field.replace(/_/g, " ")}</strong>: {messages.join(" ")}
+      </li>
+    ))}
+  </ul>
+);
+
+const DatasetTranslationModal = ({ dataset, open, onClose }: DatasetTranslationModalProps) => {
+  const { message } = App.useApp();
+  const metadataUrl = useAppSelector((state) => state.services.metadataService?.url ?? "");
+
+  const [form] = Form.useForm();
+  const [checking, setChecking] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [isEdit, setIsEdit] = useState(false);
+  const [initialValues, setInitialValues] = useState<Partial<DatasetModelBase> | undefined>(undefined);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [drfErrors, setDrfErrors] = useState<DRFErrors | null>(null);
+  const [importErrors, setImportErrors] = useState<Array<{ path: string; message: string }>>([]);
+
+  useEffect(() => {
+    if (!open || !metadataUrl || !dataset?.identifier) return;
+
+    setChecking(true);
+    setFetchError(null);
+    setDrfErrors(null);
+
+    fetchTranslation(metadataUrl, dataset.identifier, LANG).then((result) => {
+      if (result.exists === true) {
+        setIsEdit(true);
+        setInitialValues({ ...result.data, language: LANG });
+      } else if (result.exists === false) {
+        setIsEdit(false);
+        // Pre-fill with canonical dataset data so the user has a starting point
+        setInitialValues({ ...(dataset as Partial<DatasetModelBase>), language: LANG });
+      } else {
+        setFetchError(result.error);
+      }
+      setChecking(false);
+    });
+  }, [open, metadataUrl, dataset]);
+
+  const handleSubmit = useCallback(
+    async (validatedData: DatasetModelBase) => {
+      setSaving(true);
+      setDrfErrors(null);
+
+      const result = await upsertTranslation(metadataUrl, dataset.identifier, LANG, validatedData, isEdit);
+
+      if (result.ok) {
+        message.success(`${LANG_LABEL} translation ${isEdit ? "updated" : "added"} successfully.`);
+        form.resetFields();
+        onClose();
+      } else if (result.drfErrors) {
+        setDrfErrors(result.drfErrors);
+      } else {
+        message.error(`Unexpected error (HTTP ${result.status}). Please try again.`);
+      }
+
+      setSaving(false);
+    },
+    [metadataUrl, dataset.identifier, isEdit, form, onClose, message],
+  );
+
+  const handleJsonUpload = useCallback(
+    (file: File) => {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        try {
+          const parsed = JSON.parse(e.target?.result as string);
+          const result = validateWithZod(parsed);
+
+          const allErrors = result.success ? [] : result.errors;
+          const skippedFields = new Set(allErrors.map((err) => err.path.split(".")[0]).filter(Boolean));
+
+          const cleaned = Object.fromEntries(Object.entries(parsed).filter(([k]) => !skippedFields.has(k)));
+          form.setFieldsValue(prepareInitialValues(cleaned));
+
+          if (skippedFields.size === 0) {
+            setImportErrors([]);
+            message.success("JSON imported — review the fields before saving.");
+          } else {
+            const skippedErrors = allErrors.filter((err) => skippedFields.has(err.path.split(".")[0]));
+            setImportErrors(skippedErrors);
+            message.warning(`JSON imported — ${skippedFields.size} field(s) skipped due to invalid values.`);
+          }
+        } catch {
+          message.error("Invalid JSON file.");
+        }
+      };
+      reader.readAsText(file);
+      return false;
+    },
+    [form, message],
+  );
+
+  const handleCancel = useCallback(() => {
+    form.resetFields();
+    setDrfErrors(null);
+    setFetchError(null);
+    setImportErrors([]);
+    setInitialValues(undefined);
+    onClose();
+  }, [form, onClose]);
+
+  return (
+    <Modal
+      open={open}
+      width={848}
+      destroyOnClose
+      title={
+        <Space>
+          <GlobalOutlined />
+          <span>
+            {LANG_LABEL} Translation &ndash; &ldquo;{dataset?.title ?? ""}&rdquo;
+          </span>
+        </Space>
+      }
+      footer={
+        checking || fetchError ? null : (
+          <Space>
+            <Upload accept=".json" showUploadList={false} beforeUpload={handleJsonUpload}>
+              <Button icon={<UploadOutlined />}>Import JSON</Button>
+            </Upload>
+            <Button onClick={handleCancel}>Cancel</Button>
+            <Button type="primary" icon={<SaveOutlined />} loading={saving} onClick={() => form.submit()}>
+              {isEdit ? "Update" : "Add"} Translation
+            </Button>
+          </Space>
+        )
+      }
+      onCancel={handleCancel}
+    >
+      {checking ? (
+        <div style={{ textAlign: "center", padding: "48px 0" }}>
+          <Spin size="large" />
+          <Typography.Paragraph type="secondary" style={{ marginTop: 16 }}>
+            Checking for existing {LANG_LABEL} translation&hellip;
+          </Typography.Paragraph>
+        </div>
+      ) : fetchError ? (
+        <Alert
+          type="error"
+          showIcon
+          message="Could not load translation data"
+          description={fetchError}
+          action={
+            <Button size="small" onClick={handleCancel}>
+              Close
+            </Button>
+          }
+        />
+      ) : (
+        <>
+          <Alert
+            type={isEdit ? "info" : "warning"}
+            showIcon
+            style={{ marginBottom: 16 }}
+            message={
+              isEdit
+                ? `Editing existing ${LANG_LABEL} (${LANG}) translation`
+                : `Creating a new ${LANG_LABEL} (${LANG}) translation`
+            }
+            description={
+              isEdit
+                ? "The form is pre-filled with the current translation. Edit the fields you want to update."
+                : `The form is pre-filled with the canonical dataset. Translate text fields into ${LANG_LABEL}. The Language field is fixed to "${LANG}".`
+            }
+          />
+
+          {drfErrors && (
+            <Alert
+              type="error"
+              showIcon
+              closable
+              onClose={() => setDrfErrors(null)}
+              style={{ marginBottom: 16 }}
+              message="The server rejected this translation"
+              description={<DRFErrorList errors={drfErrors} />}
+            />
+          )}
+
+          <DatasetForm form={form} onSubmit={handleSubmit} initialValues={initialValues} open={open} />
+
+          {importErrors.length > 0 && (
+            <Alert
+              type="warning"
+              showIcon
+              closable
+              onClose={() => setImportErrors([])}
+              style={{ marginTop: 16 }}
+              message="The following fields had invalid values and were not imported"
+              description={
+                <ul style={{ margin: 0, paddingLeft: 20 }}>
+                  {importErrors.map((err, i) => (
+                    <li key={i}>
+                      <strong>{err.path || "root"}</strong>: {err.message}
+                    </li>
+                  ))}
+                </ul>
+              }
+            />
+          )}
+        </>
+      )}
+    </Modal>
+  );
+};
+
+export default DatasetTranslationModal;

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -57,6 +57,11 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
           return;
         }
 
+        if (validation.data.language !== LANG) {
+          message.error(`File language is "${validation.data.language}" — expected "${LANG}". Upload a ${LANG_LABEL} JSON file.`);
+          return;
+        }
+
         setSaving(true);
         setDrfErrors(null);
 

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -84,7 +84,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
       reader.readAsText(file);
       return false;
     },
-    [authHeader, dataset.identifier, dataset.translations, message, metadataUrl, onSave, onClose],
+    [authHeader, dataset.identifier, isEdit, message, metadataUrl, onSave, onClose],
   );
 
   const handleDelete = useCallback(async () => {
@@ -142,9 +142,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
         <Alert
           type={isEdit ? "info" : "warning"}
           showIcon
-          message={
-            isEdit ? `Existing ${LANG_LABEL} translation will be replaced` : `No ${LANG_LABEL} translation yet`
-          }
+          message={isEdit ? `Existing ${LANG_LABEL} translation will be replaced` : `No ${LANG_LABEL} translation yet`}
           description={`Upload a JSON file with the ${LANG_LABEL} dataset payload. The "language" field must be "${LANG}".`}
         />
 

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -15,7 +15,7 @@ const LANG_LABEL = "French";
 interface DatasetTranslationModalProps {
   dataset: Record<string, unknown> & { identifier: string; title?: string; translations?: string[] };
   open: boolean;
-  onSave?: () => void;
+  onSave?: (hasFrNow: boolean) => void;
   onClose: () => void;
 }
 
@@ -71,7 +71,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
 
         if (result.ok) {
           message.success(`${LANG_LABEL} translation ${isEdit ? "updated" : "added"} successfully.`);
-          onSave?.();
+          onSave?.(true);
           onClose();
         } else if (result.drfErrors) {
           setDrfErrors(result.drfErrors);
@@ -93,7 +93,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
     setDeleting(false);
     if (result.ok) {
       message.success(`${LANG_LABEL} translation deleted.`);
-      onSave?.();
+      onSave?.(false);
       onClose();
     } else {
       message.error(`Failed to delete translation (HTTP ${result.status}).`);

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -15,7 +15,7 @@ const LANG_LABEL = "French";
 interface DatasetTranslationModalProps {
   dataset: Record<string, unknown> & { identifier: string; title?: string; translations?: string[] };
   open: boolean;
-  onSave?: (hasFrNow: boolean) => void;
+  onSave?: () => void;
   onClose: () => void;
 }
 
@@ -71,7 +71,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
 
         if (result.ok) {
           message.success(`${LANG_LABEL} translation ${isEdit ? "updated" : "added"} successfully.`);
-          onSave?.(true);
+          onSave?.();
           onClose();
         } else if (result.drfErrors) {
           setDrfErrors(result.drfErrors);
@@ -93,7 +93,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
     setDeleting(false);
     if (result.ok) {
       message.success(`${LANG_LABEL} translation deleted.`);
-      onSave?.(false);
+      onSave?.();
       onClose();
     } else {
       message.error(`Failed to delete translation (HTTP ${result.status}).`);

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -37,6 +37,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
   const isEdit = (dataset.translations ?? []).includes(LANG);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [uploadError, setUploadError] = useState<{ message: string; details?: string[] } | null>(null);
   const [drfErrors, setDrfErrors] = useState<DRFErrors | null>(null);
 
   const handleUpload = useCallback(
@@ -47,22 +48,28 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
         try {
           parsed = JSON.parse(e.target?.result as string);
         } catch {
-          message.error("Invalid JSON file.");
+          setUploadError({ message: "Invalid JSON file — could not parse." });
           return;
         }
 
         const validation = validateWithZod(parsed);
         if (!validation.success) {
-          message.error(`JSON validation failed: ${validation.errors[0]?.message ?? "unknown error"}`);
+          setUploadError({
+            message: "JSON validation failed — file has the following errors:",
+            details: validation.errors.map((e) => (e.path ? `${e.path}: ${e.message}` : e.message)),
+          });
           return;
         }
 
         if (validation.data.language !== LANG) {
-          message.error(`File language is "${validation.data.language}" — expected "${LANG}". Upload a ${LANG_LABEL} JSON file.`);
+          setUploadError({
+            message: `Wrong language — file has "${validation.data.language}", expected "${LANG}". Upload a ${LANG_LABEL} JSON file.`,
+          });
           return;
         }
 
         setSaving(true);
+        setUploadError(null);
         setDrfErrors(null);
 
         const result = await upsertTranslation(
@@ -164,6 +171,24 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
           <p className="ant-upload-text">{saving ? "Uploading…" : "Click or drag a JSON file here"}</p>
         </Upload.Dragger>
 
+        {uploadError && (
+          <Alert
+            type="error"
+            showIcon
+            closable
+            onClose={() => setUploadError(null)}
+            message={uploadError.message}
+            description={
+              uploadError.details?.length ? (
+                <ul style={{ margin: 0, paddingLeft: 20 }}>
+                  {uploadError.details.map((d, i) => (
+                    <li key={i}>{d}</li>
+                  ))}
+                </ul>
+              ) : undefined
+            }
+          />
+        )}
         {drfErrors && (
           <Alert
             type="error"

--- a/src/components/datasets/DatasetTranslationModal.tsx
+++ b/src/components/datasets/DatasetTranslationModal.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useState } from "react";
-import { Alert, App, Button, Modal, Space, Upload } from "antd";
-import { GlobalOutlined, InboxOutlined } from "@ant-design/icons";
+import { Alert, App, Button, Modal, Popconfirm, Space, Upload } from "antd";
+import { DeleteOutlined, GlobalOutlined, InboxOutlined } from "@ant-design/icons";
 import { useAuthorizationHeader } from "bento-auth-js";
 
 import type { DRFErrors } from "@/api/datasetTranslations";
-import { upsertTranslation } from "@/api/datasetTranslations";
+import { deleteTranslation, upsertTranslation } from "@/api/datasetTranslations";
 import { validateWithZod } from "./DatasetForm/helpers";
 import type { DatasetModelBase } from "@/types/dataset";
 import { useAppSelector } from "@/store";
@@ -36,6 +36,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
 
   const isEdit = (dataset.translations ?? []).includes(LANG);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [drfErrors, setDrfErrors] = useState<DRFErrors | null>(null);
 
   const handleUpload = useCallback(
@@ -86,6 +87,19 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
     [authHeader, dataset.identifier, dataset.translations, message, metadataUrl, onSave, onClose],
   );
 
+  const handleDelete = useCallback(async () => {
+    setDeleting(true);
+    const result = await deleteTranslation(metadataUrl, dataset.identifier, LANG, authHeader);
+    setDeleting(false);
+    if (result.ok) {
+      message.success(`${LANG_LABEL} translation deleted.`);
+      onSave?.();
+      onClose();
+    } else {
+      message.error(`Failed to delete translation (HTTP ${result.status}).`);
+    }
+  }, [authHeader, dataset.identifier, message, metadataUrl, onSave, onClose]);
+
   const handleCancel = useCallback(() => {
     setDrfErrors(null);
     onClose();
@@ -104,7 +118,24 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
           </span>
         </Space>
       }
-      footer={<Button onClick={handleCancel}>Close</Button>}
+      footer={
+        <Space style={{ width: "100%", justifyContent: isEdit ? "space-between" : "flex-end" }}>
+          {isEdit && (
+            <Popconfirm
+              title="Delete French translation?"
+              description="This cannot be undone."
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+              onConfirm={handleDelete}
+            >
+              <Button danger icon={<DeleteOutlined />} loading={deleting} disabled={saving}>
+                Delete Translation
+              </Button>
+            </Popconfirm>
+          )}
+          <Button onClick={handleCancel}>Close</Button>
+        </Space>
+      }
       onCancel={handleCancel}
     >
       <Space direction="vertical" style={{ width: "100%" }}>
@@ -121,7 +152,7 @@ const DatasetTranslationModal = ({ dataset, open, onSave, onClose }: DatasetTran
           accept=".json"
           showUploadList={false}
           beforeUpload={handleUpload}
-          disabled={saving}
+          disabled={saving || deleting}
           style={{ padding: "8px 0" }}
         >
           <p className="ant-upload-drag-icon">

--- a/src/components/manager/projects/Project.js
+++ b/src/components/manager/projects/Project.js
@@ -156,7 +156,6 @@ const Project = ({
               <Col span={24} key={d.identifier}>
                 <Dataset
                   key={d.identifier}
-                  mode="private"
                   project={value}
                   value={d}
                 />

--- a/src/components/manager/projects/Project.js
+++ b/src/components/manager/projects/Project.js
@@ -20,17 +20,7 @@ import Dataset from "@/components/datasets/Dataset";
 import ProjectForm from "./ProjectForm";
 import ProjectExtraPropertiesModal from "@/components/manager/projects/ProjectExtraPropertiesModal";
 
-const Project = ({
-  value,
-  saving,
-  editing,
-  onAddDataset,
-  onAddJsonSchema,
-  onEdit,
-  onCancelEdit,
-  onSave,
-  onDelete,
-}) => {
+const Project = ({ value, saving, editing, onAddDataset, onAddJsonSchema, onEdit, onCancelEdit, onSave, onDelete }) => {
   const resource = makeProjectResource(value.identifier);
 
   // Project deletion is a permission on the node, so we need these permissions for that purpose.
@@ -154,11 +144,7 @@ const Project = ({
             .sort((d1, d2) => d1.title.localeCompare(d2.title))
             .map((d) => (
               <Col span={24} key={d.identifier}>
-                <Dataset
-                  key={d.identifier}
-                  project={value}
-                  value={d}
-                />
+                <Dataset key={d.identifier} project={value} value={d} />
               </Col>
             ))}
         </Space>

--- a/src/components/manager/projects/Project.js
+++ b/src/components/manager/projects/Project.js
@@ -25,7 +25,6 @@ const Project = ({
   saving,
   editing,
   onAddDataset,
-  onEditDataset,
   onAddJsonSchema,
   onEdit,
   onCancelEdit,
@@ -160,7 +159,6 @@ const Project = ({
                   mode="private"
                   project={value}
                   value={d}
-                  onEdit={() => (onEditDataset || nop)(d)}
                 />
               </Col>
             ))}
@@ -201,7 +199,6 @@ Project.propTypes = {
   onCancelEdit: PropTypes.func,
   onSave: PropTypes.func,
   onAddDataset: PropTypes.func,
-  onEditDataset: PropTypes.func,
   onAddJsonSchema: PropTypes.func,
 };
 

--- a/src/components/manager/projects/RoutedProject.js
+++ b/src/components/manager/projects/RoutedProject.js
@@ -9,7 +9,7 @@ import Project from "./Project";
 import ProjectJsonSchemaModal from "./ProjectJsonSchemaModal";
 import ProjectSkeleton from "./ProjectSkeleton";
 
-import { FORM_MODE_ADD, FORM_MODE_EDIT } from "@/constants";
+import { FORM_MODE_ADD } from "@/constants";
 import { beginProjectEditing, endProjectEditing } from "@/modules/manager/actions";
 import { deleteProjectIfPossible, saveProjectIfPossible } from "@/modules/metadata/actions";
 import { useProjects } from "@/modules/metadata/hooks";
@@ -32,16 +32,9 @@ const RoutedProject = () => {
   const editingProject = useAppSelector((state) => state.manager.editingProject);
 
   const [datasetAdditionModal, setDatasetAdditionModal] = useState(false);
-  const [datasetEditModal, setDatasetEditModal] = useState(false);
   const [jsonSchemaModal, setJsonSchemaModal] = useState(false);
-  const [selectedDataset, setSelectedDataset] = useState(null);
 
   const project = projectsByID[selectedProjectID];
-
-  // Derive from live Redux state so the form reflects post-save data
-  const datasetForEdit = selectedDataset
-    ? (project?.datasets?.find((d) => d.identifier === selectedDataset.identifier) ?? selectedDataset)
-    : selectedDataset;
 
   useEffect(() => {
     if (!projectsByID[selectedProjectID] && !loadingProjects) {
@@ -64,10 +57,6 @@ const RoutedProject = () => {
 
   const hideDatasetAdditionModal = useCallback(() => {
     setDatasetAdditionModal(false);
-  }, []);
-
-  const hideDatasetEditModal = useCallback(() => {
-    setDatasetEditModal(false);
   }, []);
 
   const setJsonSchemaModalVisible = useCallback((visible) => {
@@ -99,11 +88,6 @@ const RoutedProject = () => {
     });
   }, [dispatch, modal, project]);
 
-  const handleDatasetEdit = useCallback((dataset) => {
-    setSelectedDataset(dataset);
-    setDatasetEditModal(true);
-  }, []);
-
   if (!selectedProjectID) {
     return null;
   }
@@ -117,16 +101,6 @@ const RoutedProject = () => {
         open={datasetAdditionModal}
         onCancel={hideDatasetAdditionModal}
         onOk={hideDatasetAdditionModal}
-      />
-
-      <DatasetFormModal
-        key={`${selectedDataset?.identifier ?? "edit"}-${datasetEditModal}`}
-        mode={FORM_MODE_EDIT}
-        project={project}
-        open={datasetEditModal}
-        initialValue={datasetForEdit}
-        onCancel={hideDatasetEditModal}
-        onOk={hideDatasetEditModal}
       />
 
       <ProjectJsonSchemaModal
@@ -145,7 +119,6 @@ const RoutedProject = () => {
         onCancelEdit={() => dispatch(endProjectEditing())}
         onSave={handleProjectSave}
         onAddDataset={showDatasetAdditionModal}
-        onEditDataset={handleDatasetEdit}
         onAddJsonSchema={() => setJsonSchemaModalVisible(true)}
       />
     </>

--- a/src/modules/metadata/actions.js
+++ b/src/modules/metadata/actions.js
@@ -18,6 +18,7 @@ export const DELETE_PROJECT_JSON_SCHEMA = createNetworkActionTypes("DELETE_PROJE
 
 export const ADD_PROJECT_DATASET = createNetworkActionTypes("ADD_PROJECT_DATASET");
 export const SAVE_PROJECT_DATASET = createNetworkActionTypes("SAVE_PROJECT_DATASET");
+export const REFRESH_DATASET = createNetworkActionTypes("REFRESH_DATASET");
 export const DELETE_PROJECT_DATASET = createNetworkActionTypes("DELETE_PROJECT_DATASET");
 export const ADD_DATASET_LINKED_FIELD_SET = createNetworkActionTypes("ADD_DATASET_LINKED_FIELD_SET");
 export const SAVE_DATASET_LINKED_FIELD_SET = createNetworkActionTypes("SAVE_DATASET_LINKED_FIELD_SET");
@@ -201,6 +202,12 @@ export const saveProjectDataset = networkAction((dataset, onSuccess = nop) => (_
     await onSuccess();
     messageApi.success(`Saved dataset '${dataset.title}'`);
   },
+}));
+
+export const refreshDataset = networkAction((datasetId) => (_dispatch, getState) => ({
+  types: REFRESH_DATASET,
+  url: `${getState().services.metadataService.url}/api/datasets/${datasetId}`,
+  err: `Error refreshing dataset '${datasetId}'`,
 }));
 
 export const deleteProjectDataset = networkAction((project, dataset) => (_dispatch, getState) => ({

--- a/src/modules/metadata/reducers.ts
+++ b/src/modules/metadata/reducers.ts
@@ -12,6 +12,7 @@ import {
   SAVE_PROJECT,
   ADD_PROJECT_DATASET,
   SAVE_PROJECT_DATASET,
+  REFRESH_DATASET,
   DELETE_PROJECT_DATASET,
   ADD_DATASET_LINKED_FIELD_SET,
   SAVE_DATASET_LINKED_FIELD_SET,
@@ -221,7 +222,8 @@ export const projects: Reducer<ProjectsState> = (
     case SAVE_PROJECT_DATASET.RECEIVE:
     case ADD_DATASET_LINKED_FIELD_SET.RECEIVE:
     case SAVE_DATASET_LINKED_FIELD_SET.RECEIVE:
-    case DELETE_DATASET_LINKED_FIELD_SET.RECEIVE: {
+    case DELETE_DATASET_LINKED_FIELD_SET.RECEIVE:
+    case REFRESH_DATASET.RECEIVE: {
       const updatedDataset = action.data as ProjectScopedDatasetModel;
       const replaceDataset = (d: DatasetModel): ProjectScopedDatasetModel =>
         d.identifier === updatedDataset.identifier
@@ -238,6 +240,13 @@ export const projects: Reducer<ProjectsState> = (
             ...(state.itemsByID[updatedDataset.project] || {}),
             datasets: ((state.itemsByID[updatedDataset.project] || {}).datasets ?? []).map(replaceDataset),
           },
+        },
+        datasets: state.datasets.map((d) =>
+          d.identifier === updatedDataset.identifier ? { ...d, ...updatedDataset } : d,
+        ),
+        datasetsByID: {
+          ...state.datasetsByID,
+          [updatedDataset.identifier]: { ...state.datasetsByID[updatedDataset.identifier], ...updatedDataset },
         },
       };
     }

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -452,7 +452,7 @@ export const DatasetModelBase = z
     resources: z.array(VersionedOntologyResource).min(1).nullable().optional(),
     stakeholders: z.array(PersonOrOrganization).min(1).nullable().optional(),
     funding_sources: z
-      .union([z.array(z.union([FundingSource, Link])), nonEmptyString])
+      .union([z.array(z.union([Link, FundingSource])), nonEmptyString])
       .nullable()
       .optional(),
 


### PR DESCRIPTION
## Summary
Redmine ticket [2830](https://redmine.c3g-app.sd4h.ca/issues/2830)
Requires: https://github.com/bento-platform/katsu/pull/705

- Adds a typed API layer (`src/api/datasetTranslations.ts`) for the katsu translation endpoints (`GET`/`POST`/`PUT` `/api/datasets/{id}/translations/{lang}`), with bearer token support via `useAuthorizationHeader`
- Adds a French Translation modal on each dataset card that checks for an existing translation on open and presents a drag-and-drop JSON upload; validates locally with Zod, posts to the API, and displays DRF field-keyed errors inline
- The translation button label dynamically reflects whether a translation exists ("Add French Translation" / "Edit French Translation") by probing the API on mount and after the modal closes
- Adds an Export dropdown next to "View Provenance" with options for English (canonical, downloaded instantly from local state) and French (fetched then downloaded); the French option is hidden when no translation exists