### PR TITLE
chore: bump version to 8.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bento_web",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bento_web",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@ant-design/icons": "~5.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bento_web",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "private": true,
   "description": "Bento platform front-end",
   "main": "src/index.tsx",


### PR DESCRIPTION
re-release for nginx CVE patch